### PR TITLE
TILA-2482: Fix reservation unit filter issues

### DIFF
--- a/admin-ui/src/component/filters/ReservationUnitFilter.tsx
+++ b/admin-ui/src/component/filters/ReservationUnitFilter.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
 import { useTranslation } from "react-i18next";
 import { Query, ReservationUnitType } from "common/types/gql-types";
@@ -11,22 +11,39 @@ type Props = {
   value: OptionType[];
 };
 
+// Doing repeated GQL requests because the backend (or Apollo) limits us to 100 results per query
+const LIMIT = 100;
+
 const ReservationUnitFilter = ({ onChange, value }: Props): JSX.Element => {
   const { t } = useTranslation();
-  const { data, loading } = useQuery<Query>(RESERVATION_UNITS_QUERY);
+  const [resUnits, setResUnits] = useState<ReservationUnitType[]>([]);
 
-  const opts: OptionType[] = (data?.reservationUnits?.edges ?? [])
-    .map((e) => e?.node)
-    .filter((e): e is ReservationUnitType => e != null)
-    .map((reservationUnit) => ({
-      label: reservationUnit?.nameFi ?? "",
-      value: reservationUnit?.pk ?? "",
-    }));
+  // TODO this request is rerun whenever the selection changes (it'll return 0 every time)
+  const { loading } = useQuery<Query>(RESERVATION_UNITS_QUERY, {
+    variables: { offset: resUnits.length, count: LIMIT },
+    onCompleted: (data) => {
+      const qd = data?.reservationUnits;
+      if (qd?.edges.length != null && qd?.totalCount && qd?.edges.length > 0) {
+        const ds =
+          data.reservationUnits?.edges
+            .map((x) => x?.node)
+            .filter((x): x is ReservationUnitType => x != null) ?? [];
+        setResUnits([...resUnits, ...ds]);
+      }
+    },
+  });
 
+  const opts: OptionType[] = (resUnits ?? []).map((reservationUnit) => ({
+    label: reservationUnit?.nameFi ?? "",
+    value: reservationUnit?.pk ?? "",
+  }));
+
+  // NOTE replaced frontend sort with backend, but this caused the sort to be case sensitive.
+  // TODO combobox would be preferable since we have like 400 items in it
+  // but combobox has some weird issue with ghost options being created.
   return (
     <SortedSelect
       disabled={loading}
-      sort
       label={t("ReservationUnitsFilter.label")}
       multiselect
       placeholder={t("common.filter")}

--- a/admin-ui/src/component/filters/queries.ts
+++ b/admin-ui/src/component/filters/queries.ts
@@ -14,14 +14,21 @@ export const RESERVATION_UNIT_TYPES_QUERY = gql`
 `;
 
 export const RESERVATION_UNITS_QUERY = gql`
-  query reservationUnits($unit: [ID]) {
-    reservationUnits(onlyWithPermission: true, unit: $unit) {
+  query reservationUnits($offset: Int, $unit: [ID], $count: Int) {
+    reservationUnits(
+      offset: $offset
+      onlyWithPermission: true
+      unit: $unit
+      orderBy: "nameFi"
+      first: $count
+    ) {
       edges {
         node {
           nameFi
           pk
         }
       }
+      totalCount
     }
   }
 `;

--- a/admin-ui/src/component/reservations/AllReservations.tsx
+++ b/admin-ui/src/component/reservations/AllReservations.tsx
@@ -8,6 +8,7 @@ import ReservationsDataLoader, { Sort } from "./ReservationsDataLoader";
 import BreadcrumbWrapper from "../BreadcrumbWrapper";
 import { HR } from "../lists/components";
 import { Container } from "../../styles/layout";
+import { DATE_FORMAT, formatDate } from "../../common/util";
 
 const AllReservations = (): JSX.Element => {
   const [search, setSearch] = useState<FilterArguments>(emptyState);
@@ -31,11 +32,15 @@ const AllReservations = (): JSX.Element => {
           <H1 $legacy>{t("Reservations.allReservationListHeading")}</H1>
           <p>{t("Reservations.allReservationListDescription")}</p>
         </div>
-        <Filters onSearch={debouncedSearch} />
+        <Filters
+          onSearch={debouncedSearch}
+          initialFiltering={{
+            begin: formatDate(new Date().toISOString(), DATE_FORMAT) as string,
+          }}
+        />
         <HR />
         <ReservationsDataLoader
           defaultFiltering={{}}
-          key={JSON.stringify({ ...search, ...sort })}
           filters={search}
           sort={sort}
           sortChanged={onSortChanged}

--- a/admin-ui/src/component/reservations/Filters.tsx
+++ b/admin-ui/src/component/reservations/Filters.tsx
@@ -11,7 +11,6 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import i18next from "i18next";
 import { OptionType } from "../../common/types";
-import { Grid, Span3 } from "../../styles/layout";
 import ReservationUnitTypeFilter from "../filters/ReservationUnitTypeFilter";
 import Tags, { Action, getReducer, toTags } from "../lists/Tags";
 import UnitFilter from "../filters/UnitFilter";
@@ -62,7 +61,11 @@ const ThinButton = styled(Button)`
   }
 `;
 
-const Buttons = styled.div``;
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+  gap: var(--spacing-m);
+`;
 
 export const emptyState: FilterArguments = {
   reservationUnitType: [],
@@ -134,47 +137,55 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
     <div>
       <Wrapper>
         <Grid>
-          <Span3>
+          <div>
             <ReservationUnitTypeFilter
               onChange={(reservationUnitType) =>
                 dispatch({ type: "set", value: { reservationUnitType } })
               }
               value={state.reservationUnitType}
             />
-          </Span3>
-          <Span3>
+          </div>
+          <div>
             <ReservationStateFilter
               onChange={(reservationState) =>
                 dispatch({ type: "set", value: { reservationState } })
               }
               value={state.reservationState}
             />
-          </Span3>
-          <Span3>
+          </div>
+          <div>
             <UnitFilter
               onChange={(unit) => dispatch({ type: "set", value: { unit } })}
               value={state.unit}
             />
-          </Span3>
-          <Span3>
+          </div>
+          <div>
             <MyTextInput
               id="textSearch"
               dispatch={dispatch}
               value={state.textSearch || ""}
             />
-          </Span3>
-          <Span3>
+          </div>
+          <div>
             <PaymentStatusFilter
               onChange={(paymentStatuses) =>
                 dispatch({ type: "set", value: { paymentStatuses } })
               }
               value={state.paymentStatuses || []}
             />
-          </Span3>
+          </div>
+          <div>
+            <ReservationUnitFilter
+              onChange={(reservationUnit) =>
+                dispatch({ type: "set", value: { reservationUnit } })
+              }
+              value={state.reservationUnit}
+            />
+          </div>
         </Grid>
         {more && (
           <Grid>
-            <Span3>
+            <div>
               <DateInput
                 language="fi"
                 id="begin"
@@ -184,8 +195,8 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
                 }
                 value={state.begin}
               />
-            </Span3>
-            <Span3>
+            </div>
+            <div>
               <DateInput
                 id="end"
                 language="fi"
@@ -193,8 +204,8 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
                 onChange={(end) => dispatch({ type: "set", value: { end } })}
                 value={state.end}
               />
-            </Span3>
-            <Span3>
+            </div>
+            <div>
               <NumberInput
                 type="number"
                 value={
@@ -215,8 +226,8 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
                   })
                 }
               />
-            </Span3>
-            <Span3>
+            </div>
+            <div>
               <NumberInput
                 type="number"
                 value={
@@ -239,20 +250,12 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
                   });
                 }}
               />
-            </Span3>
-            <Span3>
-              <ReservationUnitFilter
-                onChange={(reservationUnit) =>
-                  dispatch({ type: "set", value: { reservationUnit } })
-                }
-                value={state.reservationUnit}
-              />
-            </Span3>
+            </div>
           </Grid>
         )}
       </Wrapper>
 
-      <Buttons>
+      <div>
         <ThinButton
           variant="supplementary"
           onClick={() => setMore(!more)}
@@ -264,7 +267,7 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
               : "ReservationUnitsSearch.moreFilters"
           )}
         </ThinButton>
-      </Buttons>
+      </div>
       <Tags tags={tags} t={t} dispatch={dispatch} />
     </div>
   );


### PR DESCRIPTION
- GQL queries are limited to 100 items (hard limit), so our 400 unit test data got lost, added automatic fetchMore.
- Move reservation unit filter to be always visible in the ui.
- Make only upcoming the default filtering option for all reservations.