### PR TITLE
Fix: speed up loading reservations

### DIFF
--- a/admin-ui/src/common/const.ts
+++ b/admin-ui/src/common/const.ts
@@ -23,7 +23,7 @@ export const publicUrl = process.env.PUBLIC_URL;
 export const previewUrlPrefix =
   process.env.REACT_APP_RESERVATION_UNIT_PREVIEW_URL_PREFIX;
 
-export const LIST_PAGE_SIZE = 36;
+export const LIST_PAGE_SIZE = 20;
 
 export const ALLOCATION_CALENDAR_TIMES = [7, 23];
 

--- a/admin-ui/src/component/reservations/RequestedReservations.tsx
+++ b/admin-ui/src/component/reservations/RequestedReservations.tsx
@@ -43,7 +43,6 @@ const Reservations = (): JSX.Element => {
           defaultFiltering={{
             state: ["DENIED", "CONFIRMED", "REQUIRES_HANDLING"],
           }}
-          key={JSON.stringify({ ...search, ...sort })}
           filters={search}
           sort={sort}
           sortChanged={onSortChanged}

--- a/admin-ui/src/component/reservations/queries.ts
+++ b/admin-ui/src/component/reservations/queries.ts
@@ -95,7 +95,6 @@ export const RESERVATIONS_QUERY = gql`
       edges {
         node {
           pk
-          workingMemo
           state
           reservationUnits {
             nameFi
@@ -107,9 +106,7 @@ export const RESERVATIONS_QUERY = gql`
           end
           reserveeFirstName
           reserveeLastName
-          reserveeEmail
           name
-          price
           orderStatus
           createdAt
         }


### PR DESCRIPTION
Query time dropped from 1.6s to 350 - 450 ms.
Remove unused query params.
Refactor query into a hook.
Reduce results from 36 to 20.
Fix a type cast error.
Drop useless keys in components.