### PR TITLE
add: accessibility details link

### DIFF
--- a/ui/components/reservation-unit/Address.tsx
+++ b/ui/components/reservation-unit/Address.tsx
@@ -78,6 +78,14 @@ const mapUrl = (locale: string, unit: UnitType): string | null => {
   return `https://palvelukartta.hel.fi/${locale}/unit/${unit.tprekId}`;
 };
 
+const accessibilityUrl = (locale: string, unit: UnitType): string | null => {
+  if (!unit?.tprekId) {
+    return null;
+  }
+
+  return `https://palvelukartta.hel.fi/${locale}/unit/${unit.tprekId}?p=1&t=accessibilityDetails`;
+};
+
 const Address = ({ reservationUnit }: Props): JSX.Element => {
   const { t, i18n } = useTranslation();
 
@@ -110,6 +118,10 @@ const Address = ({ reservationUnit }: Props): JSX.Element => {
         <ExternalLink
           href={hslUrl(i18n.language, location)}
           name={t("reservationUnit:linkHSL")}
+        />
+        <ExternalLink
+          href={accessibilityUrl(i18n.language, reservationUnit.unit)}
+          name={t("reservationUnit:linkAccessibility")}
         />
       </Links>
     </Container>

--- a/ui/public/locales/en/reservationUnit.json
+++ b/ui/public/locales/en/reservationUnit.json
@@ -8,6 +8,7 @@
   "linkMap": "Open map in a new window",
   "linkHSL": "HSL Route Guide",
   "linkGoogle": "Google Directions",
+  "linkAccessibility": "Accessibility details",
   "images": "Images",
   "description": "Description",
   "equipment": "Equipment",

--- a/ui/public/locales/fi/reservationUnit.json
+++ b/ui/public/locales/fi/reservationUnit.json
@@ -8,6 +8,7 @@
   "linkMap": "Avaa kartta uuteen ikkunaan",
   "linkHSL": "HSL Reittiopas",
   "linkGoogle": "Google reittiohjeet",
+  "linkAccessibility": "Tutustu esteettömyyteen",
   "images": "Kuvat",
   "description": "Tietoa tilasta",
   "equipment": "Varustelu",

--- a/ui/public/locales/sv/reservationUnit.json
+++ b/ui/public/locales/sv/reservationUnit.json
@@ -8,6 +8,7 @@
   "linkMap": "Öppna kartan i ett nytt fönster",
   "linkHSL": "HRT Reseplaneraren",
   "linkGoogle": "Google vägbeskrivningar",
+  "linkAccessibility": "Tillgänglighet",
   "images": "Bilder",
   "description": "Beskrivning",
   "equipment": "Utrustning",


### PR DESCRIPTION
- adds the accessibility detail link to the reservation unit’s page along with relevant translations for the link text