### PR TITLE
Fix: smaller error log on failed refetch tokens

### DIFF
--- a/ui/middleware.ts
+++ b/ui/middleware.ts
@@ -1,6 +1,5 @@
 import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
-import { ExtendedJWT } from "./pages/api/auth/[...nextauth]";
 
 const nextAuthSecret = process.env.NEXTAUTH_SECRET;
 const authEnabled = process.env.DISABLE_AUTH === "false";
@@ -10,10 +9,10 @@ export const config = { matcher: ["/reservations", "/applications"] };
 // export { default } from "next-auth/middleware";    this would be the default way of doing things, below is necessary only because of cypress testing
 export default async function middleware(req: NextRequest) {
   if (authEnabled) {
-    const token = (await getToken({
+    const token = await getToken({
       req,
       secret: nextAuthSecret,
-    })) as ExtendedJWT;
+    });
 
     if (!token?.user) {
       const url = req.nextUrl.clone();

--- a/ui/modules/apolloClient.ts
+++ b/ui/modules/apolloClient.ts
@@ -11,11 +11,10 @@ import {
   PROFILE_TOKEN_HEADER,
   SESSION_EXPIRED_ERROR,
 } from "./const";
-import { ExtendedSession } from "../pages/api/auth/[...nextauth]";
 
 const authLink = setContext(
   async (notUsed, { headers }: { headers: Headers }) => {
-    const session = (await getSession()) as ExtendedSession;
+    const session = await getSession();
 
     const modifiedHeader = {
       headers: {
@@ -45,11 +44,13 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     }
 
     graphQLErrors.forEach(async (error: GraphQLError) => {
+      // eslint-disable-next-line no-console
       console.error(`GQL_ERROR: ${error.message}`);
     });
   }
 
   if (networkError) {
+    // eslint-disable-next-line no-console
     console.error(`NETWORK_ERROR: ${networkError.message}`);
   }
 });

--- a/ui/modules/auth/axiosClient.ts
+++ b/ui/modules/auth/axiosClient.ts
@@ -2,7 +2,6 @@ import axios from "axios";
 import applyCaseMiddleware from "axios-case-converter";
 
 import { getSession } from "next-auth/react";
-import { ExtendedSession } from "../../pages/api/auth/[...nextauth]";
 import { authEnabled, isBrowser, PROFILE_TOKEN_HEADER } from "../const";
 
 const axiosOptions = {
@@ -17,7 +16,7 @@ const axiosClient = applyCaseMiddleware(axios.create(axiosOptions));
 
 if (isBrowser && authEnabled) {
   axiosClient.interceptors.request.use(async (req) => {
-    const session = (await getSession()) as ExtendedSession;
+    const session = await getSession();
 
     if (session?.apiTokens?.tilavaraus) {
       req.headers.Authorization = `Bearer ${session.apiTokens.tilavaraus}`;

--- a/ui/pages/api/auth/[...nextauth].ts
+++ b/ui/pages/api/auth/[...nextauth].ts
@@ -138,7 +138,9 @@ const refreshAccessToken = async (token: JWT): Promise<JWT> => {
         Authorization: `Bearer ${token.accessToken}`,
       },
     })
-    .catch(() => {
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.log("error: ", err?.response?.data?.error);
       throw new Error("Failed to refresh session token for a valid user.");
     });
 
@@ -264,11 +266,12 @@ const options = (): NextAuthOptions => {
         }
       },
       async session({ session, token }: SessionParams): Promise<Session> {
-        if (!token) return undefined;
-
-        const { accessToken, accessTokenExpires, user, apiTokens } = token;
-
-        return { ...session, accessToken, accessTokenExpires, user, apiTokens };
+        return {
+          ...session,
+          error: token.error,
+          apiTokens: token.apiTokens,
+          user: token.user,
+        };
       },
       async redirect({ url, baseUrl }) {
         return url.startsWith(baseUrl)
@@ -307,8 +310,8 @@ export default function nextAuthApiHandler(
 
 declare module "next-auth/core/types" {
   interface Session {
-    accessToken: string;
-    accessTokenExpires: number;
+    // accessToken: string;
+    // accessTokenExpires: number;
     user: TilavarauspalveluUser;
     apiTokens: APITokens;
     error?: "RefreshAccessTokenError";

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -36,9 +36,17 @@ const Home = ({ purposes, units }: Props): JSX.Element => {
   const { data: session } = useSession();
 
   useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log("index: useEffect: session ", session);
+    // TODO this needs testing; if the getToken can fail without reseting the session to null
+    // we end up in a infinite relogin loop because the error is set but there is an accessToken
+    // in the session so we try to refetch which fails, setting the error.
     if (session?.error === "RefreshAccessTokenError") {
       // eslint-disable-next-line no-console
       console.log("TRYING to sign in");
+      // This works (it logs in and the user works when you navigate to the home page)
+      // but doesn't FIX the token that is set on signIn so it causes constant errors
+      // because refetchToken fails (old refetch token)
       signIn(); // Force sign in to hopefully resolve error
     }
   }, [session]);

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import styled from "styled-components";
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -10,7 +10,6 @@ import {
   QueryUnitsArgs,
   UnitType,
 } from "common/types/gql-types";
-import { signIn, useSession } from "next-auth/react";
 import Header from "../components/index/Header";
 import SearchGuides from "../components/index/SearchGuides";
 import Purposes from "../components/index/Purposes";
@@ -32,24 +31,6 @@ const Wrapper = styled.div`
 
 const Home = ({ purposes, units }: Props): JSX.Element => {
   const { t } = useTranslation(["home", "common"]);
-
-  const { data: session } = useSession();
-
-  useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log("index: useEffect: session ", session);
-    // TODO this needs testing; if the getToken can fail without reseting the session to null
-    // we end up in a infinite relogin loop because the error is set but there is an accessToken
-    // in the session so we try to refetch which fails, setting the error.
-    if (session?.error === "RefreshAccessTokenError") {
-      // eslint-disable-next-line no-console
-      console.log("TRYING to sign in");
-      // This works (it logs in and the user works when you navigate to the home page)
-      // but doesn't FIX the token that is set on signIn so it causes constant errors
-      // because refetchToken fails (old refetch token)
-      signIn(); // Force sign in to hopefully resolve error
-    }
-  }, [session]);
 
   return (
     <Wrapper>

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -10,6 +10,7 @@ import {
   QueryUnitsArgs,
   UnitType,
 } from "common/types/gql-types";
+import { signIn, useSession } from "next-auth/react";
 import Header from "../components/index/Header";
 import SearchGuides from "../components/index/SearchGuides";
 import Purposes from "../components/index/Purposes";
@@ -31,6 +32,16 @@ const Wrapper = styled.div`
 
 const Home = ({ purposes, units }: Props): JSX.Element => {
   const { t } = useTranslation(["home", "common"]);
+
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session?.error === "RefreshAccessTokenError") {
+      // eslint-disable-next-line no-console
+      console.log("TRYING to sign in");
+      signIn(); // Force sign in to hopefully resolve error
+    }
+  }, [session]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
For some reason refetch request is made for non logged in users.

Should have a better way of handling this. Do we return early if the access token is not defined instead of throwing an error?

What happens here is that:
- Non logged in user (no accessToken) comes to the site
- Our backend logs (NextJs) are flooded with Axios Exceptions that are not handled because the refetch fails.