### PR TITLE
Build on dependency changes too

### DIFF
--- a/.github/workflows/admin-ui.yml
+++ b/.github/workflows/admin-ui.yml
@@ -13,12 +13,15 @@ on:
     paths:
       - "admin-ui/**"
       - ".github/workflows/admin-ui.yml"
+      - "yarn.lock"
+
   pull_request:
     branches:
       - "main"
       - "TILA-663"
     paths:
       - "admin-ui/**"
+      - "yarn.lock"
       - ".github/workflows/admin-ui.yml"
 
 jobs:

--- a/.github/workflows/common-style-test.yml
+++ b/.github/workflows/common-style-test.yml
@@ -8,10 +8,12 @@ on:
     branches: [main]
     paths:
       - "common/**"
+      - "yarn.lock"
       - ".github/workflows/common-style-test.yml"
   pull_request:
     paths:
       - "common/**"
+      - "yarn.lock"
       - ".github/workflows/common-style-test.yml"
 
 jobs:

--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "ui/**"
       - ".github/workflows/ui-e2e.yml"
+      - "yarn.lock"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/ui-style-test.yml
+++ b/.github/workflows/ui-style-test.yml
@@ -8,11 +8,13 @@ on:
     branches: [main]
     paths:
       - "ui/**"
+      - "yarn.lock"
       - ".github/workflows/ui-style-test.yml"
   pull_request:
     branches: [main]
     paths:
       - "ui/**"
+      - "yarn.lock"
       - ".github/workflows/ui-style-test.yml"
 jobs:
   build:

--- a/.github/workflows/ui-unit-test.yml
+++ b/.github/workflows/ui-unit-test.yml
@@ -8,11 +8,13 @@ on:
     branches: [main]
     paths:
       - "ui/**"
+      - "yarn.lock"
       - ".github/workflows/ui-unit-test.yml"
   pull_request:
     branches: [main]
     paths:
       - "ui/**"
+      - "yarn.lock"
       - ".github/workflows/ui-unit-test.yml"
 jobs:
   build:


### PR DESCRIPTION
Change builds so that we build also when only the dependencies changes (for example when dependabot creates a pr)