### PR TITLE
TILA-2137: fixes to email templates

### DIFF
--- a/common/email/i18n/en.json
+++ b/common/email/i18n/en.json
@@ -4,9 +4,8 @@
     "helsinkiCity": "City of Helsinki",
     "salutation": "Hi",
 
-    "manageReservationHeading": "Manage your reservation at Varaamo",
-    "checkYourReservation": "You can check the details of your reservation and Varaamo’s terms of contract and cancellation on the",
-    "ownReservationsPage": "‘Your reservations’ page",
+    "manageReservation": "Manage your reservation at Varaamo. You can check the details of your reservation and Varaamo’s terms of contract and cancellation on the",
+    "ownReservationsPage": "‘My bookings’ page",
     "thankYouForUsing": "Thank you for choosing Varaamo!",
 
     "withRegards": "Kind regards,",

--- a/common/email/i18n/fi.json
+++ b/common/email/i18n/fi.json
@@ -4,16 +4,15 @@
     "helsinkiCity": "Helsingin kaupunki",
     "salutation": "Hei",
 
-    "manageReservationHeading": "Hallitse varaustasi Varaamossa",
-    "checkYourReservation": "Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot",
+    "manageReservation": "Hallitse varaustasi Varaamossa. Voit perua varauksesi tai tarkistaa varauksesi tiedot sekä Varaamon sopimus- ja peruutusehdot",
     "ownReservationsPage": "Omat Varaukset-sivulla",
     "thankYouForUsing": "Kiitos, kun käytit Varaamoa!",
 
     "withRegards": "Ystävällisin terveisin,",
-    "automaticMessage": "Tämä on automaattinen viesti, siihen ei voi vastata.",
+    "automaticMessage": "Tämä on automaattinen viesti, johon ei voi vastata.",
     "sendUs": "Lähetä meille",
     "feedbackOnService": "palautetta Varaamosta",
-    "reserveCityResourcesAt": "Varaa helposti kaupungin tiloja ja laiteteita käyttöösi osoitteesta",
+    "reserveCityResourcesAt": "Varaa helposti kaupungin tiloja ja laitteita käyttöösi osoitteessa",
 
     "reservationPending": "Olet tehnyt alustavan varauksen:",
     "reservationCompleted": "Olet tehnyt uuden varauksen:",

--- a/common/email/i18n/sv.json
+++ b/common/email/i18n/sv.json
@@ -4,9 +4,8 @@
     "helsinkiCity": "Helsingfors stad",
     "salutation": "Hej",
 
-    "manageReservationHeading": "Hantera din bokning på Varaamo",
-    "checkYourReservation": "Du kan kontrollera uppgifterna om din bokning samt Varaamos avtals- och avbokningsvillkor på sidan",
-    "ownReservationsPage": "Mina bokningar",
+    "manageReservation": "Hantera din bokning på Varaamo. Du kan kontrollera uppgifterna om din bokning samt Varaamos avtals- och avbokningsvillkor på sidan",
+    "ownReservationsPage": "”Mina bokningar”",
     "thankYouForUsing": "Tack för att du använder Varaamo!",
 
     "withRegards": "Med vänliga hälsningar,",

--- a/common/email/templates/partials/attributes.mjml
+++ b/common/email/templates/partials/attributes.mjml
@@ -1,5 +1,5 @@
 <mj-attributes>
-  <mj-text line-height="18px" font-weight="400" font-size="18px" padding-top="4px" padding-bottom="4px" />
+  <mj-text line-height="1" font-weight="400" font-size="18px" padding-top="4px" padding-bottom="4px" />
   <mj-spacer height="30px" />
   <mj-button background-color="#0000BF" font-weight="700" color="#FFFFFF" border-radius="0" inner-padding="16px 32px" align="left" />
   <mj-body background-color="#ffffff" width="960px" />

--- a/common/email/templates/partials/footer.mjml
+++ b/common/email/templates/partials/footer.mjml
@@ -2,11 +2,11 @@
   <mj-body>
     <mj-section background-color="#E6E6E6" padding-bottom="0">
       <mj-group>
-        <mj-column vertical-align="middle" width="150px" padding="0">
-          <mj-image src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png" width="100px" />
+        <mj-column vertical-align="middle" width="15%" padding="0">
+          <mj-image align="left" padding-right="0" src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png" />
         </mj-column>
         <mj-column vertical-align="middle">
-          <mj-text font-size="16px" align="left" padding="0">
+          <mj-text font-size="16px" align="left">
             <b>${serviceName}</b>
           </mj-text>
         </mj-column>

--- a/common/email/templates/partials/header.mjml
+++ b/common/email/templates/partials/header.mjml
@@ -2,11 +2,11 @@
   <mj-body>
     <mj-section background-color="#FFFFFF">
       <mj-group>
-        <mj-column vertical-align="middle" width="200px" padding="0">
-          <mj-image width="200px" align="left" src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png" />
+        <mj-column vertical-align="middle" width="25%" padding="0">
+          <mj-image align="left" padding-right="0" src="https://makasiini.hel.ninja/helsinki-logos/helsinki-logo-black.png" />
         </mj-column>
         <mj-column vertical-align="middle">
-          <mj-text font-size="24px" align="left" padding="0">
+          <mj-text font-size="24px" align="left">
             <b>${serviceName}</b>
           </mj-text>
         </mj-column>

--- a/common/email/templates/partials/manageReservation.mjml
+++ b/common/email/templates/partials/manageReservation.mjml
@@ -2,10 +2,7 @@
   <mj-body>
     <mj-section>
       <mj-column>
-        <mj-text>
-          <h2>${manageReservationHeading}<h2>
-        </mj-text>
-        <mj-text font-size="16px">${checkYourReservation} <a href={{my_reservations_ext_link}}>${ownReservationsPage}</a>.</mj-text>
+        <mj-text font-size="16px">${manageReservation} <a href={{my_reservations_ext_link}}>${ownReservationsPage}</a>.</mj-text>
       </mj-column>
     </mj-section>
   </mj-body>

--- a/common/email/templates/reservationRejection.template.mjml
+++ b/common/email/templates/reservationRejection.template.mjml
@@ -34,7 +34,17 @@
         <mj-text font-size="16px">{{cancelled_instructions}}</mj-text>
       </mj-column>
     </mj-section>
-    <mj-include path="partials/closing.mjml" />
+    <mj-section>
+      <mj-column>
+        <mj-text font-size="16px">${withRegards}</mj-text>
+        <mj-text font-size="16px">${serviceName}</mj-text>
+        <mj-spacer />
+        <mj-text font-size="16px">${automaticMessage}</mj-text>
+        <mj-text font-size="16px">${sendUs} <a href={{feedback_ext_link}}>${feedbackOnService}</a>.</mj-text>
+        <mj-text font-size="16px">${reserveCityResourcesAt} <a href={{varaamo_ext_link}}>${serviceUrl}</a>.</mj-text>
+        <mj-spacer height="50px" />
+      </mj-column>
+    </mj-section>
     <mj-include path="partials/footer.mjml" />
   </mj-body>
 </mjml>

--- a/common/email/text-templates/reservationCompleted.template.txt
+++ b/common/email/text-templates/reservationCompleted.template.txt
@@ -23,8 +23,7 @@ ${reservationNumber}: {{reservation_number}}
 ${reservationInstruction}
 {{confirmed_instructions}}
 
-${manageReservationHeading}
-${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+${manageReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
 
 ${thankYouForUsing}
 ${withRegards}

--- a/common/email/text-templates/reservationConfirmation.template.txt
+++ b/common/email/text-templates/reservationConfirmation.template.txt
@@ -19,8 +19,7 @@ ${reservationNumber}: {{reservation_number}}
 ${reservationInstruction}
 {{confirmed_instructions}}
 
-${manageReservationHeading}
-${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+${manageReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
 
 ${thankYouForUsing}
 ${withRegards}

--- a/common/email/text-templates/reservationPreliminary.template.txt
+++ b/common/email/text-templates/reservationPreliminary.template.txt
@@ -23,8 +23,7 @@ ${reservationNumber}: {{reservation_number}}
 ${reservationInstruction}
 {{pending_instructions}}
 
-${manageReservationHeading}
-${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+${manageReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
 
 ${thankYouForUsing}
 ${withRegards}

--- a/common/email/text-templates/reservationRejection.template.txt
+++ b/common/email/text-templates/reservationRejection.template.txt
@@ -15,7 +15,6 @@ ${reservationNumber}: {{reservation_number}}
 ${rejectionInstructions}
 {{cancelled_instructions}}
 
-${thankYouForUsing}
 ${withRegards}
 ${serviceName}
 

--- a/common/email/text-templates/reservationUpdated.template.txt
+++ b/common/email/text-templates/reservationUpdated.template.txt
@@ -19,8 +19,7 @@ ${reservationNumber}: {{reservation_number}}
 ${reservationInstruction}
 {{confirmed_instructions}}
 
-${manageReservationHeading}
-${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+${manageReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
 
 ${thankYouForUsing}
 ${withRegards}

--- a/common/email/text-templates/reservationWaitingPayment.template.txt
+++ b/common/email/text-templates/reservationWaitingPayment.template.txt
@@ -18,8 +18,7 @@ ${payReservation}: {{my_reservations_ext_link}}
 ${reservationInstruction}
 {{confirmed_instructions}}
 
-${manageReservationHeading}
-${checkYourReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
+${manageReservation} ${ownReservationsPage}: {{my_reservations_ext_link}}
 
 ${thankYouForUsing}
 ${withRegards}


### PR DESCRIPTION
- Some typo fixes to texts; manage your reservation should have no separate heading line
- Reservation rejection template should not have the line "thank you for using" in the closing section
- Image columns had zero width on mobile clients because mjml calculates the widths incorrectly below the mobile breakpoint in the generated HTML/CSS if given in pixels; compromising on percentage widths (of the 960px container) yields sufficient results on both mobile and desktop for the Helsinki logo in the header & footer, approximating the desired desktop pixel widths
- Atttributes had line-height fixed to 18px which broke displaying of the salutation line (36px font-size) in Outlook where the top of the line was cropped out; setting it to 1 unit fixed that