### PR TITLE
TILA-2490: bug fixes to Application rounds

### DIFF
--- a/admin-ui/src/common/util.test.ts
+++ b/admin-ui/src/common/util.test.ts
@@ -3,7 +3,7 @@ import { jest, test, expect } from "@jest/globals";
 import {
   convertHMSToSeconds,
   formatTimeDistance,
-  parseDuration,
+  formatDuration,
   secondsToHms,
   filterData,
   formatDecimal,
@@ -24,28 +24,29 @@ test("secondToHms", () => {
 
 // can't test actual values since i18next mock doesn't pass them through
 test("parseDuration short", () => {
-  expect(parseDuration(3600)).toBe("common.hoursUnit");
-  expect(parseDuration(3600 * 10)).toContain("common.hoursUnit");
-  expect(parseDuration(7834)).toContain("common.hoursUnit");
-  expect(parseDuration(3600 - 10)).not.toContain("common.hoursUnit");
-  expect(parseDuration(3600 - 10)).toBe("common.minutesUnit");
-  expect(parseDuration(3600 + 2 * 60)).toBe(
+  expect(formatDuration(3600)).toBe("common.hoursUnit");
+  expect(formatDuration(3600 * 10)).toContain("common.hoursUnit");
+  expect(formatDuration(7834)).toContain("common.hoursUnit");
+  expect(formatDuration(3600 - 10)).not.toContain("common.hoursUnit");
+  expect(formatDuration(3600 - 10)).toBe("common.minutesUnit");
+  // we have both hours and minutes
+  expect(formatDuration(3600 + 2 * 60)).toBe(
     "common.hoursUnit common.minutesUnit"
   );
 });
 
 test("parseDuration long", () => {
-  expect(parseDuration(3600, "long")).toBe("common.hoursUnitLong");
-  expect(parseDuration(3600 - 10, "long")).toBe("common.minutesUnitLong");
-  expect(parseDuration(3600 + 2 * 60, "long")).toBe(
+  expect(formatDuration(3600, "long")).toBe("common.hoursUnitLong");
+  expect(formatDuration(3600 - 10, "long")).toBe("common.minutesUnitLong");
+  expect(formatDuration(3600 + 2 * 60, "long")).toBe(
     "common.hoursUnitLong common.minutesUnitLong"
   );
 });
 
 test("parseDuration invalid", () => {
-  expect(parseDuration(0)).toBe("");
-  expect(parseDuration(-30)).toBe("");
-  expect(parseDuration(undefined)).toBe("");
+  expect(formatDuration(0)).toBe("");
+  expect(formatDuration(-30)).toBe("");
+  expect(formatDuration(undefined)).toBe("");
 });
 
 test("parseDurationString", () => {

--- a/admin-ui/src/common/util.test.ts
+++ b/admin-ui/src/common/util.test.ts
@@ -1,3 +1,4 @@
+import { jest, test, expect } from "@jest/globals";
 import {
   convertHMSToSeconds,
   formatTimeDistance,
@@ -7,6 +8,11 @@ import {
   formatDecimal,
 } from "./util";
 
+jest.mock("i18next", () => ({
+  // t: (str: string, { count }) => `${count} ${str}`,
+  t: (str: string) => str,
+}));
+
 test("secondToHms", () => {
   expect(secondsToHms(9832475)).toEqual({ h: 2731, m: 14, s: 35 });
   expect(secondsToHms(0)).toEqual({});
@@ -15,8 +21,16 @@ test("secondToHms", () => {
   expect(secondsToHms(undefined)).toEqual({});
 });
 
+// can't test actual values since mock doesn't pass them through
 test("parseDuration", () => {
-  expect(parseDuration(7834)).toBe("undefined undefined");
+  expect(parseDuration(3600)).toBe("common.hoursUnit");
+  expect(parseDuration(3600 * 10)).toContain("common.hoursUnit");
+  expect(parseDuration(7834)).toContain("common.hoursUnit");
+  expect(parseDuration(3600 - 10)).not.toContain("common.hoursUnit");
+  expect(parseDuration(3600 - 10)).toContain("common.minutesUnit");
+  // TODO test long format (proper minutes / hours label)
+
+  // invalid values
   expect(parseDuration(0)).toBe("");
   expect(parseDuration(-30)).toBe("");
   expect(parseDuration(undefined)).toBe("");

--- a/admin-ui/src/common/util.ts
+++ b/admin-ui/src/common/util.ts
@@ -184,28 +184,28 @@ export const secondsToHms = (duration?: number | null): HMS => {
   return { h, m, s };
 };
 
+const parseDurationShort = (hms: HMS): string =>
+  `${hms.h ? i18next.t("common.hoursUnit", { count: hms.h }) : ""} ${
+    hms.m ? i18next.t("common.minutesUnit", { count: hms.m }) : ""
+  }`;
+
+const parseDurationLong = (hms: HMS): string =>
+  `${hms.h ? i18next.t("common.hoursUnitLong", { count: hms.h }) : ""} ${
+    hms.m ? i18next.t("common.minutesUnitLong", { count: hms.m }) : ""
+  }`;
+
 export const parseDuration = (
   duration: number | null | undefined,
   unitFormat?: "long"
 ): string => {
   const hms = secondsToHms(duration);
-  let hoursUnit: string;
-  let minutesUnit: string;
-  let output = "";
 
   switch (unitFormat) {
     case "long":
-      hoursUnit = "common.hoursUnitLong";
-      minutesUnit = "common.minutesUnitLong";
-      break;
+      return parseDurationLong(hms).trim();
     default:
-      hoursUnit = "common.hoursUnit";
-      minutesUnit = "common.minutesUnit";
+      return parseDurationShort(hms).trim();
   }
-  if (hms.h) output += `${i18next.t(hoursUnit, { count: hms.h })} `;
-  if (hms.m) output += `${i18next.t(minutesUnit, { count: hms.m })}`;
-
-  return output.trim();
 };
 
 export const convertHMSToSeconds = (input: string): number | null => {

--- a/admin-ui/src/common/util.ts
+++ b/admin-ui/src/common/util.ts
@@ -73,20 +73,7 @@ export const formatDecimal = ({
   return parseFloat(value.toFixed(decimals));
 };
 
-interface IFormatDurationOutput {
-  hours: number;
-  minutes: number;
-}
-
 export type ApplicationRoundStatusView = "listing";
-
-export const formatDuration = (time: string): IFormatDurationOutput => {
-  const [hours, minutes] = time.split(":");
-  return {
-    hours: Number(hours),
-    minutes: Number(minutes),
-  };
-};
 
 export const getNormalizedApplicationEventStatus = (
   status: ApplicationEventStatus,
@@ -184,16 +171,38 @@ export const secondsToHms = (duration?: number | null): HMS => {
   return { h, m, s };
 };
 
-const parseDurationShort = (hms: HMS): string =>
+// TODO remove the String when the parses are renamed
+export const parseDurationString = (time: string): HMS | undefined => {
+  const [hours, minutes] = time.split(":");
+  if (!hours && !minutes) {
+    return undefined;
+  }
+  const h = Number(hours);
+  const m = Number(minutes);
+  if (
+    Number.isNaN(h) ||
+    Number.isNaN(m) ||
+    h >= 24 ||
+    h < 0 ||
+    m < 0 ||
+    m >= 60
+  ) {
+    return undefined;
+  }
+  return { h, m };
+};
+
+export const formatDurationShort = (hms: HMS): string =>
   `${hms.h ? i18next.t("common.hoursUnit", { count: hms.h }) : ""} ${
     hms.m ? i18next.t("common.minutesUnit", { count: hms.m }) : ""
   }`;
 
-const parseDurationLong = (hms: HMS): string =>
+export const formatDurationLong = (hms: HMS): string =>
   `${hms.h ? i18next.t("common.hoursUnitLong", { count: hms.h }) : ""} ${
     hms.m ? i18next.t("common.minutesUnitLong", { count: hms.m }) : ""
   }`;
 
+// TODO parseDuration is not a parse. parse: string => object (this is a print / format)
 export const parseDuration = (
   duration: number | null | undefined,
   unitFormat?: "long"
@@ -202,9 +211,9 @@ export const parseDuration = (
 
   switch (unitFormat) {
     case "long":
-      return parseDurationLong(hms).trim();
+      return formatDurationLong(hms).trim();
     default:
-      return parseDurationShort(hms).trim();
+      return formatDurationShort(hms).trim();
   }
 };
 

--- a/admin-ui/src/common/util.ts
+++ b/admin-ui/src/common/util.ts
@@ -171,7 +171,6 @@ export const secondsToHms = (duration?: number | null): HMS => {
   return { h, m, s };
 };
 
-// TODO remove the String when the parses are renamed
 export const parseDurationString = (time: string): HMS | undefined => {
   const [hours, minutes] = time.split(":");
   if (!hours && !minutes) {
@@ -202,8 +201,7 @@ export const formatDurationLong = (hms: HMS): string =>
     hms.m ? i18next.t("common.minutesUnitLong", { count: hms.m }) : ""
   }`;
 
-// TODO parseDuration is not a parse. parse: string => object (this is a print / format)
-export const parseDuration = (
+export const formatDuration = (
   duration: number | null | undefined,
   unitFormat?: "long"
 ): string => {

--- a/admin-ui/src/component/DataTable.tsx
+++ b/admin-ui/src/component/DataTable.tsx
@@ -97,7 +97,9 @@ interface IToggleableButton {
   $isActive: boolean;
 }
 
-const Wrapper = styled.div``;
+const Wrapper = styled.div`
+  display: grid;
+`;
 
 const tableBorder = (size = "0.5em"): string =>
   `${size} solid var(--tilavaraus-admin-gray)`;

--- a/admin-ui/src/component/StickyHeader.tsx
+++ b/admin-ui/src/component/StickyHeader.tsx
@@ -7,7 +7,6 @@ const Sticky = styled.div`
   position: sticky;
   top: 0px;
   width: 100%;
-  max-width: calc(48px + var(--container-width-l));
   background-color: white;
   height: 0;
 `;

--- a/admin-ui/src/component/Tabs.tsx
+++ b/admin-ui/src/component/Tabs.tsx
@@ -6,6 +6,9 @@ import styled from "styled-components";
 const TabPanel = styled(HDSTabs.TabPanel)`
   margin-top: var(--spacing-s);
   padding-block: var(--spacing-m);
+  & > div {
+    display: grid;
+  }
 `;
 
 type TabHeader = {

--- a/admin-ui/src/component/applications/Application.tsx
+++ b/admin-ui/src/component/applications/Application.tsx
@@ -48,7 +48,7 @@ import {
   formatDate,
   formatNumber,
   localizedValue,
-  parseDuration,
+  formatDuration,
 } from "../../common/util";
 import ApplicationStatusBlock from "./ApplicationStatusBlock";
 import Accordion from "../Accordion";
@@ -322,7 +322,7 @@ const AccordionContent = ({
                   end={endDate}
                   weekday={weekday}
                   biweekly={applicationEvent.biweekly || false}
-                  durationStr={parseDuration(duration)}
+                  durationStr={formatDuration(duration)}
                   timeStart={formatDate(beginDate || "", "H:mm:ss")}
                   timeEnd={formatDate(endDate || "", "H:mm:ss")}
                 />
@@ -619,7 +619,7 @@ const Application = () => {
                     </tr>
                     <tr>
                       <th>{t("ApplicationRound.totalReservationTime")}</th>
-                      <td data-testid="application__data--applied-min-duration-total">{`${parseDuration(
+                      <td data-testid="application__data--applied-min-duration-total">{`${formatDuration(
                         application.aggregatedData.appliedMinDurationTotal
                       )}`}</td>
                     </tr>
@@ -668,7 +668,7 @@ const Application = () => {
                                     {t("ApplicationRound.totalReservationTime")}
                                   </th>
                                   <td>
-                                    {parseDuration(
+                                    {formatDuration(
                                       application.aggregatedData
                                         .reservationsDurationTotal
                                     )}

--- a/admin-ui/src/component/applications/Application.tsx
+++ b/admin-ui/src/component/applications/Application.tsx
@@ -228,6 +228,140 @@ const ActionButton = styled(Button)`
   right: var(--spacing-layout-xl);
 `;
 
+const AccordionContent = ({
+  recurringReservations,
+  applicationId,
+  applicationEvents,
+}: {
+  recurringReservations: RecurringReservation[];
+  applicationId?: number;
+  applicationEvents: ApplicationEvent[];
+}) => {
+  const { t, i18n } = useTranslation();
+
+  return (
+    <Accordion
+      heading={t("Application.summaryOfAllocatedApplicationEvents")}
+      defaultOpen={false}
+    >
+      <NarrowContainer
+        style={{
+          paddingRight: 0,
+          marginLeft: 'calc(var("--spacing-layout-m") * -1)',
+        }}
+      >
+        {recurringReservations.map((recurringReservation) => {
+          const applicationEvent: ApplicationEvent | undefined =
+            applicationEvents.find(
+              (n: ApplicationEvent) =>
+                n.id === get(recurringReservation, "applicationEventId")
+            );
+
+          const reservationUnit: ReservationUnit | undefined =
+            recurringReservation.reservations?.[0].reservationUnit?.[0];
+
+          const beginDate: string | null =
+            recurringReservation.firstReservationBegin;
+
+          const endDate: string | null =
+            recurringReservation.lastReservationEnd;
+
+          const weekday: number | null = get(
+            recurringReservation,
+            "reservations.0.beginWeekday",
+            null
+          );
+
+          const duration: number = Math.abs(
+            differenceInSeconds(
+              new Date(get(recurringReservation, "reservations.0.begin", 0)),
+              new Date(get(recurringReservation, "reservations.0.end", 0))
+            )
+          );
+
+          return applicationEvent && reservationUnit ? (
+            <ReservationWrapper>
+              <H2>{applicationEvent?.name}</H2>
+              <DataGrid
+                style={{
+                  borderTop: 0,
+                  paddingTop: 0,
+                  marginBottom: "var(--spacing-layout-s)",
+                }}
+              >
+                <GridCol>
+                  <table>
+                    <tbody>
+                      <tr>
+                        <th>{t("Application.space")}</th>
+                        <td>
+                          {trim(
+                            `${reservationUnit.unit?.name.fi || ""}, ${
+                              localizedValue(
+                                reservationUnit.name,
+                                i18n.language
+                              ) || ""
+                            }`,
+                            ", "
+                          )}
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>{t("Application.headings.purpose")}</th>
+                        <td>{applicationEvent.purpose}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </GridCol>
+                <GridCol />
+              </DataGrid>
+              <table>
+                <RecommendedSlot
+                  id={applicationEvent.id || null}
+                  start={beginDate}
+                  end={endDate}
+                  weekday={weekday}
+                  biweekly={applicationEvent.biweekly || false}
+                  durationStr={parseDuration(duration)}
+                  timeStart={formatDate(beginDate || "", "H:mm:ss")}
+                  timeEnd={formatDate(endDate || "", "H:mm:ss")}
+                />
+              </table>
+              {recurringReservation.deniedReservations?.length > 0 && (
+                <DeclinedReservations>
+                  <H3>{t("Application.declinedReservations")}</H3>
+                  <div>
+                    {trim(
+                      recurringReservation.deniedReservations
+                        .map((n: Reservation) => `${formatDate(n.begin)}, `)
+                        .reverse()
+                        .join(", "),
+                      ", "
+                    )}
+                  </div>
+                </DeclinedReservations>
+              )}
+              {applicationId ? (
+                <ReservationListLinkWrapper>
+                  <ReservationListLink
+                    to={`${applicationUrl(
+                      applicationId
+                    )}/recurringReservation/${recurringReservation.id}`}
+                  >
+                    <IconCalendar aria-hidden />{" "}
+                    {t("Application.showDetailedResultList")}{" "}
+                    <IconArrowRight aria-hidden />
+                  </ReservationListLink>
+                </ReservationListLinkWrapper>
+              ) : null}
+            </ReservationWrapper>
+          ) : null;
+        })}
+      </NarrowContainer>
+    </Accordion>
+  );
+};
+
 const Application = () => {
   const { notifyError } = useNotification();
   const [isLoading, setIsLoading] = useState(true);
@@ -245,7 +379,7 @@ const Application = () => {
     useState<ApplicationStatus | null>(null);
 
   const { applicationId } = useParams<IRouteParams>();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
 
   const fetchApplication = async (id: number) => {
     try {
@@ -599,163 +733,11 @@ const Application = () => {
                 <WideContainer>
                   {recurringReservations &&
                     recurringReservations.length > 0 && (
-                      <Accordion
-                        heading={t(
-                          "Application.summaryOfAllocatedApplicationEvents"
-                        )}
-                        defaultOpen={false}
-                      >
-                        <NarrowContainer
-                          style={{
-                            paddingRight: 0,
-                            marginLeft: 'calc(var("--spacing-layout-m") * -1)',
-                          }}
-                        >
-                          {recurringReservations.map((recurringReservation) => {
-                            const applicationEvent:
-                              | ApplicationEvent
-                              | undefined = application.applicationEvents.find(
-                              (n: ApplicationEvent) =>
-                                n.id ===
-                                get(recurringReservation, "applicationEventId")
-                            );
-
-                            const reservationUnit: ReservationUnit | undefined =
-                              recurringReservation.reservations?.[0]
-                                .reservationUnit?.[0];
-
-                            const beginDate: string | null =
-                              recurringReservation.firstReservationBegin;
-
-                            const endDate: string | null =
-                              recurringReservation.lastReservationEnd;
-
-                            const weekday: number | null = get(
-                              recurringReservation,
-                              "reservations.0.beginWeekday",
-                              null
-                            );
-
-                            const duration: number = Math.abs(
-                              differenceInSeconds(
-                                new Date(
-                                  get(
-                                    recurringReservation,
-                                    "reservations.0.begin",
-                                    0
-                                  )
-                                ),
-                                new Date(
-                                  get(
-                                    recurringReservation,
-                                    "reservations.0.end",
-                                    0
-                                  )
-                                )
-                              )
-                            );
-
-                            return applicationEvent && reservationUnit ? (
-                              <ReservationWrapper key={applicationEvent.id}>
-                                <H2>{applicationEvent?.name}</H2>
-                                <DataGrid
-                                  style={{
-                                    borderTop: 0,
-                                    paddingTop: 0,
-                                    marginBottom: "var(--spacing-layout-s)",
-                                  }}
-                                >
-                                  <GridCol>
-                                    <table>
-                                      <tbody>
-                                        <tr>
-                                          <th>{t("Application.space")}</th>
-                                          <td>
-                                            {trim(
-                                              `${
-                                                reservationUnit.unit?.name.fi ||
-                                                ""
-                                              }, ${
-                                                localizedValue(
-                                                  reservationUnit.name,
-                                                  i18n.language
-                                                ) || ""
-                                              }`,
-                                              ", "
-                                            )}
-                                          </td>
-                                        </tr>
-                                        <tr>
-                                          <th>
-                                            {t("Application.headings.purpose")}
-                                          </th>
-                                          <td>{applicationEvent.purpose}</td>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                  </GridCol>
-                                  <GridCol />
-                                </DataGrid>
-                                <table>
-                                  <RecommendedSlot
-                                    id={applicationEvent.id || null}
-                                    start={beginDate}
-                                    end={endDate}
-                                    weekday={weekday}
-                                    biweekly={
-                                      applicationEvent.biweekly || false
-                                    }
-                                    durationStr={parseDuration(duration)}
-                                    timeStart={formatDate(
-                                      beginDate || "",
-                                      "H:mm:ss"
-                                    )}
-                                    timeEnd={formatDate(
-                                      endDate || "",
-                                      "H:mm:ss"
-                                    )}
-                                  />
-                                </table>
-                                {recurringReservation.deniedReservations
-                                  ?.length > 0 && (
-                                  <DeclinedReservations>
-                                    <H3>
-                                      {t("Application.declinedReservations")}
-                                    </H3>
-                                    <div>
-                                      {trim(
-                                        recurringReservation.deniedReservations
-                                          .map(
-                                            (n: Reservation) =>
-                                              `${formatDate(n.begin)}, `
-                                          )
-                                          .reverse()
-                                          .join(", "),
-                                        ", "
-                                      )}
-                                    </div>
-                                  </DeclinedReservations>
-                                )}
-                                {applicationId ? (
-                                  <ReservationListLinkWrapper>
-                                    <ReservationListLink
-                                      to={`${applicationUrl(
-                                        applicationId
-                                      )}/recurringReservation/${
-                                        recurringReservation.id
-                                      }`}
-                                    >
-                                      <IconCalendar aria-hidden />{" "}
-                                      {t("Application.showDetailedResultList")}{" "}
-                                      <IconArrowRight aria-hidden />
-                                    </ReservationListLink>
-                                  </ReservationListLinkWrapper>
-                                ) : null}
-                              </ReservationWrapper>
-                            ) : null;
-                          })}
-                        </NarrowContainer>
-                      </Accordion>
+                      <AccordionContent
+                        recurringReservations={recurringReservations}
+                        applicationId={applicantId ?? undefined}
+                        applicationEvents={application.applicationEvents}
+                      />
                     )}
                   <ActionButtonContainer>
                     {normalizedApplicationStatus === "approved" && (

--- a/admin-ui/src/component/applications/ApplicationDetails.tsx
+++ b/admin-ui/src/component/applications/ApplicationDetails.tsx
@@ -361,8 +361,6 @@ function ApplicationDetails(): JSX.Element | null {
                   applicationEvent.maxDuration,
                   t
                 );
-                // const duration = appEventDuration(applicationEvent, t);
-                console.log("application event duration: ", duration);
 
                 return (
                   <ScrollIntoView
@@ -472,7 +470,7 @@ function ApplicationDetails(): JSX.Element | null {
                                 return (
                                   <EventSchedule key={day}>
                                     <Strong>{t(`calendar.${day}`)}</Strong>
-                                    {schedulesTxt ? `,${schedulesTxt}` : ""}
+                                    {schedulesTxt ? `: ${schedulesTxt}` : ""}
                                   </EventSchedule>
                                 );
                               })}

--- a/admin-ui/src/component/applications/ApplicationDetails.tsx
+++ b/admin-ui/src/component/applications/ApplicationDetails.tsx
@@ -28,7 +28,8 @@ import {
   formatDate,
   parseApplicationEventSchedules,
   parseAgeGroups,
-  formatDuration,
+  parseDurationString,
+  formatDurationShort,
 } from "../../common/util";
 import ValueBox from "./ValueBox";
 import { publicUrl, weekdays } from "../../common/const";
@@ -167,25 +168,21 @@ const KV = ({
   </div>
 );
 
-// FIXME this pair of utility functions fails (adding double translations)
-// might be fixed now? TODO test it
-// TODO this is bad (we got similar conversion function already, and this code is messy)
-const parseDuration = (
+// TODO there is a missing space between the hours and minutes => TEST
+const formatDuration = (
   duration: string | null,
   t: TFunction,
   type?: "min" | "max"
 ): string => {
-  if (!duration) return "";
-  const dur = formatDuration(duration);
-  const translationKey = `common.${type}Amount`;
-  let result = "";
-  result += `${type ? t(translationKey) : ""} ${
-    dur.hours && t("common.hoursUnit", { count: dur.hours })
-  }`;
-  if (dur.minutes) {
-    result += t("common.minutesUnit", { count: dur.minutes });
+  if (!duration) {
+    return "";
   }
-  return result;
+  const dur = parseDurationString(duration);
+  const translationKey = `common.${type}Amount`;
+  if (!dur) {
+    return "";
+  }
+  return `${type ? t(translationKey) : ""} ${formatDurationShort(dur)}`;
 };
 
 const appEventDuration = (
@@ -195,10 +192,10 @@ const appEventDuration = (
 ): string => {
   let duration = "";
   if (isEqual(min, max)) {
-    duration += parseDuration(min, t);
+    duration += formatDuration(min, t);
   } else {
-    duration += parseDuration(min, t, "min");
-    duration += `, ${parseDuration(max, t, "max")}`;
+    duration += formatDuration(min, t, "min");
+    duration += `, ${formatDuration(max, t, "max")}`;
   }
   return trim(duration, ", ");
 };

--- a/admin-ui/src/component/applications/ApplicationDetails.tsx
+++ b/admin-ui/src/component/applications/ApplicationDetails.tsx
@@ -452,7 +452,7 @@ function ApplicationDetails(): JSX.Element | null {
                                 return (
                                   <EventSchedule key={day}>
                                     <Strong>{t(`calendar.${day}`)}</Strong>
-                                    {schedulesTxt ? `,${schedulesTxt}` : ""}
+                                    {schedulesTxt ? `: ${schedulesTxt}` : ""}
                                   </EventSchedule>
                                 );
                               })}

--- a/admin-ui/src/component/applications/ApplicationDetails.tsx
+++ b/admin-ui/src/component/applications/ApplicationDetails.tsx
@@ -257,7 +257,7 @@ function ApplicationDetails(): JSX.Element | null {
           <ShowWhenTargetInvisible target={ref}>
             <StickyHeader
               name={customerName}
-              tagline={`${t("Application.id")}:${application.id}`}
+              tagline={`${t("Application.id")}: ${application.id}`}
             />
           </ShowWhenTargetInvisible>
 

--- a/admin-ui/src/component/applications/ApplicationDetails.tsx
+++ b/admin-ui/src/component/applications/ApplicationDetails.tsx
@@ -168,7 +168,6 @@ const KV = ({
   </div>
 );
 
-// TODO there is a missing space between the hours and minutes => TEST
 const formatDuration = (
   duration: string | null,
   t: TFunction,

--- a/admin-ui/src/component/applications/Applications.tsx
+++ b/admin-ui/src/component/applications/Applications.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../common/types";
 import Loader from "../Loader";
 import DataTable, { CellConfig } from "../DataTable";
-import { formatNumber, parseDuration } from "../../common/util";
+import { formatNumber, formatDuration } from "../../common/util";
 import StatusCell from "../StatusCell";
 import { applicationUrl } from "../../common/urls";
 import { getNormalizedApplicationStatus } from "./util";
@@ -141,7 +141,7 @@ const appMapper = (
       `${formatNumber(
         app.aggregatedData?.appliedReservationsTotal,
         t("common.volumeUnit")
-      )} / ${parseDuration(app.aggregatedData?.appliedMinDurationTotal)}`,
+      )} / ${formatDuration(app.aggregatedData?.appliedMinDurationTotal)}`,
       " / "
     ),
     applicationCountSort: app.aggregatedData?.appliedReservationsTotal || 0,

--- a/admin-ui/src/component/applications/util.ts
+++ b/admin-ui/src/component/applications/util.ts
@@ -1,14 +1,11 @@
 import { differenceInWeeks } from "date-fns";
-import { isEqual, sum, trim } from "lodash";
-import { TFunction } from "i18next";
+import { sum } from "lodash";
 import { ApplicationType } from "common/types/gql-types";
 import {
   Application,
-  ApplicationEvent,
   ApplicationRoundStatus,
   ApplicationStatus,
 } from "../../common/types";
-import { formatDuration } from "../../common/util";
 
 export const applicantName = (app: Application | ApplicationType): string => {
   return app.applicantType === "individual" ||

--- a/admin-ui/src/component/applications/util.ts
+++ b/admin-ui/src/component/applications/util.ts
@@ -126,35 +126,3 @@ export const applicationTurns = (application: Application): number =>
       )
     )
   );
-
-const parseDuration = (
-  duration: string | null,
-  t: TFunction,
-  type?: "min" | "max"
-): string => {
-  if (!duration) return "";
-  const durationObj = formatDuration(duration);
-  const translationKey = `common.${type}Amount`;
-  let result = "";
-  result += `${type ? t(translationKey) : ""} ${
-    durationObj.hours && durationObj.hours + t("common.hoursUnit")
-  }`;
-  if (durationObj.minutes) {
-    result += ` ${durationObj.minutes + t("common.minutesUnit")}`;
-  }
-  return result;
-};
-
-export const appEventDuration = (
-  applicationEvent: ApplicationEvent,
-  t: TFunction
-): string => {
-  let duration = "";
-  if (isEqual(applicationEvent.minDuration, applicationEvent.maxDuration)) {
-    duration += parseDuration(applicationEvent.minDuration, t);
-  } else {
-    duration += parseDuration(applicationEvent?.minDuration, t, "min");
-    duration += `, ${parseDuration(applicationEvent?.maxDuration, t, "max")}`;
-  }
-  return trim(duration, ", ");
-};

--- a/admin-ui/src/component/lists/components.tsx
+++ b/admin-ui/src/component/lists/components.tsx
@@ -2,7 +2,6 @@ import { get } from "lodash";
 import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import { breakpoints } from "common/src/common/style";
 import { Table, TableProps } from "../../common/hds-fork/table/Table";
 
 type TableWrapperProps = {
@@ -17,17 +16,9 @@ export const HR = styled.hr`
   width: 100%;
 `;
 
-const TableWrapper = styled.div<TableWrapperProps>`
-  div {
-    overflow-x: auto;
-    @media (min-width: ${breakpoints.xl}) {
-      overflow-x: unset !important;
-    }
-  }
-  table {
-    width: 100%;
+const StyledTable = styled(Table)<TableWrapperProps>`
+  & {
     th {
-      color: black !important;
       font-family: var(--font-bold);
       padding: var(--spacing-xs);
       background: ${({ $headingBackground = "var(--color-black-10)" }) =>
@@ -56,15 +47,14 @@ const TableWrapper = styled.div<TableWrapperProps>`
 export const CustomTable = (
   props: TableProps & { setSort: (col: string) => void }
 ): JSX.Element => (
-  <TableWrapper
+  <StyledTable
     $headingBackground="var(--color-black-10)"
     $tableBackground="var(--color-white)"
     $colWidths={
       props?.cols ? props.cols.map((col) => get(col, "width", "auto")) : []
     }
-  >
-    <Table {...props} />
-  </TableWrapper>
+    {...props}
+  />
 );
 
 const NoDataMessage = styled.span`

--- a/admin-ui/src/component/lists/components.tsx
+++ b/admin-ui/src/component/lists/components.tsx
@@ -18,6 +18,7 @@ export const HR = styled.hr`
 
 const StyledTable = styled(Table)<TableWrapperProps>`
   & {
+    white-space: nowrap;
     th {
       font-family: var(--font-bold);
       padding: var(--spacing-xs);
@@ -31,7 +32,6 @@ const StyledTable = styled(Table)<TableWrapperProps>`
       }
     }
     td {
-      white-space: nowrap;
       padding: var(--spacing-xs);
       background: ${({ $tableBackground = "transparent" }) => $tableBackground};
     }

--- a/admin-ui/src/component/lists/components.tsx
+++ b/admin-ui/src/component/lists/components.tsx
@@ -17,8 +17,9 @@ export const HR = styled.hr`
 `;
 
 const StyledTable = styled(Table)<TableWrapperProps>`
-  & {
+  &&& {
     white-space: nowrap;
+    border-collapse: collapse;
     th {
       font-family: var(--font-bold);
       padding: var(--spacing-xs);

--- a/admin-ui/src/component/lists/components.tsx
+++ b/admin-ui/src/component/lists/components.tsx
@@ -68,7 +68,7 @@ export const CustomTable = (
 );
 
 const NoDataMessage = styled.span`
-  line-height: 4;
+  line-height: 1.5;
 `;
 
 const A = styled(Link)`

--- a/admin-ui/src/component/recurring-reservations/AllApplicationRounds.tsx
+++ b/admin-ui/src/component/recurring-reservations/AllApplicationRounds.tsx
@@ -173,8 +173,8 @@ function AllApplicationRounds(): JSX.Element | null {
                     <TableLink
                       to={applicationRoundUrl(Number(applicationRound.pk))}
                     >
-                      <span title={applicationRound.nameFi as string}>
-                        {truncate(applicationRound.nameFi as string, 20)}
+                      <span title={applicationRound.nameFi ?? ""}>
+                        {truncate(applicationRound.nameFi ?? "", 20)}
                       </span>
                     </TableLink>
                   ),
@@ -183,7 +183,7 @@ function AllApplicationRounds(): JSX.Element | null {
                 {
                   headerName: t("ApplicationRound.headings.service"),
                   transform: (applicationRound: ApplicationRoundType) =>
-                    applicationRound.serviceSector?.nameFi as string,
+                    applicationRound.serviceSector?.nameFi ?? "",
                   key: "serviceSectorName",
                 },
                 {

--- a/admin-ui/src/component/recurring-reservations/ApplicationRoundCard.tsx
+++ b/admin-ui/src/component/recurring-reservations/ApplicationRoundCard.tsx
@@ -73,6 +73,7 @@ function Stat({ value, label }: { value: number; label: string }): JSX.Element {
 
 function ApplicationRoundCard({ applicationRound }: IProps): JSX.Element {
   const { t } = useTranslation();
+
   return (
     <StyledCard>
       <Layout>
@@ -93,15 +94,15 @@ function ApplicationRoundCard({ applicationRound }: IProps): JSX.Element {
           </Times>
           <Stats>
             <Stat
-              value={applicationRound.reservationUnitCount as number}
+              value={applicationRound.reservationUnitCount ?? 0}
               label={t("ApplicationRound.reservationUnitCount", {
-                count: applicationRound.reservationUnitCount as number,
+                count: applicationRound.reservationUnitCount ?? 0,
               })}
             />
             <Stat
-              value={applicationRound.applicationsCount as number}
+              value={applicationRound.applicationsCount ?? 0}
               label={t("ApplicationRound.applicationCount", {
-                count: applicationRound.applicationsCount as number,
+                count: applicationRound.applicationsCount ?? 0,
               })}
             />
           </Stats>

--- a/admin-ui/src/component/recurring-reservations/Handling.tsx
+++ b/admin-ui/src/component/recurring-reservations/Handling.tsx
@@ -39,7 +39,7 @@ import {
   formatNumber,
   getNormalizedApplicationEventStatus,
   parseAgeGroups,
-  parseDuration,
+  formatDuration,
 } from "../../common/util";
 import {
   prepareAllocationResults,
@@ -276,7 +276,7 @@ const getCellConfig = (
               `${formatNumber(
                 aggregatedData?.reservationsTotal,
                 t("common.volumeUnit")
-              )} / ${parseDuration(aggregatedData?.durationTotal)}`,
+              )} / ${formatDuration(aggregatedData?.durationTotal)}`,
               " / "
             )}
           </>

--- a/admin-ui/src/component/recurring-reservations/PreApproval.tsx
+++ b/admin-ui/src/component/recurring-reservations/PreApproval.tsx
@@ -27,7 +27,7 @@ import TimeframeStatus from "./TimeframeStatus";
 import { ContentHeading } from "../../styles/typography";
 import DataTable, { CellConfig, OrderTypes } from "../DataTable";
 import Dialog from "../Dialog";
-import { formatNumber, parseDuration } from "../../common/util";
+import { formatNumber, formatDuration } from "../../common/util";
 import {
   prepareAllocationResults,
   processAllocationResult,
@@ -245,7 +245,7 @@ const getCellConfig = (
                     `${formatNumber(
                       aggregatedData?.reservationsTotal,
                       t("common.volumeUnit")
-                    )} / ${parseDuration(aggregatedData?.durationTotal)}`,
+                    )} / ${formatDuration(aggregatedData?.durationTotal)}`,
                     " / "
                   )
                 : t("Recommendation.noRecommendations")}

--- a/admin-ui/src/component/recurring-reservations/Recommendation.tsx
+++ b/admin-ui/src/component/recurring-reservations/Recommendation.tsx
@@ -29,7 +29,11 @@ import {
   Application as ApplicationType,
   ApplicationRound as ApplicationRoundType,
 } from "../../common/types";
-import { formatNumber, parseAgeGroups, parseDuration } from "../../common/util";
+import {
+  formatNumber,
+  parseAgeGroups,
+  formatDuration,
+} from "../../common/util";
 import { processAllocationResult } from "../../common/AllocationResult";
 import { IngressContainer, NarrowContainer } from "../../styles/layout";
 import { BasicLink, Divider } from "../../styles/util";
@@ -613,7 +617,7 @@ function Recommendation(): JSX.Element {
                     `${formatNumber(
                       recommendation.aggregatedData?.reservationsTotal,
                       t("common.volumeUnit")
-                    )} / ${parseDuration(
+                    )} / ${formatDuration(
                       recommendation.aggregatedData?.durationTotal
                     )}`,
                     " / "

--- a/admin-ui/src/component/recurring-reservations/RecommendationsByApplicant.tsx
+++ b/admin-ui/src/component/recurring-reservations/RecommendationsByApplicant.tsx
@@ -35,7 +35,7 @@ import {
   formatNumber,
   getNormalizedApplicationEventStatus,
   parseAgeGroups,
-  parseDuration,
+  formatDuration,
 } from "../../common/util";
 import {
   modifyAllocationResults,
@@ -130,7 +130,7 @@ const getCellConfig = (
               `${formatNumber(
                 aggregatedData?.reservationsTotal,
                 t("common.volumeUnit")
-              )} / ${parseDuration(aggregatedData?.durationTotal)}`,
+              )} / ${formatDuration(aggregatedData?.durationTotal)}`,
               " / "
             )}
           </>

--- a/admin-ui/src/component/recurring-reservations/RecommendationsByApplicant.tsx
+++ b/admin-ui/src/component/recurring-reservations/RecommendationsByApplicant.tsx
@@ -373,6 +373,7 @@ function RecommendationsByApplicant(): JSX.Element {
   const isApplicationRoundApproved =
     applicationRound && ["approved"].includes(applicationRound.status);
 
+  console.log("RecomendationsDyApplications");
   return (
     <Wrapper>
       {applicationRoundId ? (

--- a/admin-ui/src/component/recurring-reservations/RecommendationsByApplicant.tsx
+++ b/admin-ui/src/component/recurring-reservations/RecommendationsByApplicant.tsx
@@ -373,7 +373,6 @@ function RecommendationsByApplicant(): JSX.Element {
   const isApplicationRoundApproved =
     applicationRound && ["approved"].includes(applicationRound.status);
 
-  console.log("RecomendationsDyApplications");
   return (
     <Wrapper>
       {applicationRoundId ? (

--- a/admin-ui/src/component/recurring-reservations/RecommendationsByReservationUnit.tsx
+++ b/admin-ui/src/component/recurring-reservations/RecommendationsByReservationUnit.tsx
@@ -43,7 +43,7 @@ import {
   localizedValue,
   parseAddress,
   parseAgeGroups,
-  parseDuration,
+  formatDuration,
 } from "../../common/util";
 import {
   prepareAllocationResults,
@@ -227,7 +227,7 @@ const getCellConfig = (
               `${formatNumber(
                 aggregatedData?.reservationsTotal,
                 t("common.volumeUnit")
-              )} / ${parseDuration(aggregatedData?.durationTotal)}`,
+              )} / ${formatDuration(aggregatedData?.durationTotal)}`,
               " / "
             )}
           </>

--- a/admin-ui/src/component/recurring-reservations/RecommendedSlot.tsx
+++ b/admin-ui/src/component/recurring-reservations/RecommendedSlot.tsx
@@ -107,8 +107,6 @@ function RecommendedSlot({
 }: IProps): JSX.Element {
   const { t } = useTranslation();
 
-  console.log("RecomendationsDyApplications");
-
   return (
     <Wrapper data-test-id={`recommendation__slot--${id}`}>
       <Heading>

--- a/admin-ui/src/component/recurring-reservations/RecommendedSlot.tsx
+++ b/admin-ui/src/component/recurring-reservations/RecommendedSlot.tsx
@@ -6,7 +6,7 @@ import { weekdays } from "../../common/const";
 import {
   convertHMSToSeconds,
   formatDate,
-  parseDuration,
+  formatDuration,
 } from "../../common/util";
 import { ReactComponent as IconCalendar } from "../../images/icon_calendar.svg";
 
@@ -150,7 +150,7 @@ function RecommendedSlot({
                     duration:
                       durationStr ||
                       (duration &&
-                        parseDuration(convertHMSToSeconds(duration))),
+                        formatDuration(convertHMSToSeconds(duration))),
                   })}
                 </Duration>
               </Col>

--- a/admin-ui/src/component/recurring-reservations/RecommendedSlot.tsx
+++ b/admin-ui/src/component/recurring-reservations/RecommendedSlot.tsx
@@ -89,6 +89,11 @@ function Label({ type, children }: IDateLabelProps): JSX.Element {
   );
 }
 
+const formatTime = (input: string) => {
+  const hm = input.split(":").slice(0, -1);
+  return hm.join(":");
+};
+
 function RecommendedSlot({
   id,
   start,
@@ -102,10 +107,7 @@ function RecommendedSlot({
 }: IProps): JSX.Element {
   const { t } = useTranslation();
 
-  const formatTime = (input: string) => {
-    const hm = input.split(":").slice(0, -1);
-    return hm.join(":");
-  };
+  console.log("RecomendationsDyApplications");
 
   return (
     <Wrapper data-test-id={`recommendation__slot--${id}`}>

--- a/admin-ui/src/component/recurring-reservations/ReservationSummariesByReservationUnit.tsx
+++ b/admin-ui/src/component/recurring-reservations/ReservationSummariesByReservationUnit.tsx
@@ -32,7 +32,7 @@ import {
   formatDate,
   localizedValue,
   parseAgeGroups,
-  parseDuration,
+  formatDuration,
 } from "../../common/util";
 import { ReactComponent as IconBulletList } from "../../images/icon_list-bullet.svg";
 import RecommendedSlot from "./RecommendedSlot";
@@ -297,7 +297,7 @@ function ReservationSummariesByReservationUnit(): JSX.Element | null {
                           end={endDate}
                           weekday={weekday}
                           biweekly={recurringReservation.biweekly} // TODO
-                          durationStr={parseDuration(duration)}
+                          durationStr={formatDuration(duration)}
                           timeStart={formatDate(beginDate || "", "H:mm:ss")}
                           timeEnd={formatDate(endDate || "", "H:mm:ss")}
                         />

--- a/admin-ui/src/component/recurring-reservations/ResolutionReport.tsx
+++ b/admin-ui/src/component/recurring-reservations/ResolutionReport.tsx
@@ -19,7 +19,7 @@ import { ContentContainer, IngressContainer } from "../../styles/layout";
 import withMainMenu from "../withMainMenu";
 import { ContentHeading } from "../../styles/typography";
 import DataTable, { CellConfig, OrderTypes } from "../DataTable";
-import { formatNumber, parseDuration } from "../../common/util";
+import { formatNumber, formatDuration } from "../../common/util";
 import {
   IAllocationCapacity,
   prepareAllocationResults,
@@ -199,7 +199,7 @@ const getCellConfig = (
                     `${formatNumber(
                       aggregatedData?.reservationsTotal,
                       t("common.volumeUnit")
-                    )} / ${parseDuration(aggregatedData?.durationTotal)}`,
+                    )} / ${formatDuration(aggregatedData?.durationTotal)}`,
                     " / "
                   )
                 : t("Recommendation.noRecommendations")}

--- a/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventCard.tsx
+++ b/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventCard.tsx
@@ -10,7 +10,7 @@ import {
 } from "common/types/gql-types";
 import { publicUrl } from "../../../common/const";
 import { AllocationApplicationEventCardType } from "../../../common/types";
-import { parseDuration } from "../../../common/util";
+import { formatDuration } from "../../../common/util";
 import { ageGroup } from "../../reservations/requested/util";
 import {
   getApplicantName,
@@ -127,8 +127,8 @@ const ApplicationEventCard = ({
   const isActive = applicationEvent === selectedApplicationEvent;
   const parsedDuration =
     applicationEvent.minDuration === applicationEvent.maxDuration
-      ? parseDuration(applicationEvent.minDuration)
-      : `${parseDuration(applicationEvent.minDuration)} - ${parseDuration(
+      ? formatDuration(applicationEvent.minDuration)
+      : `${formatDuration(applicationEvent.minDuration)} - ${formatDuration(
           applicationEvent.maxDuration
         )}`;
   const otherReservationUnits = applicationEvent?.eventReservationUnits

--- a/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventScheduleCard.tsx
+++ b/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventScheduleCard.tsx
@@ -12,7 +12,7 @@ import {
   MutationUpdateApplicationEventScheduleResultArgs,
   ReservationUnitType,
 } from "common/types/gql-types";
-import { parseDuration } from "../../../common/util";
+import { formatDuration } from "../../../common/util";
 import { useAllocationContext } from "../../../context/AllocationContext";
 import { useNotification } from "../../../context/NotificationContext";
 import { SmallRoundButton } from "../../../styles/buttons";
@@ -141,7 +141,7 @@ const ApplicationEventScheduleCard = ({
   });
 
   const selectionDuration = useMemo(
-    () => selection && parseDuration(selection.length * 30 * 60),
+    () => selection && formatDuration(selection.length * 30 * 60),
     [selection]
   );
 
@@ -162,8 +162,8 @@ const ApplicationEventScheduleCard = ({
   const parsedDuration = useMemo(
     () =>
       applicationEvent.minDuration === applicationEvent.maxDuration
-        ? parseDuration(applicationEvent.minDuration)
-        : `${parseDuration(applicationEvent.minDuration)} - ${parseDuration(
+        ? formatDuration(applicationEvent.minDuration)
+        : `${formatDuration(applicationEvent.minDuration)} - ${formatDuration(
             applicationEvent.maxDuration
           )}`,
     [applicationEvent.minDuration, applicationEvent.maxDuration]

--- a/admin-ui/src/component/recurring-reservations/review/Filters.tsx
+++ b/admin-ui/src/component/recurring-reservations/review/Filters.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useReducer } from "react";
 import { useTranslation } from "react-i18next";
+import { gql, useQuery } from "@apollo/client";
+import { Query, UnitType } from "common/types/gql-types";
 import { OptionType } from "../../../common/types";
-import UnitFilter from "../../filters/UnitFilter";
 import Tags, { getReducer, toTags } from "../../lists/Tags";
 import { AutoGrid, FullRow } from "../../../styles/layout";
+import SortedSelect from "../../ReservationUnits/ReservationUnitEditor/SortedSelect";
 
 export type FilterArguments = {
   unit: OptionType[];
@@ -13,11 +15,63 @@ export const emptyFilterState = { unit: [] };
 
 const multivaledFields = ["unit"];
 
-type Props = {
-  onSearch: (args: FilterArguments) => void;
+const APPLICATION_UNITS_QUERY = gql`
+  query units($pks: [ID]) {
+    units(onlyWithPermission: true, pk: $pks) {
+      edges {
+        node {
+          nameFi
+          pk
+        }
+      }
+    }
+  }
+`;
+
+const ReviewUnitFilter = ({
+  unitPks,
+  value,
+  onChange,
+}: {
+  unitPks: number[];
+  onChange: (units: OptionType[]) => void;
+  value: OptionType[];
+}) => {
+  const { t } = useTranslation();
+  const { data, loading } = useQuery<Query>(APPLICATION_UNITS_QUERY, {
+    variables: {
+      pks: unitPks,
+    },
+  });
+
+  const opts: OptionType[] = (data?.units?.edges || [])
+    .map((e) => e?.node)
+    .filter((e): e is UnitType => e != null)
+    .map((unit) => ({
+      label: unit?.nameFi ?? "",
+      value: unit?.pk ?? "",
+    }));
+
+  return (
+    <SortedSelect
+      disabled={loading}
+      label={t("ReservationUnitsSearch.unitLabel")}
+      multiselect
+      placeholder={t("ReservationUnitsSearch.unitPlaceHolder")}
+      options={opts}
+      value={value}
+      onChange={onChange}
+      id="reservation-unit-combobox"
+    />
+  );
 };
 
-const Filters = ({ onSearch }: Props): JSX.Element => {
+type Props = {
+  onSearch: (args: FilterArguments) => void;
+  unitPks: number[];
+};
+
+const Filters = ({ onSearch, unitPks }: Props): JSX.Element => {
   const { t } = useTranslation();
   const [state, dispatch] = useReducer(
     getReducer<FilterArguments>(emptyFilterState),
@@ -34,7 +88,8 @@ const Filters = ({ onSearch }: Props): JSX.Element => {
   return (
     <AutoGrid>
       <div>
-        <UnitFilter
+        <ReviewUnitFilter
+          unitPks={unitPks}
           onChange={(e) => dispatch({ type: "set", value: { unit: e } })}
           value={state.unit}
         />

--- a/admin-ui/src/component/recurring-reservations/review/Filters.tsx
+++ b/admin-ui/src/component/recurring-reservations/review/Filters.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useReducer } from "react";
 import { useTranslation } from "react-i18next";
 import { OptionType } from "../../../common/types";
-import { Grid, Span3 } from "../../../styles/layout";
 import UnitFilter from "../../filters/UnitFilter";
 import Tags, { getReducer, toTags } from "../../lists/Tags";
+import { AutoGrid, FullRow } from "../../../styles/layout";
 
 export type FilterArguments = {
   unit: OptionType[];
@@ -32,17 +32,17 @@ const Filters = ({ onSearch }: Props): JSX.Element => {
   const tags = toTags(state, t, multivaledFields, []);
 
   return (
-    <>
-      <Grid>
-        <Span3>
-          <UnitFilter
-            onChange={(e) => dispatch({ type: "set", value: { unit: e } })}
-            value={state.unit}
-          />
-        </Span3>
-      </Grid>
-      <Tags tags={tags} t={t} dispatch={dispatch} />
-    </>
+    <AutoGrid>
+      <div>
+        <UnitFilter
+          onChange={(e) => dispatch({ type: "set", value: { unit: e } })}
+          value={state.unit}
+        />
+      </div>
+      <FullRow>
+        <Tags tags={tags} t={t} dispatch={dispatch} />
+      </FullRow>
+    </AutoGrid>
   );
 };
 

--- a/admin-ui/src/component/recurring-reservations/review/Filters.tsx
+++ b/admin-ui/src/component/recurring-reservations/review/Filters.tsx
@@ -17,7 +17,7 @@ const multivaledFields = ["unit"];
 
 const APPLICATION_UNITS_QUERY = gql`
   query units($pks: [ID]) {
-    units(onlyWithPermission: true, pk: $pks) {
+    units(onlyWithPermission: true, pk: $pks, orderBy: "nameFI") {
       edges {
         node {
           nameFi

--- a/admin-ui/src/component/recurring-reservations/review/Review.tsx
+++ b/admin-ui/src/component/recurring-reservations/review/Review.tsx
@@ -3,8 +3,9 @@ import { debounce } from "lodash";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { gql, useQuery } from "@apollo/client";
 import { H2 } from "common/src/common/typography";
-import { ApplicationRoundType } from "common/types/gql-types";
+import { ApplicationRoundType, Query } from "common/types/gql-types";
 import { ApplicationRound as RestApplicationRoundType } from "../../../common/types";
 import { applicationRoundUrl } from "../../../common/urls";
 import { Container, VerticalFlex } from "../../../styles/layout";
@@ -48,6 +49,25 @@ const TabContent = styled.div`
   line-height: 1;
 `;
 
+// TODO this and the Filter query can be simplified into a single query here
+// (pass the nameFi + pk to Filter)
+// we need to use this query here because we know the reservationUnit not the unit
+// but the filter is for unit selector
+const APPLICATION_RESERVATION_UNITS_QUERY = gql`
+  query reservationUnits($pks: [ID]) {
+    reservationUnits(onlyWithPermission: true, pk: $pks) {
+      edges {
+        node {
+          unit {
+            nameFi
+            pk
+          }
+        }
+      }
+    }
+  }
+`;
+
 function Review({ applicationRound }: IProps): JSX.Element | null {
   const [search, setSearch] = useState<FilterArguments>(emptyFilterState);
   const [sort, setSort] = useState<Sort>();
@@ -61,6 +81,17 @@ function Review({ applicationRound }: IProps): JSX.Element | null {
   };
 
   const { t } = useTranslation();
+
+  const { data } = useQuery<Query>(APPLICATION_RESERVATION_UNITS_QUERY, {
+    variables: {
+      pks: applicationRound.reservationUnitIds,
+    },
+  });
+
+  const unitPks =
+    data?.reservationUnits?.edges
+      ?.map((x) => x?.node?.unit?.pk)
+      ?.filter((x): x is number => x != null) ?? [];
 
   return (
     <>
@@ -129,7 +160,7 @@ function Review({ applicationRound }: IProps): JSX.Element | null {
           <Tabs.TabPanel>
             <TabContent>
               <VerticalFlex>
-                <Filters onSearch={debouncedSearch} />
+                <Filters onSearch={debouncedSearch} unitPks={unitPks} />
                 <ApplicationDataLoader
                   applicationRound={applicationRound}
                   key={JSON.stringify({ ...search, ...sort })}
@@ -143,7 +174,7 @@ function Review({ applicationRound }: IProps): JSX.Element | null {
           <Tabs.TabPanel>
             <TabContent>
               <VerticalFlex>
-                <Filters onSearch={debouncedSearch} />
+                <Filters onSearch={debouncedSearch} unitPks={unitPks} />
                 <ApplicationEventDataLoader
                   applicationRound={applicationRound}
                   key={JSON.stringify({ ...search, ...sort })}

--- a/admin-ui/src/component/recurring-reservations/review/Review.tsx
+++ b/admin-ui/src/component/recurring-reservations/review/Review.tsx
@@ -49,17 +49,12 @@ const TabContent = styled.div`
   line-height: 1;
 `;
 
-// TODO this and the Filter query can be simplified into a single query here
-// (pass the nameFi + pk to Filter)
-// we need to use this query here because we know the reservationUnit not the unit
-// but the filter is for unit selector
 const APPLICATION_RESERVATION_UNITS_QUERY = gql`
   query reservationUnits($pks: [ID]) {
     reservationUnits(onlyWithPermission: true, pk: $pks) {
       edges {
         node {
           unit {
-            nameFi
             pk
           }
         }

--- a/admin-ui/src/component/reservations/Filters.tsx
+++ b/admin-ui/src/component/reservations/Filters.tsx
@@ -17,6 +17,7 @@ import UnitFilter from "../filters/UnitFilter";
 import ReservationUnitFilter from "../filters/ReservationUnitFilter";
 import ReservationStateFilter from "../filters/ReservationStateFilter";
 import PaymentStatusFilter from "./PaymentStatusFilter";
+import { AutoGrid } from "../../styles/layout";
 
 export type FilterArguments = {
   reservationUnitType: OptionType[];
@@ -59,12 +60,6 @@ const ThinButton = styled(Button)`
     padding: 0;
     line-height: 1;
   }
-`;
-
-const Grid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
-  gap: var(--spacing-m);
 `;
 
 export const emptyState: FilterArguments = {
@@ -136,7 +131,7 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
   return (
     <div>
       <Wrapper>
-        <Grid>
+        <AutoGrid>
           <div>
             <ReservationUnitTypeFilter
               onChange={(reservationUnitType) =>
@@ -182,9 +177,9 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
               value={state.reservationUnit}
             />
           </div>
-        </Grid>
+        </AutoGrid>
         {more && (
-          <Grid>
+          <AutoGrid>
             <div>
               <DateInput
                 language="fi"
@@ -251,7 +246,7 @@ const Filters = ({ onSearch, initialFiltering }: Props): JSX.Element => {
                 }}
               />
             </div>
-          </Grid>
+          </AutoGrid>
         )}
       </Wrapper>
 

--- a/admin-ui/src/component/withMainMenu.tsx
+++ b/admin-ui/src/component/withMainMenu.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "styled-components";
-import { breakpoints } from "common/src/common/style";
 import MainMenu from "./MainMenu";
 
 const Wrapper = styled.div`
@@ -9,10 +8,6 @@ const Wrapper = styled.div`
 
 const InnerWrapper = styled.div`
   width: 100%;
-
-  @media (min-width: ${breakpoints.m}) {
-    width: calc(100% - var(--main-menu-width) - 2.625rem);
-  }
 `;
 export const MainMenuWrapper: React.FC<{ children: React.ReactNode }> = ({
   children,

--- a/admin-ui/src/i18n/messages.ts
+++ b/admin-ui/src/i18n/messages.ts
@@ -116,22 +116,22 @@ const translations: ITranslations = {
     apply: ["Käytä"],
     areaUnitSquareMeter: [" m²"],
     volumeUnit: [" kpl", " ", " "],
-    personUnit: ["{{count}} henkilö"],
-    personUnit_plural: ["{{count}} henkeä"],
+    personUnit_one: ["{{count}} henkilö"],
+    personUnit_other: ["{{count}} henkeä"],
     hoursUnit: ["{{count}} h", "{{count}} h", "{{count}} h"],
-    hoursUnitLong: ["{{count}} tunti", "{{count}} hour", "{{count}} timme"],
-    hoursUnitLong_plural: [
+    hoursUnitLong_one: ["{{count}} tunti", "{{count}} hour", "{{count}} timme"],
+    hoursUnitLong_other: [
       "{{count}} tuntia",
       "{{count}} hours",
       "{{count}} timmar",
     ],
     minutesUnit: ["{{count}} min", "{{count}} min", "{{count}} min"],
-    minutesUnitLong: [
+    minutesUnitLong_one: [
       "{{count}} minuutti",
       "{{count}} minute",
       "{{count}} minut",
     ],
-    minutesUnitLong_plural: [
+    minutesUnitLong_other: [
       "{{count}} minuuttia",
       "{{count}} minutes",
       "{{count}} minuter",
@@ -418,9 +418,9 @@ const translations: ITranslations = {
     },
   },
   Application: {
-    id: ["Hakemnustunnus"],
-    application: ["Hakemus", "Application"],
-    application_plural: ["Hakemusta", "Applications"],
+    id: ["Hakemustunnus"],
+    application_one: ["Hakemus", "Application"],
+    application_other: ["Hakemusta", "Applications"],
     applicantType: ["Asiakastyyppi"],
     showAllApplications: ["Näytä kaikki hakemukset"],
     showResolutions: ["Näytä päätöslauselma"],
@@ -508,8 +508,8 @@ const translations: ITranslations = {
     },
     contactPerson: ["Yhteyshenkilö"],
     identificationNumber: ["Y-tunnus"],
-    applicationsSelected: ["{{count}} hakemus valittu"],
-    applicationsSelected_plural: ["{{count}} hakemusta valittu"],
+    applicationsSelected_one: ["{{count}} hakemus valittu"],
+    applicationsSelected_other: ["{{count}} hakemusta valittu"],
     allApplications: ["Kaikki hakemukset"],
     resolution: ["Päätös"],
     graduatedToAllocation: ["Edennyt jakoon esitarkastuksessa"],
@@ -667,19 +667,19 @@ const translations: ITranslations = {
     listHandlingIngressEmpty: [
       "Vastuullasi ei ole tällä hetkellä ole lainkaan tulevia tai käsittelyvaiheessa olevia hakukierroksia.",
     ],
-    listHandlingIngress: [
+    listHandlingIngress_one: [
       "Vastuullasi on tällä hetkellä {{count}} tuleva tai käsittelyvaiheessa oleva hakukierros.",
     ],
-    listHandlingIngress_plural: [
+    listHandlingIngress_other: [
       "Vastuullasi on tällä hetkellä {{count}} tulevaa tai käsittelyvaiheessa olevaa hakukierrosta.",
     ],
     listHandlingPlaceholder: [
       "Ei vielä tulevia tai käsittelyvaiheessa olevia hakukierroksia.",
     ],
-    listApprovalIngress: [
+    listApprovalIngress_one: [
       "Hyväksyntääsi odottaa tällä hetkellä {{count}} päätöslauselma.",
     ],
-    listApprovalIngress_plural: [
+    listApprovalIngress_other: [
       "Hyväksyntääsi odottaa tällä hetkellä {{count}} päätöslauselmaa",
     ],
     allRecurringApplicationRounds: ["Vakiovuorojen kaikki hakukierrokset"],
@@ -796,8 +796,8 @@ const translations: ITranslations = {
     labelAppliedReservations: ["Vuoroja"],
     labelReservationUnitRank: ["Tarjottu tila toivesijalla {{rank}}"],
     actionMassActionSubmit: ["Massakäsittele valitut"],
-    recommendationCount: ["{{count}} ehdotus tehty"],
-    recommendationCount_plural: ["{{count}} ehdotusta tehty"],
+    recommendationCount_one: ["{{count}} ehdotus tehty"],
+    recommendationCount_other: ["{{count}} ehdotusta tehty"],
     showOriginalApplication: ["Näytä alkuperäinen hakemus"],
     headings: {
       applicationEventName: ["Ryhmä"],
@@ -866,8 +866,8 @@ const translations: ITranslations = {
   },
   ReservationUnit: {
     reservationStatus: ["Varaustilanne"],
-    purposeCount: ["{{count}} käyttötarkoitus"],
-    purposeCount_plural: ["{{count}} käyttötarkoitusta"],
+    purposeCount_one: ["{{count}} käyttötarkoitus"],
+    purposeCount_other: ["{{count}} käyttötarkoitusta"],
     downloadSpaceCalendar: ["Lataa tilan kalenterimerkinnät (.ics)"],
     isDraft: {
       true: ["Luonnos"],
@@ -986,13 +986,13 @@ const translations: ITranslations = {
       maxPersons: ["Henkilömäärä"],
       area: ["Alue"],
     },
-    reservationUnits: ["{{count}} varausyksikkö"],
-    reservationUnits_plural: ["{{count}} varausyksikköä"],
+    reservationUnits_one: ["{{count}} varausyksikkö"],
+    reservationUnits_other: ["{{count}} varausyksikköä"],
     noReservationUnits: ["Ei varausyksiköitä"],
     noArea: ["Alue puuttuu"],
     noService: ["Palvelu puuttuu"],
-    unitCount: ["{{count}} toimipiste"],
-    unitCount_plural: ["{{count}} toimipistettä"],
+    unitCount_one: ["{{count}} toimipiste"],
+    unitCount_other: ["{{count}} toimipistettä"],
     noUnits: ["Ei toimipisteitä"],
     showOnMap: ["Näytä kartalla"],
     showOpeningHours: ["Aukioloajat"],
@@ -1124,8 +1124,8 @@ const translations: ITranslations = {
     },
   },
   SpaceTable: {
-    subSpaceCount: ["alitila"],
-    subSpaceCount_plural: ["alitilaa"],
+    subSpaceCount_one: ["alitila"],
+    subSpaceCount_other: ["alitilaa"],
     menuAddSubSpace: ["Lisää alitiloja"],
     menuEditSpace: ["Muokkaa tilatietoja"],
     menuRemoveSpace: ["Poista tila"],
@@ -1296,8 +1296,8 @@ const translations: ITranslations = {
     },
   },
   ReservationUnitsSearch: {
-    resultCount: ["{{count}} hakutulos"],
-    resultCount_plural: ["{{count}} hakutulosta"],
+    resultCount_one: ["{{count}} hakutulos"],
+    resultCount_other: ["{{count}} hakutulosta"],
     textSearchLabel: ["Varausyksikön nimi"],
     textSearchPlaceHolder: ["Hae"],
     typeLabel: ["Tilan tyyppi"],
@@ -1340,8 +1340,8 @@ const translations: ITranslations = {
     noMaxPersons: ["Maksimihenkilömäärä puuttuu"],
     noReservationUnitType: ["Varausyksikön tyyppi puuttuu"],
     noPurpose: ["Käyttötarkoitus puuttuu"],
-    purpose: ["{{count}} käyttötarkoitus"],
-    purpose_plural: ["{{count}} käyttötarkoitusta"],
+    purpose_one: ["{{count}} käyttötarkoitus"],
+    purpose_other: ["{{count}} käyttötarkoitusta"],
     statePublished: ["Julkaistu"],
     stateDraft: ["Luonnos"],
   },

--- a/admin-ui/src/styles/layout.tsx
+++ b/admin-ui/src/styles/layout.tsx
@@ -142,9 +142,9 @@ export const VerticalFlexNoGap = styled.div`
 
 VerticalFlexNoGap.displayName = "VerticalFlexNoGap";
 
+// grid because flex causes overflow problems in children
 export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--spacing-layout-2-xs);
 
   max-width: var(--container-width-xl);

--- a/admin-ui/src/styles/layout.tsx
+++ b/admin-ui/src/styles/layout.tsx
@@ -164,6 +164,24 @@ export const Content = styled.div`
 
 Content.displayName = "Content";
 
+export const AutoGrid = styled.div<{ $minWidth?: string }>`
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(
+      ${({ $minWidth }) =>
+        $minWidth && $minWidth?.length > 0 ? $minWidth : "16rem"},
+      1fr
+    )
+  );
+  align-items: baseline;
+  gap: var(--spacing-m);
+`;
+
+export const FullRow = styled.div`
+  grid-column: 1 / -1;
+`;
+
 export const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(12, 1fr);


### PR DESCRIPTION
- Filters: Only show units that are in the round
- Rename: parseDuration  -> formatDuration (object => string)
- Add: Autogrid CSS for Filters (responsive, min 16 rem per filter)
- Sticky header: full screen width (- side nav)
- Responsive fixes to containers with tables (tables overflew at 1360px, top container constrained to 1200px)
- fix i18n plurals
- fix typos and formatting