### PR TITLE
TILA-2387: Display recurring reservation instead of regular reservation

### DIFF
--- a/admin-ui/src/component/ReservationsList.tsx
+++ b/admin-ui/src/component/ReservationsList.tsx
@@ -20,6 +20,7 @@ type NewReservationListItem = {
 
 type Props = {
   items: NewReservationListItem[];
+  hasPadding?: boolean;
 };
 
 // In the UI spec parent container max height is 22rem, but overflow forces us to define child max-height
@@ -29,14 +30,13 @@ const ListWrapper = styled.div`
   overflow-x: hidden;
 `;
 
-const StyledList = styled.ul`
+const StyledList = styled.ul<{ $hasPadding: boolean }>`
   list-style-type: none;
   border: none;
-  padding: 0 var(--spacing-s);
+  padding: ${({ $hasPadding }) => ($hasPadding ? "0 var(--spacing-s)" : "0")};
 `;
 
 const StyledListItem = styled.li`
-  padding: var(--spacing-xs) 0;
   border-bottom: 1px solid var(--color-black-20);
   display: flex;
   flex-wrap: wrap;
@@ -47,6 +47,7 @@ const StyledListItem = styled.li`
 `;
 
 const TextWrapper = styled.span<{ $failed: boolean }>`
+  padding: var(--spacing-xs) 0;
   flex-grow: 1;
   gap: 0.5rem 2rem;
   display: grid;
@@ -70,7 +71,7 @@ const ErrorLabel = styled.div`
 const stripTimeZeros = (time: string) =>
   time.substring(0, 1) === "0" ? time.substring(1) : time;
 
-const ReservationList = ({ items }: Props) => {
+const ReservationList = ({ items, hasPadding }: Props) => {
   const { t } = useTranslation();
 
   if (!items.length) return null;
@@ -78,7 +79,7 @@ const ReservationList = ({ items }: Props) => {
   // TODO if isRemoved show a different style
   return (
     <ListWrapper>
-      <StyledList>
+      <StyledList $hasPadding={hasPadding ?? false}>
         {items.map((item) => (
           <StyledListItem
             key={`${item.date}-${item.startTime}-${item.endTime}`}

--- a/admin-ui/src/component/ReservationsList.tsx
+++ b/admin-ui/src/component/ReservationsList.tsx
@@ -54,8 +54,9 @@ const TextWrapper = styled.span<{ $failed: boolean }>`
   ${({ $failed }) => ($failed ? "color: var(--color-black-60)" : "")};
 `;
 
-const Capitalize = styled.span`
+const Capitalize = styled.span<{ $isRemoved: boolean }>`
   text-transform: capitalize;
+  ${({ $isRemoved }) => ($isRemoved ? "color: var(--color-black-50)" : "")};
 `;
 
 const ErrorLabel = styled.div`
@@ -83,11 +84,18 @@ const ReservationList = ({ items }: Props) => {
             key={`${item.date}-${item.startTime}-${item.endTime}`}
           >
             <TextWrapper $failed={!!item.error}>
-              <Capitalize>
+              <Capitalize $isRemoved={item.isRemoved ?? false}>
                 {`${toUIDate(item.date, "cccccc d.M.yyyy")}, ${stripTimeZeros(
                   item.startTime
                 )}-${stripTimeZeros(item.endTime)}`}
               </Capitalize>
+              {item.isRemoved && (
+                <ErrorLabel>
+                  <span>
+                    {t("MyUnits.RecurringReservation.Confirmation.removed")}
+                  </span>
+                </ErrorLabel>
+              )}
               {item.error && (
                 <ErrorLabel>
                   <span>

--- a/admin-ui/src/component/ReservationsList.tsx
+++ b/admin-ui/src/component/ReservationsList.tsx
@@ -15,6 +15,7 @@ type NewReservationListItem = {
   error?: string;
   reservationPk?: number;
   button?: CallbackButton;
+  isRemoved?: boolean;
 };
 
 type Props = {
@@ -73,6 +74,7 @@ const ReservationList = ({ items }: Props) => {
 
   if (!items.length) return null;
 
+  // TODO if isRemoved show a different style
   return (
     <ListWrapper>
       <StyledList>

--- a/admin-ui/src/component/ReservationsList.tsx
+++ b/admin-ui/src/component/ReservationsList.tsx
@@ -55,7 +55,7 @@ const TextWrapper = styled.span<{ $failed: boolean }>`
   ${({ $failed }) => ($failed ? "color: var(--color-black-60)" : "")};
 `;
 
-const Capitalize = styled.span<{ $isRemoved: boolean }>`
+const DateElement = styled.div<{ $isRemoved: boolean }>`
   text-transform: capitalize;
   ${({ $isRemoved }) => ($isRemoved ? "color: var(--color-black-50)" : "")};
 `;
@@ -76,7 +76,6 @@ const ReservationList = ({ items, hasPadding }: Props) => {
 
   if (!items.length) return null;
 
-  // TODO if isRemoved show a different style
   return (
     <ListWrapper>
       <StyledList $hasPadding={hasPadding ?? false}>
@@ -85,11 +84,11 @@ const ReservationList = ({ items, hasPadding }: Props) => {
             key={`${item.date}-${item.startTime}-${item.endTime}`}
           >
             <TextWrapper $failed={!!item.error}>
-              <Capitalize $isRemoved={item.isRemoved ?? false}>
+              <DateElement $isRemoved={item.isRemoved ?? false}>
                 {`${toUIDate(item.date, "cccccc d.M.yyyy")}, ${stripTimeZeros(
                   item.startTime
                 )}-${stripTimeZeros(item.endTime)}`}
-              </Capitalize>
+              </DateElement>
               {item.isRemoved && (
                 <ErrorLabel>
                   <span>

--- a/admin-ui/src/component/ReservationsList.tsx
+++ b/admin-ui/src/component/ReservationsList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { toUIDate } from "common/src/common/util";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
-import { Button, IconArrowUndo, IconCrossCircle } from "hds-react";
+import { Button, IconArrowUndo, IconCross } from "hds-react";
 
 type CallbackButton = {
   callback: () => void;
@@ -111,7 +111,7 @@ const ReservationList = ({ items }: Props) => {
                 <Button
                   variant="supplementary"
                   onClick={item.button.callback}
-                  iconRight={<IconCrossCircle />}
+                  iconLeft={<IconCross />}
                   size="small"
                 >
                   {t("common.remove")}
@@ -120,7 +120,7 @@ const ReservationList = ({ items }: Props) => {
                 <Button
                   variant="supplementary"
                   onClick={item.button.callback}
-                  iconRight={<IconArrowUndo />}
+                  iconLeft={<IconArrowUndo />}
                   size="small"
                 >
                   {t("common.restore")}

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
@@ -400,7 +400,10 @@ const MyUnitRecurringReservationForm = ({ reservationUnits }: Props) => {
                   count: newReservations.reservations.length,
                 })}
               </Label>
-              <ReservationList items={newReservations.reservations} />
+              <ReservationList
+                items={newReservations.reservations}
+                hasPadding
+              />
             </Element>
           )}
 

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
@@ -21,7 +21,7 @@ import { RecurringReservationFormSchema } from "./RecurringReservationSchema";
 import type { RecurringReservationForm } from "./RecurringReservationSchema";
 import SortedSelect from "../../ReservationUnits/ReservationUnitEditor/SortedSelect";
 import { WeekdaysSelector } from "./WeekdaysSelector";
-import ReservationList from "./ReservationsList";
+import ReservationList from "../../ReservationsList";
 import { CREATE_RECURRING_RESERVATION } from "./queries";
 import { useNotification } from "../../../context/NotificationContext";
 import { dateTime } from "../../ReservationUnits/ReservationUnitEditor/DateTimeInput";

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/RecurringReservationDone.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/RecurringReservationDone.tsx
@@ -128,11 +128,11 @@ const RecurringReservationDone = () => {
           {t(`${locPrefix}.failedTitle`)} ({failed.length})
         </StyledH6>
       )}
-      <ReservationList items={failed} />
+      <ReservationList items={failed} hasPadding />
       <StyledH6 as="h2">
         {t(`${locPrefix}.successTitle`)} ({successes.length})
       </StyledH6>
-      <ReservationList items={successes} />
+      <ReservationList items={successes} hasPadding />
       <ActionsWrapper>
         <Button
           variant="secondary"

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/RecurringReservationDone.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/RecurringReservationDone.tsx
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { H1, H6 } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import { ActionsWrapper } from "./commonStyling";
-import ReservationList from "./ReservationsList";
+import ReservationList from "../../ReservationsList";
 import withMainMenu from "../../withMainMenu";
 
 const InfoSection = styled.p`

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/ReservationsList.test.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/ReservationsList.test.tsx
@@ -7,7 +7,7 @@ import { addDays, nextMonday } from "date-fns";
 import { ReservationUnitsReservationUnitReservationStartIntervalChoices } from "common/types/gql-types";
 import { toUIDate } from "common/src/common/util";
 import { generateReservations } from "./generateReservations";
-import ReservationList from "./ReservationsList";
+import ReservationList from "../../ReservationsList";
 
 const today = new Date();
 const dtoday = Date.UTC(today.getFullYear(), today.getMonth(), today.getDate());

--- a/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
+++ b/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { type ReservationType } from "common/types/gql-types";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@apollo/client";
+import { format } from "date-fns";
+import { RECURRING_RESERVATION_QUERY } from "./queries";
+import { useNotification } from "../../../context/NotificationContext";
+import ReservationList from "../../ReservationsList";
+
+// TODO types ? DONT write them here like this; either use the predefined or zod to validate
+type RecurringFromGQL = {
+  beginDate: string;
+  endDate: string;
+  beginTime: string;
+  endTime: string;
+  pk: number;
+  weekdays: number[];
+  name: string;
+  description: string;
+};
+
+type ReservationShortType = {
+  begin: string;
+  end: string;
+  pk: number;
+  // TODO what are valid values here? other than CONFIRMED
+  state: string;
+};
+
+const RecurringReservationsView = ({
+  reservation,
+}: {
+  reservation: ReservationType;
+}) => {
+  const { notifyError } = useNotification();
+  const { t } = useTranslation();
+
+  console.log("recurring for :", reservation);
+  const { loading, data } = useQuery<any, any>(RECURRING_RESERVATION_QUERY, {
+    skip: !reservation.recurringReservation?.pk,
+    variables: {
+      recurringPk: Number(reservation.recurringReservation?.pk),
+    },
+    onError: () => {
+      notifyError(t("RequestedReservation.errorFetchingData"));
+    },
+  });
+
+  if (loading || data == null) {
+    return <div>Loading</div>;
+  }
+  /* Do we need this data? for genering the recursion list against the backend one maybe
+   * depends if the backend has removed state for the reservation
+  const recurrancePk = reservation?.recurringReservation?.pk;
+  // console.log("recurring pk:", recurrancePk);
+
+  // GQL returns all recurring with no filtering
+  const recurring: RecurringFromGQL = data?.recurringReservations?.edges
+    ?.map((x: any) => x.node)
+    .find((x: any) => x.pk === recurrancePk);
+  */
+
+  // TODO what data do we want here? what ever we need for the ReservationList
+  /* so an array of these {
+  date: Date;
+  startTime: string;
+  endTime: string;
+  error?: string;
+  reservationPk?: number;
+  button?: CallbackButton;
+  }
+  */
+  const reservations: ReservationShortType[] =
+    data?.reservations?.edges?.map((x: any) => x.node) ?? [];
+  // console.log("the recurring object: ", recurring);
+  // console.log("reservations: ", reservations);
+
+  // TODO generate removal buttons
+  // TODO show the removed ones? are they saved somwehre? need to investigate after removal is implemted
+  // TODO need to show them differently if the state !== "CONFIRMED"
+  const forDisplay = reservations.map((x) => ({
+    date: new Date(x.begin),
+    startTime: format(new Date(x.begin), "hh:mm"),
+    endTime: format(new Date(x.begin), "hh:mm"),
+    isRemoved: x.state !== "CONFIRMED",
+  }));
+
+  return <ReservationList items={forDisplay} />;
+};
+
+export default RecurringReservationsView;

--- a/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
+++ b/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
@@ -85,7 +85,16 @@ const RecurringReservationsView = ({
     isRemoved: x.state !== "CONFIRMED",
   }));
 
-  return <ReservationList items={forDisplay} />;
+  return (
+    <>
+      <div>
+        TODO this needs to push a few action buttons into the Reservation list
+        They arent in the other use cases of this list component but here they
+        need to be
+      </div>
+      <ReservationList items={forDisplay} />
+    </>
+  );
 };
 
 export default RecurringReservationsView;

--- a/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
+++ b/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 import {
   Query,
   QueryReservationByPkArgs,
@@ -11,6 +12,14 @@ import { RECURRING_RESERVATION_QUERY } from "./queries";
 import { useNotification } from "../../../context/NotificationContext";
 import ReservationList from "../../ReservationsList";
 
+const StyledHeading = styled.h3`
+  background: var(--color-black-10);
+  font-size: var(--fontsize-body-m);
+  font-weight: 500;
+  padding: var(--spacing-xs) var(--spacing-2-xs);
+  margin: 0;
+`;
+
 const RecurringReservationsView = ({
   reservation,
 }: {
@@ -22,7 +31,6 @@ const RecurringReservationsView = ({
   const { loading, data } = useQuery<Query, QueryReservationByPkArgs>(
     RECURRING_RESERVATION_QUERY,
     {
-      // const { loading, data } = useQuery<any, any>(RECURRING_RESERVATION_QUERY, {
       skip: !reservation.recurringReservation?.pk,
       variables: {
         pk: Number(reservation.recurringReservation?.pk),
@@ -36,35 +44,12 @@ const RecurringReservationsView = ({
   if (loading || data == null) {
     return <div>Loading</div>;
   }
-  /* Do we need this data? for genering the recursion list against the backend one maybe
-   * depends if the backend has removed state for the reservation
-  const recurrancePk = reservation?.recurringReservation?.pk;
-  // console.log("recurring pk:", recurrancePk);
 
-  // GQL returns all recurring with no filtering
-  const recurring: RecurringFromGQL = data?.recurringReservations?.edges
-    ?.map((x: any) => x.node)
-    .find((x: any) => x.pk === recurrancePk);
-  */
-
-  // TODO what data do we want here? what ever we need for the ReservationList
-  /* so an array of these {
-  date: Date;
-  startTime: string;
-  endTime: string;
-  error?: string;
-  reservationPk?: number;
-  button?: CallbackButton;
-  }
-  */
   const reservations =
     data?.reservations?.edges
       ?.map((x) => x?.node)
       .filter((x): x is ReservationType => x != null) ?? [];
-  // console.log("the recurring object: ", recurring);
-  // console.log("reservations: ", reservations);
 
-  // TODO generate removal buttons
   const forDisplay = reservations.map((x) => ({
     date: new Date(x.begin),
     startTime: format(new Date(x.begin), "hh:mm"),
@@ -85,11 +70,7 @@ const RecurringReservationsView = ({
 
   return (
     <>
-      <div>
-        TODO this needs to push a few action buttons into the Reservation list
-        They arent in the other use cases of this list component but here they
-        need to be
-      </div>
+      <StyledHeading>{t("RecurringReservationsView.Heading")}</StyledHeading>
       <ReservationList items={forDisplay} />
     </>
   );

--- a/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
+++ b/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
@@ -1,31 +1,15 @@
 import React from "react";
-import { type ReservationType } from "common/types/gql-types";
+import {
+  Query,
+  QueryReservationByPkArgs,
+  type ReservationType,
+} from "common/types/gql-types";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@apollo/client";
 import { format } from "date-fns";
 import { RECURRING_RESERVATION_QUERY } from "./queries";
 import { useNotification } from "../../../context/NotificationContext";
 import ReservationList from "../../ReservationsList";
-
-// TODO types ? DONT write them here like this; either use the predefined or zod to validate
-type RecurringFromGQL = {
-  beginDate: string;
-  endDate: string;
-  beginTime: string;
-  endTime: string;
-  pk: number;
-  weekdays: number[];
-  name: string;
-  description: string;
-};
-
-type ReservationShortType = {
-  begin: string;
-  end: string;
-  pk: number;
-  // TODO what are valid values here? other than CONFIRMED
-  state: string;
-};
 
 const RecurringReservationsView = ({
   reservation,
@@ -35,16 +19,19 @@ const RecurringReservationsView = ({
   const { notifyError } = useNotification();
   const { t } = useTranslation();
 
-  console.log("recurring for :", reservation);
-  const { loading, data } = useQuery<any, any>(RECURRING_RESERVATION_QUERY, {
-    skip: !reservation.recurringReservation?.pk,
-    variables: {
-      recurringPk: Number(reservation.recurringReservation?.pk),
-    },
-    onError: () => {
-      notifyError(t("RequestedReservation.errorFetchingData"));
-    },
-  });
+  const { loading, data } = useQuery<Query, QueryReservationByPkArgs>(
+    RECURRING_RESERVATION_QUERY,
+    {
+      // const { loading, data } = useQuery<any, any>(RECURRING_RESERVATION_QUERY, {
+      skip: !reservation.recurringReservation?.pk,
+      variables: {
+        pk: Number(reservation.recurringReservation?.pk),
+      },
+      onError: () => {
+        notifyError(t("RequestedReservation.errorFetchingData"));
+      },
+    }
+  );
 
   if (loading || data == null) {
     return <div>Loading</div>;
@@ -70,19 +57,30 @@ const RecurringReservationsView = ({
   button?: CallbackButton;
   }
   */
-  const reservations: ReservationShortType[] =
-    data?.reservations?.edges?.map((x: any) => x.node) ?? [];
+  const reservations =
+    data?.reservations?.edges
+      ?.map((x) => x?.node)
+      .filter((x): x is ReservationType => x != null) ?? [];
   // console.log("the recurring object: ", recurring);
   // console.log("reservations: ", reservations);
 
   // TODO generate removal buttons
-  // TODO show the removed ones? are they saved somwehre? need to investigate after removal is implemted
-  // TODO need to show them differently if the state !== "CONFIRMED"
   const forDisplay = reservations.map((x) => ({
     date: new Date(x.begin),
     startTime: format(new Date(x.begin), "hh:mm"),
     endTime: format(new Date(x.begin), "hh:mm"),
     isRemoved: x.state !== "CONFIRMED",
+    ...(x.state === "CONFIRMED"
+      ? {
+          button: {
+            type: "remove" as const,
+            callback: () => {
+              // eslint-disable-next-line no-console
+              console.log("TODO: NOT IMEPLENETED remove pressed");
+            },
+          },
+        }
+      : {}),
   }));
 
   return (

--- a/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
+++ b/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
@@ -6,8 +6,10 @@ import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
+import { format } from "date-fns";
 import { breakpoints } from "common/src/common/style";
 import { H1 } from "common/src/common/typography";
+import { parseDate } from "common/src/common/util";
 import {
   Maybe,
   Mutation,
@@ -274,6 +276,23 @@ const RequestedReservation = (): JSX.Element | null => {
       ReservationUnitsReservationUnitPricingPricingTypeChoices.Paid &&
     pricing.highestPrice >= 0;
 
+  const recurringTag =
+    reservation.recurringReservation?.beginDate &&
+    reservation.recurringReservation?.endDate
+      ? `
+    ${format(
+      parseDate(reservation.recurringReservation.beginDate),
+      "dd.MM.yyyy"
+    )} - ${format(
+          parseDate(reservation.recurringReservation.endDate),
+          "dd.MM.yyyy"
+        )}
+  `
+      : "";
+  const unitTag = reservation?.reservationUnits
+    ?.map(reservationUnitName)
+    .join(", ");
+
   const reservationTagline = `${reservationDateTime(
     reservation.begin,
     reservation.end,
@@ -281,7 +300,7 @@ const RequestedReservation = (): JSX.Element | null => {
   )} ${reservationDuration(
     reservation.begin,
     reservation.end
-  )}t | ${reservation?.reservationUnits?.map(reservationUnitName).join(", ")}`;
+  )}t | ${recurringTag} | ${unitTag}`;
 
   return (
     <>
@@ -301,6 +320,7 @@ const RequestedReservation = (): JSX.Element | null => {
       />
       <ShowWhenTargetInvisible target={ref}>
         {/* TODO update the reservationTagLine if the reservation is a recurring one based on the UI spec */}
+        {/* TODO need different buttons when the Reservation is recurring */}
         <StickyHeader
           name={getName(reservation, t)}
           tagline={reservationTagline}

--- a/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
+++ b/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
@@ -51,6 +51,7 @@ import { Accordion } from "../../../common/hds-fork/Accordion";
 import ApprovalButtons from "./ApprovalButtons";
 import { CURRENT_USER } from "../../../context/queries";
 import { useAuthState } from "../../../context/AuthStateContext";
+import RecurringReservationsView from "./RecurringReservationsView";
 
 const Dot = styled.div`
   display: inline-block;
@@ -299,6 +300,7 @@ const RequestedReservation = (): JSX.Element | null => {
         ]}
       />
       <ShowWhenTargetInvisible target={ref}>
+        {/* TODO update the reservationTagLine if the reservation is a recurring one based on the UI spec */}
         <StickyHeader
           name={getName(reservation, t)}
           tagline={reservationTagline}
@@ -463,6 +465,11 @@ const RequestedReservation = (): JSX.Element | null => {
               </VisibleIfPermission>
             </VerticalFlex>
           </Accordion>
+          {reservation.recurringReservation && (
+            <Accordion heading={t("RequestedReservation.recurring")}>
+              <RecurringReservationsView reservation={reservation} />
+            </Accordion>
+          )}
           <Accordion heading={t("RequestedReservation.calendar")}>
             <Calendar
               key={reservation.state}

--- a/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
+++ b/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
@@ -6,10 +6,8 @@ import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
-import { format } from "date-fns";
 import { breakpoints } from "common/src/common/style";
 import { H1 } from "common/src/common/typography";
-import { parseDate } from "common/src/common/util";
 import {
   Maybe,
   Mutation,
@@ -45,7 +43,7 @@ import {
 import { publicUrl } from "../../../common/const";
 import ShowWhenTargetInvisible from "../../ShowWhenTargetInvisible";
 import StickyHeader from "../../StickyHeader";
-import { formatDateTime } from "../../../common/util";
+import { formatDate, formatDateTime } from "../../../common/util";
 import Calendar from "./Calendar";
 import ReservationUserBirthDate from "./ReservationUserBirthDate";
 import VisibleIfPermission from "./VisibleIfPermission";
@@ -279,15 +277,9 @@ const RequestedReservation = (): JSX.Element | null => {
   const recurringTag =
     reservation.recurringReservation?.beginDate &&
     reservation.recurringReservation?.endDate
-      ? `
-    ${format(
-      parseDate(reservation.recurringReservation.beginDate),
-      "dd.MM.yyyy"
-    )} - ${format(
-          parseDate(reservation.recurringReservation.endDate),
-          "dd.MM.yyyy"
-        )}
-  `
+      ? `${formatDate(reservation.recurringReservation.beginDate)}-${formatDate(
+          reservation.recurringReservation.endDate
+        )}`
       : "";
   const unitTag = reservation?.reservationUnits
     ?.map(reservationUnitName)
@@ -297,7 +289,7 @@ const RequestedReservation = (): JSX.Element | null => {
     reservation.begin,
     reservation.end,
     t
-  )} ${reservationDuration(
+  )}, ${reservationDuration(
     reservation.begin,
     reservation.end
   )}t | ${recurringTag} | ${unitTag}`;
@@ -319,8 +311,7 @@ const RequestedReservation = (): JSX.Element | null => {
         ]}
       />
       <ShowWhenTargetInvisible target={ref}>
-        {/* TODO update the reservationTagLine if the reservation is a recurring one based on the UI spec */}
-        {/* TODO need different buttons when the Reservation is recurring */}
+        {/* TODO need Remove All button when the Reservation is recurring */}
         <StickyHeader
           name={getName(reservation, t)}
           tagline={reservationTagline}
@@ -491,7 +482,6 @@ const RequestedReservation = (): JSX.Element | null => {
             </Accordion>
           )}
           <Accordion heading={t("RequestedReservation.calendar")}>
-            {/* TODO there should be the first reservation time here: is it the first requested or the first CONFIRMED time though? */}
             <Calendar
               key={reservation.state}
               begin={reservation.begin}

--- a/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
+++ b/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
@@ -491,6 +491,7 @@ const RequestedReservation = (): JSX.Element | null => {
             </Accordion>
           )}
           <Accordion heading={t("RequestedReservation.calendar")}>
+            {/* TODO there should be the first reservation time here: is it the first requested or the first CONFIRMED time though? */}
             <Calendar
               key={reservation.state}
               begin={reservation.begin}

--- a/admin-ui/src/component/reservations/requested/queries.ts
+++ b/admin-ui/src/component/reservations/requested/queries.ts
@@ -107,8 +107,8 @@ export const RESERVATION_QUERY = gql`
 `;
 
 export const RECURRING_RESERVATION_QUERY = gql`
-  query recurringReservation($recurringPk: ID!) {
-    reservations(recurringReservation: $recurringPk) {
+  query recurringReservation($pk: ID!) {
+    reservations(recurringReservation: $pk) {
       edges {
         node {
           pk

--- a/admin-ui/src/component/reservations/requested/queries.ts
+++ b/admin-ui/src/component/reservations/requested/queries.ts
@@ -108,28 +108,13 @@ export const RESERVATION_QUERY = gql`
 
 export const RECURRING_RESERVATION_QUERY = gql`
   query recurringReservation($pk: ID!) {
-    reservations(recurringReservation: $pk) {
+    reservations(recurringReservation: $pk, state: ["CONFIRMED", "DENIED"]) {
       edges {
         node {
           pk
           begin
           end
           state
-        }
-      }
-    }
-    recurringReservations {
-      edges {
-        node {
-          pk
-          weekdays
-          beginTime
-          endTime
-          beginDate
-          endDate
-          name
-          description
-          user
         }
       }
     }

--- a/admin-ui/src/component/reservations/requested/queries.ts
+++ b/admin-ui/src/component/reservations/requested/queries.ts
@@ -54,6 +54,7 @@ export const RESERVATION_QUERY = gql`
         pk
         beginDate
         endDate
+        weekdays
       }
       orderStatus
       ageGroup {

--- a/admin-ui/src/component/reservations/requested/queries.ts
+++ b/admin-ui/src/component/reservations/requested/queries.ts
@@ -50,6 +50,11 @@ export const RESERVATION_QUERY = gql`
           status
         }
       }
+      recurringReservation {
+        pk
+        beginDate
+        endDate
+      }
       orderStatus
       ageGroup {
         minimum
@@ -97,6 +102,36 @@ export const RESERVATION_QUERY = gql`
       billingAddressZip
       freeOfChargeReason
       applyingForFreeOfCharge
+    }
+  }
+`;
+
+export const RECURRING_RESERVATION_QUERY = gql`
+  query recurringReservation($recurringPk: ID!) {
+    reservations(recurringReservation: $recurringPk) {
+      edges {
+        node {
+          pk
+          begin
+          end
+          state
+        }
+      }
+    }
+    recurringReservations {
+      edges {
+        node {
+          pk
+          weekdays
+          beginTime
+          endTime
+          beginDate
+          endDate
+          name
+          description
+          user
+        }
+      }
     }
   }
 `;

--- a/admin-ui/src/component/reservations/requested/util.ts
+++ b/admin-ui/src/component/reservations/requested/util.ts
@@ -35,17 +35,16 @@ export const reservationDateTime = (
 
   const startDay = t(`dayShort.${toMondayFirst(getDay(startDate))}`);
 
-  const endTimeFormat = endDate.getMinutes() === 0 ? "HH" : "HH:mm";
-  const startTimeFormat = startDate.getMinutes() === 0 ? "HH" : "HH:mm";
-  return isSameDay(startDate, endDate)
-    ? `${startDay} ${formatDate(start)} klo ${formatTime(
-        start,
-        startTimeFormat
-      )} - ${formatTime(end, endTimeFormat)}`
-    : `${formatDate(start)} klo ${formatTime(
-        start,
-        startTimeFormat
-      )} - ${formatDate(end, endTimeFormat)} klo ${formatTime(end)}`;
+  if (isSameDay(startDate, endDate)) {
+    return `${startDay} ${formatDate(start)} ${formatTime(
+      start,
+      "HH:mm"
+    )}-${formatTime(end, "HH:mm")}`;
+  }
+  return `${formatDate(start)} ${formatTime(start, "HH:mm")}-${formatDate(
+    end,
+    "HH:mm"
+  )} ${formatTime(end, "HH:mm")}`;
 };
 
 export const reservationDuration = (start: string, end: string): string => {

--- a/admin-ui/src/i18n/messages.ts
+++ b/admin-ui/src/i18n/messages.ts
@@ -320,6 +320,7 @@ const translations: ITranslations = {
       },
       pageTitle: ["Tee toistuva varaus"],
       Confirmation: {
+        removed: ["Poistettu"],
         title: ["Toistuva varaus tehty"],
         failedTitle: ["Epäonnistuneet varaukset"],
         successTitle: ["Varaukset"],
@@ -1883,6 +1884,7 @@ const translations: ITranslations = {
     heading: ["Varauksen tarkastelu"],
     calendar: ["Varauskalenteri"],
     summary: ["Varauksen yhteenveto"],
+    recurring: ["Toistokerrat"],
     state: {
       REQUIRES_HANDLING: ["Käsittelemättä"],
       CONFIRMED: ["Hyväksytty"],

--- a/admin-ui/src/i18n/messages.ts
+++ b/admin-ui/src/i18n/messages.ts
@@ -1810,6 +1810,9 @@ const translations: ITranslations = {
     removeFailed: ["Resurssin poistaminen ei onnistunut."],
     removeSuccess: ["Resurssi poistettu."],
   },
+  RecurringReservationsView: {
+    Heading: ["Ajankohta"],
+  },
   RequestedReservations: {
     heading: {
       unit: ["Toimipiste"],


### PR DESCRIPTION
The same view as normal requested/reservation but small changes if the reservation is part of a set.
- Different date-time after the header.
- extra Accordion for the other reservations in the set
- update the recurring list styling

Also some fixes to the time format we use.