### PR TITLE
TILA-2058: Adds 'createdAt' column for reservation table

### DIFF
--- a/admin-ui/src/component/reservations/ReservationsTable.tsx
+++ b/admin-ui/src/component/reservations/ReservationsTable.tsx
@@ -5,10 +5,18 @@ import { ReservationType } from "common/types/gql-types";
 import { CustomTable, DataOrMessage, TableLink } from "../lists/components";
 import { reservationUrl } from "../../common/urls";
 import { getReserveeName, reservationDateTime } from "./requested/util";
+import { formatDateTime } from "../../common/util";
 
 export type Sort = {
   field: string;
   asc: boolean;
+};
+
+type ReservationTableColumn = {
+  headerName: string;
+  key: string;
+  isSortable: boolean;
+  transform?: (reservationtype: ReservationType) => JSX.Element | string;
 };
 
 type Props = {
@@ -17,7 +25,7 @@ type Props = {
   reservations: ReservationType[];
 };
 
-const getColConfig = (t: TFunction) => [
+const getColConfig = (t: TFunction): ReservationTableColumn[] => [
   {
     headerName: t("Reservations.headings.id"),
     key: "pk",
@@ -59,6 +67,13 @@ const getColConfig = (t: TFunction) => [
     isSortable: true,
     transform: ({ begin, end }: ReservationType) =>
       reservationDateTime(begin, end, t),
+  },
+  {
+    headerName: t("Reservations.headings.createdAt"),
+    key: "created_at",
+    isSortable: true,
+    transform: ({ createdAt }: ReservationType) =>
+      formatDateTime(createdAt as string),
   },
   {
     headerName: t("Reservations.headings.paymentStatus"),

--- a/admin-ui/src/component/reservations/queries.ts
+++ b/admin-ui/src/component/reservations/queries.ts
@@ -111,6 +111,7 @@ export const RESERVATIONS_QUERY = gql`
           name
           price
           orderStatus
+          createdAt
         }
       }
       pageInfo {

--- a/admin-ui/src/i18n/messages.ts
+++ b/admin-ui/src/i18n/messages.ts
@@ -1606,6 +1606,7 @@ const translations: ITranslations = {
       reservationUnit: ["Varausyksikkö"],
       unit: ["Toimipiste"],
       datetime: ["Aika"],
+      createdAt: ["Tehty"],
       paymentStatus: ["Maksutila"],
       state: ["Käsittelytila"],
     },


### PR DESCRIPTION
 - Adds 'createdAt' column for reservation table
 - Adds translation for the column header