### PR TITLE
TILA-2137: translations for email template generation

### DIFF
--- a/common/.gitignore
+++ b/common/.gitignore
@@ -23,5 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 
-# generated email htmls
+# generated email htmls and texts
 email/html/
+email/txt/

--- a/common/README.md
+++ b/common/README.md
@@ -26,9 +26,12 @@ yarn generate-certificate
 ### Generate email .html templates
 
 ```
-yarn generate-email-template
+yarn generate-email-templates
 ```
 
+ - Converts and translates (using `i18n/*.json`) the `templates/*.template.mjml` files to `html/*_{lang}.html` and `text-templates/*.template.txt` to `txt/*_{lang}.txt`.
+ - Inside the templates, `${key}` is translated using the value of the `key` in the JSON files; `{{...}}` and `{%...%}` is intended for the Django template engine to interpret when the generated templates are used to render the actual emails, and are left as is by this command.
+ - The text versions of the emails in the `text-templates` directory are translated (to the 'txt' directory) along with the .mjml to .html conversion but do not contain any other syntax that is handled by this command.
  - For previewing the .mjml templates from which the .html files are generated, install the MJML extension (mjmlio.vscode-mjml), make sure to get the correct one (by MJML).
  - To prevent headaches from prettier in formatting of .mjml files include the following in your vscode settings:
     ```
@@ -36,4 +39,5 @@ yarn generate-email-template
         "editor.defaultFormatter": "mjmlio.vscode-mjml"
     }
     ```
- - NOTE: NEVER! EVER! EVER! modify the .html files directly. If changes are required, change the .mjml files and re-generate the .html files
+ - NOTE: NEVER! EVER! EVER! modify the generated .html/.txt files directly. If changes are required, change the .mjml files in the `templates` and the .txt files in the `text-templates` directory (and/or the translations in `i18n/`), and re-generate the .html/.txt files.
+ - See further the documentation in Confluence (Finnish): https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8178106373/Email-pohjat

--- a/common/email/convertToHTML.js
+++ b/common/email/convertToHTML.js
@@ -11,6 +11,7 @@ const main = () => {
     let html;
     let fileContent;
 
+    fs.mkdirSync(path.join(__dirname, "/html/"), { recursive: true } );
     files.forEach((file) => {
       fileContent = fs.readFileSync(
         path.join(__dirname, "../email/templates", file)

--- a/common/email/convertToHTML.mjs
+++ b/common/email/convertToHTML.mjs
@@ -7,28 +7,85 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const templateFolder = path.join(__dirname, "templates");
+const i18nFolder = path.join(__dirname, "i18n");
+const translations = { '': {} }; // '' = untranslated
+
+const flattenJSON = (obj = {}, res = {}, extraKey = '') => {
+  for (let key in obj) {
+     if(typeof obj[key] !== 'object') {
+        res[extraKey + key] = obj[key];
+     } else {
+        flattenJSON(obj[key], res, `${extraKey}${key}.`);
+     };
+  };
+  return res;
+};
+const translateContent = (content, i18n) => {
+  if (content && i18n) for (let key in i18n) {
+    // escaped version of reg.exp literal with variable embedded: /\$\{\s*PROP\s*\}/g
+    content = content.replaceAll(new RegExp(`\\$\\{\\s*${key}\\s*\\}`, "g"), i18n[key]);
+  }
+  return content;
+};
+const writeEmailFile = (templateName, fileContent, emailType, emailLang) => {
+  const fileName = templateName.replace(".template.mjml", (emailLang ? `_${emailLang}.${emailType}` : `.${emailType}`));
+  const emailFile = path.join(__dirname, `/${emailType}/` + fileName);
+
+  fs.writeFileSync(emailFile, fileContent);
+  console.log(chalk`{greenBright.bold UPDATED:} {grey ${fileName}}`);
+}
 
 const main = () => {
-  fs.readdir(templateFolder, { withFileTypes: true }, (err, entities) => {
-    if (err) return;
+  // ensure that the html folders exist
+  fs.mkdirSync(path.join(__dirname, "/html/"), { recursive: true } );
+  fs.mkdirSync(path.join(__dirname, "/txt/"), { recursive: true } );
 
-    const files = entities
-      .filter((entity) => entity.isFile())
-      .map((file) => file.name);
-    let html;
-    let fileContent;
-    let fileName;
+  // first read the translations of static texts
+  fs.readdirSync(i18nFolder, { withFileTypes: true })
+    .filter((entity) => entity.isFile())
+    .map((file) => file.name).forEach((jsonFile) => {
+    
+    const lang = jsonFile.replace(".json", "");
+    try {
+      const json = JSON.parse(
+        fs.readFileSync(path.join(__dirname, "i18n", jsonFile))
+      );
+      // flatten the object structure: { "a": { "b": "c" } } becomes { "a.b": "c" } etc.
+      translations[lang] = flattenJSON(json);
+    } catch (e) {
+      console.log(chalk`{redBright.bold FAILED to parse i18n file:} {grey ${jsonFile}`, e);
+    }
+  });
 
-    files.forEach((file) => {
-      fileName = file.replace(".template.mjml", ".html");
-      fileContent = fs.readFileSync(path.join(__dirname, "templates", file));
-      fileContent = mjml(fileContent.toString(), {
-        filePath: path.join(__dirname, "templates"),
-      });
-      html = path.join(__dirname, "/html/" + fileName);
+  // then read, convert and translate the templates
+  fs.readdirSync(templateFolder, { withFileTypes: true })
+    .filter((entity) => entity.isFile())
+    .map((file) => file.name).forEach((templateFile) => {
 
-      fs.writeFileSync(html, fileContent.html);
-      console.log(chalk`{greenBright.bold UPDATED:} {grey ${fileName}}`);
+    // convert mjml to html
+    let fileContent = fs.readFileSync(path.join(__dirname, "templates", templateFile));
+    let htmlContent = mjml(fileContent.toString(), {
+      filePath: path.join(__dirname, "templates"),
+    }).html;
+
+    // translate also the text version if it exists
+    let textFile = path.join(__dirname, "text-templates", templateFile.replace(".mjml", ".txt"));
+    let textContent = fs.existsSync(textFile) ? fs.readFileSync(textFile).toString() : '';
+
+    // repeat for each languge in addition to untranslated html
+    Object.keys(translations).forEach((lang) => {
+      if (lang) {
+        let translatedContent = translateContent(htmlContent, translations[lang]);
+        writeEmailFile(templateFile, translatedContent, "html", lang);
+
+        if (textContent) {
+          translatedContent = translateContent(textContent, translations[lang]);
+          writeEmailFile(templateFile, translatedContent, "txt", lang);
+        }
+      } else {
+        // the untranslated raw html version (text not relevant, would be identical to the template)
+        writeEmailFile(templateFile, htmlContent, "html");
+      }
     });
   });
 };

--- a/common/email/i18n/en.json
+++ b/common/email/i18n/en.json
@@ -1,0 +1,42 @@
+{
+    "serviceName": "Varaamo",
+    "serviceUrl": "varaamo.hel.fi",
+    "helsinkiCity": "City of Helsinki",
+    "salutation": "Hi",
+
+    "manageReservationHeading": "Manage your reservation at Varaamo",
+    "checkYourReservation": "You can check the details of your reservation and Varaamo’s terms of contract and cancellation on the",
+    "ownReservationsPage": "‘Your reservations’ page",
+    "thankYouForUsing": "Thank you for choosing Varaamo!",
+
+    "withRegards": "Kind regards,",
+    "automaticMessage": "This is an automated message, please do not reply.",
+    "sendUs": "Send us",
+    "feedbackOnService": "feedback one Varaamo",
+    "reserveCityResourcesAt": "Easy reservation of the city’s premises and equipment for personal use at",
+
+    "reservationPending": "You have made a new reservation request:",
+    "reservationCompleted": "You have made a new reservation:",
+    "reservationConfirmed": "Your reservation has been confirmed!",
+    "reservationSubsidized": "Your reservation has been confirmed with the following discount:",
+    "reservationNeedsPayment": "Your reservation has been confirmed, and can be paid.",
+    "reservationRejected": "Unfortunately your reservation cannot be confirmed.",
+    "reservationUpdated": "Your reservation has been updated:",
+    "reservationCancelled": "Your reservation has been cancelled.",
+
+    "cancellationReason": "Reason for cancellation",
+    "rejectionReason": "Reason for cancellation",
+    "cancellationInstructions": "Additional information about cancellation",
+    "rejectionInstructions": "Additional information",
+    "reservationInstruction": "Additional information about your reservation",
+
+    "reservationBegins": "From",
+    "reservationEnds": "To",
+    "reservationPrice": "Reservation price",
+    "reservationNumber": "Reservation number",
+
+    "oClock": "at",
+    "vatIncluded": "incl. VAT",
+    "paymentDue": "Due date",
+    "payReservation": "Pay the reservation"
+}

--- a/common/email/i18n/fi.json
+++ b/common/email/i18n/fi.json
@@ -1,0 +1,42 @@
+{
+    "serviceName": "Varaamo",
+    "serviceUrl": "varaamo.hel.fi",
+    "helsinkiCity": "Helsingin kaupunki",
+    "salutation": "Hei",
+
+    "manageReservationHeading": "Hallitse varaustasi Varaamossa",
+    "checkYourReservation": "Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot",
+    "ownReservationsPage": "Omat Varaukset-sivulla",
+    "thankYouForUsing": "Kiitos, kun käytit Varaamoa!",
+
+    "withRegards": "Ystävällisin terveisin,",
+    "automaticMessage": "Tämä on automaattinen viesti, siihen ei voi vastata.",
+    "sendUs": "Lähetä meille",
+    "feedbackOnService": "palautetta Varaamosta",
+    "reserveCityResourcesAt": "Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta",
+
+    "reservationPending": "Olet tehnyt alustavan varauksen:",
+    "reservationCompleted": "Olet tehnyt uuden varauksen:",
+    "reservationConfirmed": "Varauksesi on vahvistettu!",
+    "reservationSubsidized": "Varauksesi on hyväksytty, ja varaukseen on myönnetty seuraava alennus:",
+    "reservationNeedsPayment": "Varauksesi on hyväksytty, ja sen voi maksaa pankkitunnuksilla.",
+    "reservationRejected": "Valitettavasti alla olevaa varaustasi ei voida vahvistaa.",
+    "reservationUpdated": "Varaustasi on muutettu:",
+    "reservationCancelled": "Varauksesi on peruttu.",
+
+    "cancellationReason": "Perumisen syy",
+    "rejectionReason": "Peruutuksen syy",
+    "cancellationInstructions": "Lisätietoa peruutuksesta",
+    "rejectionInstructions": "Lisätietoa",
+    "reservationInstruction": "Lisätietoa varauksestasi",
+
+    "reservationBegins": "Alkamisaika",
+    "reservationEnds": "Päättymisaika",
+    "reservationPrice": "Varauksen hinta",
+    "reservationNumber": "Varausnumero",
+
+    "oClock": "klo",
+    "vatIncluded": "sis. alv",
+    "paymentDue": "Eräpäivä",
+    "payReservation": "Maksa varaus"
+}

--- a/common/email/i18n/sv.json
+++ b/common/email/i18n/sv.json
@@ -1,0 +1,42 @@
+{
+    "serviceName": "Varaamo",
+    "serviceUrl": "varaamo.hel.fi",
+    "helsinkiCity": "Helsingfors stad",
+    "salutation": "Hej",
+
+    "manageReservationHeading": "Hantera din bokning på Varaamo",
+    "checkYourReservation": "Du kan kontrollera uppgifterna om din bokning samt Varaamos avtals- och avbokningsvillkor på sidan",
+    "ownReservationsPage": "Mina bokningar",
+    "thankYouForUsing": "Tack för att du använder Varaamo!",
+
+    "withRegards": "Med vänliga hälsningar,",
+    "automaticMessage": "Detta är ett automatiskt meddelande som inte kan besvaras.",
+    "sendUs": "Skicka oss",
+    "feedbackOnService": "feedback om Varaamo",
+    "reserveCityResourcesAt": "Boka enkelt stadens lokaler och utrustning för eget bruk på",
+
+    "reservationPending": "Du har gjort en ny bokningsförfrågan:",
+    "reservationCompleted": "Du har gjort en ny bokning:",
+    "reservationConfirmed": "Din bokning har bekräftats!",
+    "reservationSubsidized": "Din bokning har bekräftats med följande rabatt:",
+    "reservationNeedsPayment": "Din bokning har bekräftats och kan betalas.",
+    "reservationRejected": "Tyvärr kan vi inte bekräfta din bokning.",
+    "reservationUpdated": "Din bokning har uppdaterats:",
+    "reservationCancelled": "Din bokning har avbokats.",
+
+    "cancellationReason": "Orsak till avbokning",
+    "rejectionReason": "Orsak till avbokning",
+    "cancellationInstructions": "Mer information om avbokning",
+    "rejectionInstructions": "Mer information",
+    "reservationInstruction": "Mer information om din bokning",
+
+    "reservationBegins": "Börjar",
+    "reservationEnds": "Slutar",
+    "reservationPrice": "Bokningspris",
+    "reservationNumber": "Bokningsnummer",
+
+    "oClock": "kl",
+    "vatIncluded": "inkl. moms",
+    "paymentDue": "Förfallodatum",
+    "payReservation": "Betala bokningen"
+}

--- a/common/email/templates/partials/closing.mjml
+++ b/common/email/templates/partials/closing.mjml
@@ -1,0 +1,16 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text font-size="16px">${thankYouForUsing}</mj-text>
+        <mj-text font-size="16px">${withRegards}</mj-text>
+        <mj-text font-size="16px">${serviceName}</mj-text>
+        <mj-spacer />
+        <mj-text font-size="16px">${automaticMessage}</mj-text>
+        <mj-text font-size="16px">${sendUs} <a href={{feedback_ext_link}}>${feedbackOnService}</a>.</mj-text>
+        <mj-text font-size="16px">${reserveCityResourcesAt} <a href={{varaamo_ext_link}}>${serviceUrl}</a>.</mj-text>
+        <mj-spacer height="50px" />
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/common/email/templates/partials/footer.mjml
+++ b/common/email/templates/partials/footer.mjml
@@ -7,7 +7,7 @@
         </mj-column>
         <mj-column vertical-align="middle">
           <mj-text font-size="16px" align="left" padding="0">
-            <b>Varaamo</b>
+            <b>${serviceName}</b>
           </mj-text>
         </mj-column>
       </mj-group>
@@ -16,7 +16,7 @@
       <mj-column>
         <mj-divider border-width="2px" border-style="solid" border-color="#CCCCCC" padding-top="0" />
         <mj-spacer height="10px" />
-        <mj-text font-size="14px">&copy; Helsingin kaupunki {{current_year}}</mj-text>
+        <mj-text font-size="14px">&copy; ${helsinkiCity} {{current_year}}</mj-text>
       </mj-column>
     </mj-section>
   </mj-body>

--- a/common/email/templates/partials/header.mjml
+++ b/common/email/templates/partials/header.mjml
@@ -7,7 +7,7 @@
         </mj-column>
         <mj-column vertical-align="middle">
           <mj-text font-size="24px" align="left" padding="0">
-            <b>Varaamo</b>
+            <b>${serviceName}</b>
           </mj-text>
         </mj-column>
       </mj-group>
@@ -15,7 +15,7 @@
     <mj-section background-color="#FFFFFF" padding-bottom="30px">
       <mj-column>
         <mj-text font-size="36px">
-          <b>Hei {{reservee_name}},</b>
+          <b>${salutation} {{reservee_name}},</b>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/common/email/templates/partials/manageReservation.mjml
+++ b/common/email/templates/partials/manageReservation.mjml
@@ -1,0 +1,12 @@
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>
+          <h2>${manageReservationHeading}<h2>
+        </mj-text>
+        <mj-text font-size="16px">${checkYourReservation} <a href={{my_reservations_ext_link}}>${ownReservationsPage}</a>.</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/common/email/templates/reservationCancellation.template.mjml
+++ b/common/email/templates/reservationCancellation.template.mjml
@@ -7,59 +7,48 @@
     <mj-include path="partials/header.mjml" />
     <mj-section background-color="#F7F2E4">
       <mj-column>
-        <mj-text>Varauksesi on peruttu. Perumisen syy: {{cancel_reason}}</mj-text>
+        <mj-text>${reservationCancelled} ${cancellationReason}: {{cancel_reason}}</mj-text>
         <mj-spacer />
         <mj-text><b>{{reservation_unit}}</b></mj-text>
         <mj-text>{{unit_name}}</mj-text>
         <mj-text>{{unit_location}}</mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Alkamisaika: <b>{{begin_date}}</b> klo <b>{{begin_time}}</b></p>
+          <p>${reservationBegins}: <b>{{begin_date}}</b> ${oClock} <b>{{begin_time}}</b></p>
         </mj-text>
         <mj-text>
-          <p>Päättymisaika: <b>{{end_date}}</b> klo <b>{{end_time}}</b></p>
+          <p>${reservationEnds}: <b>{{end_date}}</b> ${oClock} <b>{{end_time}}</b></p>
         </mj-text>
         <mj-spacer />
         <mj-raw>
           {% if price > 0 %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b> (sis. alv {{tax_percentage}})
+          ${reservationPrice}: <b>{{price | currency}} €</b> (${vatIncluded} {{tax_percentage}} %)
         </mj-text>
         <mj-raw>
           {% else %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b>
+          ${reservationPrice}: <b>0 €</b>
         </mj-text>
         <mj-raw>
           {% endif %}
         </mj-raw>
         <mj-text>
-          <p>Varausnumero: {{reservation_number}}</p>
+          <p>${reservationNumber}: {{reservation_number}}</p>
         </mj-text>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0">
       <mj-column>
         <mj-text font-size="20px">
-          <h2>Lisätietoa peruutuksesta</h2>
+          <h2>${cancellationInstructions}</h2>
         </mj-text>
         <mj-text font-size="16px">{{cancelled_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-section>
-      <mj-column>
-        <mj-text font-size="16px">Kiitos, kun käytit Varaamoa!</mj-text>
-        <mj-text font-size="16px">Ystävällisin terveisin</mj-text>
-        <mj-text font-size="16px">Varaamo</mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Tämä on automaattinen viesti, siihen ei voi vastata</mj-text>
-        <mj-text font-size="16px">Lähetä meille <a href={{feedback_ext_link}}>palautetta Varaamosta</a></mj-text>
-        <mj-text font-size="16px">Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta <a href={{varaamo_ext_link}}>varaamo.hel.fi</a></mj-text>
-        <mj-spacer height="50px" />
-      </mj-column>
-    </mj-section>
+    <mj-include path="partials/closing.mjml" />
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/templates/reservationCompleted.template.mjml
+++ b/common/email/templates/reservationCompleted.template.mjml
@@ -10,11 +10,11 @@
         <mj-raw>
           {% if price < non_subsidised_price %}
         </mj-raw>
-        <mj-text>Varauksesi on hyväksytty, ja varaukseen on myönnetty seuraava alennus:</mj-text>
+        <mj-text>${reservationSubsidized}</mj-text>
         <mj-raw>
           {% else %}
         </mj-raw>
-        <mj-text>Varauksesi on vahvistettu!</mj-text>
+        <mj-text>${reservationConfirmed}</mj-text>
         <mj-raw>
           {% endif %}
         </mj-raw>
@@ -24,57 +24,42 @@
         <mj-text>{{unit_location}}</mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Alkamisaika: <b>{{begin_date}}</b> klo <b>{{begin_time}}</b></p>
+          <p>${reservationBegins}: <b>{{begin_date}}</b> ${oClock} <b>{{begin_time}}</b></p>
         </mj-text>
         <mj-text>
-          <p>Päättymisaika: <b>{{end_date}}</b> klo <b>{{end_time}}</b></p>
+          <p>${reservationEnds}: <b>{{end_date}}</b> ${oClock} <b>{{end_time}}</b></p>
         </mj-text>
         <mj-spacer />
         <mj-raw>
           {% if price > 0 %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b> (sis. alv {{tax_percentage}})
+          ${reservationPrice} <b>{{price | currency}} €</b> (${vatIncluded} {{tax_percentage}} %)
         </mj-text>
         <mj-raw>
           {% else %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b>
+          ${reservationPrice}: <b>0 €</b>
         </mj-text>
         <mj-raw>
           {% endif %}
         </mj-raw>
         <mj-text>
-          <p>Varausnumero: {{reservation_number}}</p>
+          <p>${reservationNumber}: {{reservation_number}}</p>
         </mj-text>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0">
       <mj-column>
         <mj-text>
-          <h2>Lisätietoa varauksestasi</h2>
+          <h2>${reservationInstruction}</h2>
         </mj-text>
         <mj-text font-size="16px">{{confirmed_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-section>
-      <mj-column>
-        <mj-text>
-          <h2>Hallitse varaustasi varaamossa<h2>
-        </mj-text>
-        <mj-text font-size="16px">Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot <a href={{my_reservations_ext_link}}>Omat Varaukset-sivulla</a></mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Kiitos, kun käytit Varaamoa!</mj-text>
-        <mj-text font-size="16px">Ystävällisin terveisin</mj-text>
-        <mj-text font-size="16px">Varaamo</mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Tämä on automaattinen viesti, siihen ei voi vastata</mj-text>
-        <mj-text font-size="16px">Lähetä meille <a href={{feedback_ext_link}}>palautetta Varaamosta</a></mj-text>
-        <mj-text font-size="16px">Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta <a href={{varaamo_ext_link}}>varaamo.hel.fi</a></mj-text>
-        <mj-spacer height="50px" />
-      </mj-column>
-    </mj-section>
+    <mj-include path="partials/manageReservation.mjml" />
+    <mj-include path="partials/closing.mjml" />
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/templates/reservationConfirmation.template.mjml
+++ b/common/email/templates/reservationConfirmation.template.mjml
@@ -7,64 +7,49 @@
     <mj-include path="partials/header.mjml" />
     <mj-section background-color="#F7F2E4">
       <mj-column>
-        <mj-text>Olet tehnyt uuden varauksen:</mj-text>
+        <mj-text>${reservationCompleted}</mj-text>
         <mj-spacer />
         <mj-text><b>{{reservation_unit}}</b></mj-text>
         <mj-text>{{unit_name}}</mj-text>
         <mj-text>{{unit_location}}</mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Alkamisaika: <b>{{begin_date}}</b> klo <b>{{begin_time}}</b></p>
+          <p>${reservationBegins}: <b>{{begin_date}}</b> ${oClock} <b>{{begin_time}}</b></p>
         </mj-text>
         <mj-text>
-          <p>Päättymisaika: <b>{{end_date}}</b> klo <b>{{end_time}}</b></p>
+          <p>${reservationEnds}: <b>{{end_date}}</b> ${oClock} <b>{{end_time}}</b></p>
         </mj-text>
         <mj-spacer />
         <mj-raw>
           {% if price > 0 %}
         </mj-raw>
         <mj-text>
-          <p>Varauksen hinta: <b>{{price}} € </b> (sis. alv {{tax_percentage}})</p>
+          <p>${reservationPrice}: <b>{{price | currency}} €</b> (${vatIncluded} {{tax_percentage}} %)</p>
         </mj-text>
         <mj-raw>
           {% else %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b>
+          ${reservationPrice}: <b>0 €</b>
         </mj-text>
         <mj-raw>
           {% endif %}
         </mj-raw>
         <mj-text>
-          <p>Varausnumero: {{reservation_number}}</p>
+          <p>${reservationNumber}: {{reservation_number}}</p>
         </mj-text>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0">
       <mj-column>
         <mj-text>
-          <h2>Lisätietoa varauksestasi</h2>
+          <h2>${reservationInstruction}</h2>
         </mj-text>
         <mj-text font-size="16px">{{confirmed_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-section>
-      <mj-column>
-        <mj-text>
-          <h2>Hallitse varaustasi varaamossa<h2>
-        </mj-text>
-        <mj-text font-size="16px">Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot <a href={{my_reservations_ext_link}}>Omat Varaukset-sivulla</a></mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Kiitos, kun käytit Varaamoa!</mj-text>
-        <mj-text font-size="16px">Ystävällisin terveisin</mj-text>
-        <mj-text font-size="16px">Varaamo</mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Tämä on automaattinen viesti, siihen ei voi vastata</mj-text>
-        <mj-text font-size="16px">Lähetä meille <a href={{feedback_ext_link}}>palautetta Varaamosta</a></mj-text>
-        <mj-text font-size="16px">Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta <a href={{varaamo_ext_link}}>varaamo.hel.fi</a></mj-text>
-        <mj-spacer height="50px" />
-      </mj-column>
-    </mj-section>
+    <mj-include path="partials/manageReservation.mjml" />
+    <mj-include path="partials/closing.mjml" />
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/templates/reservationPreliminary.template.mjml
+++ b/common/email/templates/reservationPreliminary.template.mjml
@@ -7,17 +7,17 @@
     <mj-include path="partials/header.mjml" />
     <mj-section background-color="#F7F2E4">
       <mj-column>
-        <mj-text>Olet tehnyt alustavan varauksen:</mj-text>
+        <mj-text>${reservationPending}</mj-text>
         <mj-spacer />
         <mj-text><b>{{reservation_unit}}</b></mj-text>
         <mj-text>{{unit_name}}</mj-text>
         <mj-text>{{unit_location}}</mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Alkamisaika: <b>{{begin_date}}</b> klo <b>{{begin_time}}</b></p>
+          <p>${reservationBegins}: <b>{{begin_date}}</b> ${oClock} <b>{{begin_time}}</b></p>
         </mj-text>
         <mj-text>
-          <p>Päättymisaika: <b>{{end_date}}</b> klo <b>{{end_time}}</b></p>
+          <p>${reservationEnds}: <b>{{end_date}}</b> ${oClock} <b>{{end_time}}</b></p>
         </mj-text>
         <mj-spacer />
         <mj-raw>
@@ -26,11 +26,11 @@
         <mj-raw>
           {% if subsidised_price < price %}
         </mj-raw>
-        <mj-text>Varauksen hinta: <b>{{subsidised_price}} - {{price}} € </b> (sis. alv {{tax_percentage}})</mj-text>
+        <mj-text>${reservationPrice}: <b>{{subsidised_price | currency}} &ndash; {{price | currency}} €</b> (${vatIncluded} {{tax_percentage}} %)</mj-text>
         <mj-raw>
           {% else %}
         </mj-raw>
-        <mj-text>Varauksen hinta: <b>{{price}} € </b> (sis. alv {{tax_percentage}})</mj-text>
+        <mj-text>${reservationPrice}: <b>{{price | currency}} €</b> (${vatIncluded} {{tax_percentage}} %)</mj-text>
         <mj-raw>
           {% endif %}
         </mj-raw>
@@ -38,41 +38,26 @@
           {% else %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b>
+          ${reservationPrice}: <b>0 €</b>
         </mj-text>
         <mj-raw>
           {% endif %}
         </mj-raw>
         <mj-text>
-          <p>Varausnumero: {{reservation_number}}</p>
+          <p>${reservationNumber}: {{reservation_number}}</p>
         </mj-text>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0">
       <mj-column>
         <mj-text>
-          <h2>Lisätietoa varauksestasi</h2>
+          <h2>${reservationInstruction}</h2>
         </mj-text>
         <mj-text font-size="16px">{{pending_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-section>
-      <mj-column>
-        <mj-text>
-          <h2>Hallitse varaustasi varaamossa<h2>
-        </mj-text>
-        <mj-text font-size="16px">Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot <a href={{my_reservations_ext_link}}>Omat Varaukset-sivulla</a></mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Kiitos, kun käytit Varaamoa!</mj-text>
-        <mj-text font-size="16px">Ystävällisin terveisin</mj-text>
-        <mj-text font-size="16px">Varaamo</mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Tämä on automaattinen viesti, siihen ei voi vastata</mj-text>
-        <mj-text font-size="16px">Lähetä meille <a href={{feedback_ext_link}}>palautetta Varaamosta</a></mj-text>
-        <mj-text font-size="16px">Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta <a href={{varaamo_ext_link}}>varaamo.hel.fi</a></mj-text>
-        <mj-spacer height="50px" />
-      </mj-column>
-    </mj-section>
+    <mj-include path="partials/manageReservation.mjml" />
+    <mj-include path="partials/closing.mjml" />
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/templates/reservationRejection.template.mjml
+++ b/common/email/templates/reservationRejection.template.mjml
@@ -7,44 +7,34 @@
     <mj-include path="partials/header.mjml" />
     <mj-section background-color="#F7F2E4">
       <mj-column>
-        <mj-text>Valitettavasti alla olevaa varaustasi ei voida vahvistaa.</mj-text>
-        <mj-text>Peruutuksen syy: {{deny_reason}}</mj-text>
+        <mj-text>${reservationRejected}</mj-text>
+        <mj-text>${rejectionReason}: {{deny_reason}}</mj-text>
         <mj-spacer />
         <mj-text><b>{{reservation_unit}}</b></mj-text>
         <mj-text>{{unit_name}}</mj-text>
         <mj-text>{{unit_location}}</mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Alkamisaika: <b>{{begin_date}}</b> klo <b>{{begin_time}}</b></p>
+          <p>${reservationBegins}: <b>{{begin_date}}</b> ${oClock} <b>{{begin_time}}</b></p>
         </mj-text>
         <mj-text>
-          <p>Päättymisaika: <b>{{end_date}}</b> klo <b>{{end_time}}</b></p>
+          <p>${reservationEnds}: <b>{{end_date}}</b> ${oClock} <b>{{end_time}}</b></p>
         </mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Varausnumero: {{reservation_number}}</p>
+          <p>${reservationNumber}: {{reservation_number}}</p>
         </mj-text>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0">
       <mj-column>
         <mj-text font-size="20px">
-          <h2>Lisätietoa</h2>
+          <h2>${rejectionInstructions}</h2>
         </mj-text>
         <mj-text font-size="16px">{{cancelled_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-section>
-      <mj-column>
-        <mj-text font-size="16px">Ystävällisin terveisin,</mj-text>
-        <mj-text font-size="16px">Varaamo</mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Tämä on automaattinen viesti, siihen ei voi vastata</mj-text>
-        <mj-text font-size="16px">Lähetä meille <a href={{feedback_ext_link}}>palautetta Varaamosta</a></mj-text>
-        <mj-text font-size="16px">Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta <a href={{varaamo_ext_link}}>varaamo.hel.fi</a></mj-text>
-        <mj-spacer height="50px" />
-      </mj-column>
-    </mj-section>
+    <mj-include path="partials/closing.mjml" />
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/templates/reservationUpdated.template.mjml
+++ b/common/email/templates/reservationUpdated.template.mjml
@@ -7,64 +7,49 @@
     <mj-include path="partials/header.mjml" />
     <mj-section background-color="#F7F2E4">
       <mj-column>
-        <mj-text>Varaustasi on muutettu:</mj-text>
+        <mj-text>${reservationUpdated}</mj-text>
         <mj-spacer />
         <mj-text><b>{{reservation_unit}}</b></mj-text>
         <mj-text>{{unit_name}}</mj-text>
         <mj-text>{{unit_location}}</mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Alkamisaika: <b>{{begin_date}}</b> klo <b>{{begin_time}}</b></p>
+          <p>${reservationBegins}: <b>{{begin_date}}</b> ${oClock} <b>{{begin_time}}</b></p>
         </mj-text>
         <mj-text>
-          <p>Päättymisaika: <b>{{end_date}}</b> klo <b>{{end_time}}</b></p>
+          <p>${reservationEnds}: <b>{{end_date}}</b> ${oClock} <b>{{end_time}}</b></p>
         </mj-text>
         <mj-spacer />
         <mj-raw>
           {% if price > 0 %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b> (sis. alv {{tax_percentage}})
+          ${reservationPrice}: <b>{{price | currency}} €</b> (${vatIncluded} {{tax_percentage}} %)
         </mj-text>
         <mj-raw>
           {% else %}
         </mj-raw>
         <mj-text>
-          Varauksen hinta: <b>{{price}} € </b>
+          ${reservationPrice}: <b>0 €</b>
         </mj-text>
         <mj-raw>
           {% endif %}
         </mj-raw>
         <mj-text>
-          <p>Varausnumero: {{reservation_number}}</p>
+          <p>${reservationNumber}: {{reservation_number}}</p>
         </mj-text>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0">
       <mj-column>
         <mj-text>
-          <h2>Lisätietoa varauksestasi</h2>
+          <h2>${reservationInstruction}</h2>
         </mj-text>
         <mj-text font-size="16px">{{confirmed_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-section>
-      <mj-column>
-        <mj-text>
-          <h2>Hallitse varaustasi varaamossa<h2>
-        </mj-text>
-        <mj-text font-size="16px">Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot <a href={{my_reservations_ext_link}}>Omat Varaukset-sivulla</a></mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Kiitos, kun käytit Varaamoa!</mj-text>
-        <mj-text font-size="16px">Ystävällisin terveisin</mj-text>
-        <mj-text font-size="16px">Varaamo</mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Tämä on automaattinen viesti, siihen ei voi vastata</mj-text>
-        <mj-text font-size="16px">Lähetä meille <a href={{feedback_ext_link}}>palautetta Varaamosta</a></mj-text>
-        <mj-text font-size="16px">Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta <a href={{varaamo_ext_link}}>varaamo.hel.fi</a></mj-text>
-        <mj-spacer height="50px" />
-      </mj-column>
-    </mj-section>
+    <mj-include path="partials/manageReservation.mjml" />
+    <mj-include path="partials/closing.mjml" />
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/templates/reservationWaitingPayment.template.mjml
+++ b/common/email/templates/reservationWaitingPayment.template.mjml
@@ -7,69 +7,42 @@
     <mj-include path="partials/header.mjml" />
     <mj-section background-color="#F7F2E4">
       <mj-column>
-        <mj-text>Varauksesi on hyväksytty, ja sen voi maksaa pankkitunnuksilla.</mj-text>
+        <mj-text>${reservationNeedsPayment}</mj-text>
         <mj-spacer />
         <mj-text><b>{{reservation_unit}}</b></mj-text>
         <mj-text>{{unit_name}}</mj-text>
         <mj-text>{{unit_location}}</mj-text>
         <mj-spacer />
         <mj-text>
-          <p>Alkamisaika: <b>{{begin_date}}</b> klo <b>{{begin_time}}</b></p>
+          <p>${reservationBegins}: <b>{{begin_date}}</b> ${oClock} <b>{{begin_time}}</b></p>
         </mj-text>
         <mj-text>
-          <p>Päättymisaika: <b>{{end_date}}</b> klo <b>{{end_time}}</b></p>
+          <p>${reservationEnds}: <b>{{end_date}}</b> ${oClock} <b>{{end_time}}</b></p>
         </mj-text>
         <mj-spacer />
-        <mj-raw>
-          {% if price > 0 %}
-        </mj-raw>
         <mj-text>
-          <p>Varauksen hinta: <b>{{price}} € </b> (sis. alv {{tax_percentage}})</p>
-        </mj-text>
-        <mj-raw>
-          {% else %}
-        </mj-raw>
-        <mj-text>
-          Varauksen hinta: <b>{{price}} € </b>
-        </mj-text>
-        <mj-raw>
-          {% endif %}
-        </mj-raw>
-        <mj-text>
-          <p>Eräpäivä: {{due_date}}</p>
+          <p>${reservationPrice}: <b>{{price | currency}} €</b> (${vatIncluded} {{tax_percentage}} %)</p>
         </mj-text>
         <mj-text>
-          <p>Varausnumero: {{reservation_number}}</p>
+          <p>${paymentDue}: {{due_date}}</p>
+        </mj-text>
+        <mj-text>
+          <p>${reservationNumber}: {{reservation_number}}</p>
         </mj-text>
         <mj-spacer />
-        <mj-button href={{payment_ext_link}}>Maksa varaus</mj-button>
+        <mj-button href={{my_reservations_ext_link}}>${payReservation}</mj-button>
       </mj-column>
     </mj-section>
     <mj-section padding-bottom="0">
       <mj-column>
         <mj-text>
-          <h2>Lisätietoa varauksestasi</h2>
+          <h2>${reservationInstruction}</h2>
         </mj-text>
         <mj-text font-size="16px">{{confirmed_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-section>
-      <mj-column>
-        <mj-text>
-          <h2>Hallitse varaustasi varaamossa<h2>
-        </mj-text>
-        <mj-text font-size="16px">Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot <a href={{my_reservations_ext_link}}>Omat Varaukset-sivulla</a></mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Kiitos, kun käytit Varaamoa!</mj-text>
-        <mj-text font-size="16px">Ystävällisin terveisin</mj-text>
-        <mj-text font-size="16px">Varaamo</mj-text>
-        <mj-spacer />
-        <mj-text font-size="16px">Tämä on automaattinen viesti, siihen ei voi vastata</mj-text>
-        <mj-text font-size="16px">Lähetä meille <a href={{feedback_ext_link}}>palautetta Varaamosta</a></mj-text>
-        <mj-text font-size="16px">Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta <a href={{varaamo_ext_link}}>varaamo.hel.fi</a></mj-text>
-        <mj-spacer height="50px" />
-      </mj-column>
-    </mj-section>
+    <mj-include path="partials/manageReservation.mjml" />
+    <mj-include path="partials/closing.mjml" />
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/text-templates/reservationCancellation.template.txt
+++ b/common/email/text-templates/reservationCancellation.template.txt
@@ -1,0 +1,28 @@
+${salutation} {{reservee_name}},
+
+${reservationCancelled} ${cancellationReason}: {{cancel_reason}}
+
+{{reservation_unit}}
+{{unit_name}}
+{{unit_location}}
+
+${reservationBegins}: {{begin_date}} ${oClock} {{begin_time}}
+${reservationEnds}: {{end_date}} ${oClock} {{end_time}}
+
+{% if price > 0 %}
+${reservationPrice}: {{price | currency}} € (${vatIncluded} {{tax_percentage}} %)
+{% else %}
+${reservationPrice}: 0 €
+{% endif %}
+${reservationNumber}: {{reservation_number}}
+
+${cancellationInstructions}
+{{cancelled_instructions}}
+
+${thankYouForUsing}
+${withRegards}
+${serviceName}
+
+${automaticMessage}
+${sendUs} ${feedbackOnService}: {{feedback_ext_link}}
+${reserveCityResourcesAt} {{varaamo_ext_link}}

--- a/common/email/text-templates/reservationCompleted.template.txt
+++ b/common/email/text-templates/reservationCompleted.template.txt
@@ -1,0 +1,35 @@
+${salutation} {{reservee_name}},
+
+{% if price < non_subsidised_price %}
+${reservationSubsidized}
+{% else %}
+${reservationConfirmed}
+{% endif %}
+
+{{reservation_unit}}
+{{unit_name}}
+{{unit_location}}
+
+${reservationBegins}: {{begin_date}} ${oClock} {{begin_time}}
+${reservationEnds}: {{end_date}} ${oClock} {{end_time}}
+
+{% if price > 0 %}
+${reservationPrice}: {{price | currency}} € (${vatIncluded} {{tax_percentage}} %)
+{% else %}
+${reservationPrice}: 0 €
+{% endif %}
+${reservationNumber}: {{reservation_number}}
+
+${reservationInstruction}
+{{confirmed_instructions}}
+
+${manageReservationHeading}
+${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+
+${thankYouForUsing}
+${withRegards}
+${serviceName}
+
+${automaticMessage}
+${sendUs} ${feedbackOnService}: {{feedback_ext_link}}
+${reserveCityResourcesAt} {{varaamo_ext_link}}

--- a/common/email/text-templates/reservationConfirmation.template.txt
+++ b/common/email/text-templates/reservationConfirmation.template.txt
@@ -1,0 +1,31 @@
+${salutation} {{reservee_name}},
+
+${reservationCompleted}
+
+{{reservation_unit}}
+{{unit_name}}
+{{unit_location}}
+
+${reservationBegins}: {{begin_date}} ${oClock} {{begin_time}}
+${reservationEnds}: {{end_date}} ${oClock} {{end_time}}
+
+{% if price > 0 %}
+${reservationPrice}: {{price | currency}} € (${vatIncluded} {{tax_percentage}} %)
+{% else %}
+${reservationPrice}: 0 €
+{% endif %}
+${reservationNumber}: {{reservation_number}}
+
+${reservationInstruction}
+{{confirmed_instructions}}
+
+${manageReservationHeading}
+${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+
+${thankYouForUsing}
+${withRegards}
+${serviceName}
+
+${automaticMessage}
+${sendUs} ${feedbackOnService}: {{feedback_ext_link}}
+${reserveCityResourcesAt} {{varaamo_ext_link}}

--- a/common/email/text-templates/reservationPreliminary.template.txt
+++ b/common/email/text-templates/reservationPreliminary.template.txt
@@ -1,0 +1,35 @@
+${salutation} {{reservee_name}},
+
+${reservationPending}
+
+{{reservation_unit}}
+{{unit_name}}
+{{unit_location}}
+
+${reservationBegins}: {{begin_date}} ${oClock} {{begin_time}}
+${reservationEnds}: {{end_date}} ${oClock} {{end_time}}
+
+{% if price > 0 %}
+    {% if subsidised_price < price %}
+${reservationPrice}: {{subsidised_price | currency}} - {{price | currency}} € (${vatIncluded} {{tax_percentage}} %)
+    {% else %}
+${reservationPrice}: {{price | currency}} € (${vatIncluded} {{tax_percentage}} %)
+    {% endif %}
+{% else %}
+${reservationPrice}: 0 €
+{% endif %}
+${reservationNumber}: {{reservation_number}}
+
+${reservationInstruction}
+{{pending_instructions}}
+
+${manageReservationHeading}
+${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+
+${thankYouForUsing}
+${withRegards}
+${serviceName}
+
+${automaticMessage}
+${sendUs} ${feedbackOnService}: {{feedback_ext_link}}
+${reserveCityResourcesAt} {{varaamo_ext_link}}

--- a/common/email/text-templates/reservationRejection.template.txt
+++ b/common/email/text-templates/reservationRejection.template.txt
@@ -1,0 +1,24 @@
+${salutation} {{reservee_name}},
+
+${reservationRejected}
+${rejectionReason}: {{deny_reason}}
+
+{{reservation_unit}}
+{{unit_name}}
+{{unit_location}}
+
+${reservationBegins}: {{begin_date}} ${oClock} {{begin_time}}
+${reservationEnds}: {{end_date}} ${oClock} {{end_time}}
+
+${reservationNumber}: {{reservation_number}}
+
+${rejectionInstructions}
+{{cancelled_instructions}}
+
+${thankYouForUsing}
+${withRegards}
+${serviceName}
+
+${automaticMessage}
+${sendUs} ${feedbackOnService}: {{feedback_ext_link}}
+${reserveCityResourcesAt} {{varaamo_ext_link}}

--- a/common/email/text-templates/reservationUpdated.template.txt
+++ b/common/email/text-templates/reservationUpdated.template.txt
@@ -1,0 +1,31 @@
+${salutation} {{reservee_name}},
+
+${reservationUpdated}
+
+{{reservation_unit}}
+{{unit_name}}
+{{unit_location}}
+
+${reservationBegins}: {{begin_date}} ${oClock} {{begin_time}}
+${reservationEnds}: {{end_date}} ${oClock} {{end_time}}
+
+{% if price > 0 %}
+${reservationPrice}: {{price | currency}} € (${vatIncluded} {{tax_percentage}} %)
+{% else %}
+${reservationPrice}: 0 €
+{% endif %}
+${reservationNumber}: {{reservation_number}}
+
+${reservationInstruction}
+{{confirmed_instructions}}
+
+${manageReservationHeading}
+${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+
+${thankYouForUsing}
+${withRegards}
+${serviceName}
+
+${automaticMessage}
+${sendUs} ${feedbackOnService}: {{feedback_ext_link}}
+${reserveCityResourcesAt} {{varaamo_ext_link}}

--- a/common/email/text-templates/reservationWaitingPayment.template.txt
+++ b/common/email/text-templates/reservationWaitingPayment.template.txt
@@ -1,0 +1,30 @@
+${salutation} {{reservee_name}},
+
+${reservationNeedsPayment}
+
+{{reservation_unit}}
+{{unit_name}}
+{{unit_location}}
+
+${reservationBegins}: {{begin_date}} ${oClock} {{begin_time}}
+${reservationEnds}: {{end_date}} ${oClock} {{end_time}}
+
+${reservationPrice}: {{price | currency}} € (${vatIncluded} {{tax_percentage}} %)
+${paymentDue}: {{due_date}}
+${reservationNumber}: {{reservation_number}}
+
+${payReservation}: {{my_reservations_ext_link}}
+
+${reservationInstruction}
+{{confirmed_instructions}}
+
+${manageReservationHeading}
+${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+
+${thankYouForUsing}
+${withRegards}
+${serviceName}
+
+${automaticMessage}
+${sendUs} ${feedbackOnService}: {{feedback_ext_link}}
+${reserveCityResourcesAt} {{varaamo_ext_link}}


### PR DESCRIPTION
Language specific texts moved to i18n-jsons and .mjml to .html conversion updated to replace translation keys using them.
Certain common stuff in the .mjml templates abstracted to partials and couple of variable references fixed with currency formatting pipe added for non-zero prices.
Also added translation of text versions of the email templates in the same way so that these can be generated from the same JSON files as the HTML versions.
Cf. also https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8178106373/Email-pohjat