### PR TITLE
TILA-2552: fixes to listing pages

### DIFF
--- a/admin-ui/src/common/const.ts
+++ b/admin-ui/src/common/const.ts
@@ -23,7 +23,7 @@ export const publicUrl = process.env.PUBLIC_URL;
 export const previewUrlPrefix =
   process.env.REACT_APP_RESERVATION_UNIT_PREVIEW_URL_PREFIX;
 
-export const LIST_PAGE_SIZE = 20;
+export const LIST_PAGE_SIZE = 50;
 
 export const ALLOCATION_CALENDAR_TIMES = [7, 23];
 

--- a/admin-ui/src/common/const.ts
+++ b/admin-ui/src/common/const.ts
@@ -24,6 +24,7 @@ export const previewUrlPrefix =
   process.env.REACT_APP_RESERVATION_UNIT_PREVIEW_URL_PREFIX;
 
 export const LIST_PAGE_SIZE = 50;
+export const LARGE_LIST_PAGE_SIZE = 100;
 
 export const ALLOCATION_CALENDAR_TIMES = [7, 23];
 

--- a/admin-ui/src/component/Unit/Units.tsx
+++ b/admin-ui/src/component/Unit/Units.tsx
@@ -3,7 +3,7 @@ import { Link } from "hds-react";
 import { H1 } from "common/src/common/typography";
 import { useTranslation } from "react-i18next";
 import { debounce } from "lodash";
-import { Container, VerticalFlex } from "../../styles/layout";
+import { Container } from "../../styles/layout";
 import withMainMenu from "../withMainMenu";
 import BreadcrumbWrapper from "../BreadcrumbWrapper";
 import Filters, { emptyFilterState, FilterArguments } from "./Filters";
@@ -43,16 +43,14 @@ const Units = (): JSX.Element => {
             </Link>
           </p>
         </div>
-        <VerticalFlex>
-          <Filters onSearch={debouncedSearch} />
-          <HR />
-          <UnitsDataLoader
-            key={JSON.stringify({ ...search, ...sort })}
-            filters={search}
-            sort={sort}
-            sortChanged={onSortChanged}
-          />
-        </VerticalFlex>
+        <Filters onSearch={debouncedSearch} />
+        <HR />
+        <UnitsDataLoader
+          key={JSON.stringify({ ...search, ...sort })}
+          filters={search}
+          sort={sort}
+          sortChanged={onSortChanged}
+        />
       </Container>
     </>
   );

--- a/admin-ui/src/component/Unit/UnitsDataLoader.tsx
+++ b/admin-ui/src/component/Unit/UnitsDataLoader.tsx
@@ -5,7 +5,7 @@ import { FilterArguments } from "./Filters";
 import { useNotification } from "../../context/NotificationContext";
 import Loader from "../Loader";
 import UnitsTable from "./UnitsTable";
-import { LIST_PAGE_SIZE } from "../../common/const";
+import { LARGE_LIST_PAGE_SIZE } from "../../common/const";
 import { More } from "../lists/More";
 import { combineResults } from "../../common/util";
 import { UNITS_QUERY } from "./queries";
@@ -57,7 +57,7 @@ const UnitsDataLoader = ({
       variables: {
         orderBy: sortString,
         offset: 0,
-        first: LIST_PAGE_SIZE,
+        first: LARGE_LIST_PAGE_SIZE,
         ...mapFilterParams(filters),
       },
       onError: (err: ApolloError) => {

--- a/admin-ui/src/component/lists/components.tsx
+++ b/admin-ui/src/component/lists/components.tsx
@@ -18,6 +18,7 @@ export const HR = styled.hr`
 
 const StyledTable = styled(Table)<TableWrapperProps>`
   &&& {
+    width: 100%;
     white-space: nowrap;
     border-collapse: collapse;
     th {

--- a/admin-ui/src/component/reservation-units/ReservationUnitsDataLoader.tsx
+++ b/admin-ui/src/component/reservation-units/ReservationUnitsDataLoader.tsx
@@ -11,7 +11,7 @@ import { useNotification } from "../../context/NotificationContext";
 import Loader from "../Loader";
 import ReservationUnitsTable from "./ReservationUnitsTable";
 import { More } from "../lists/More";
-import { LIST_PAGE_SIZE } from "../../common/const";
+import { LARGE_LIST_PAGE_SIZE } from "../../common/const";
 import { combineResults } from "../../common/util";
 
 export type Sort = {
@@ -70,7 +70,7 @@ const ReservationUnitsDataReader = ({
   >(SEARCH_RESERVATION_UNITS_QUERY, {
     variables: {
       orderBy: sortString,
-      first: LIST_PAGE_SIZE,
+      first: LARGE_LIST_PAGE_SIZE,
       ...mapFilterParams(filters),
     },
     onError: (err: ApolloError) => {


### PR DESCRIPTION
- Get 50 / 100 elements depending on the page
- Responsive fix for units page
- Always use full container width tables