### PR TITLE
TILA-2535: next auth fix broken backend endpoint

### DIFF
--- a/admin-ui/src/common/apolloClient.ts
+++ b/admin-ui/src/common/apolloClient.ts
@@ -8,7 +8,6 @@ import { GraphQLError } from "graphql/error/GraphQLError";
 import { ReservationTypeConnection } from "common/types/gql-types";
 
 import {
-  PROFILE_TOKEN_HEADER,
   SESSION_EXPIRED_ERROR,
   apiBaseUrl,
   isBrowser,
@@ -26,7 +25,7 @@ const uploadLinkOptions = {
 const uploadLink = createUploadLink(uploadLinkOptions);
 const httpLink = new HttpLink({ uri: `${apiBaseUrl}/graphql/` });
 
-const authLink = setContext(async (request, previousContext) => {
+const authLink = setContext(async (_request, previousContext) => {
   const headers = previousContext.headers ?? {};
   const session = await getSession();
 
@@ -36,7 +35,6 @@ const authLink = setContext(async (request, previousContext) => {
       authorization: session?.apiTokens?.tilavaraus
         ? `Bearer ${session.apiTokens.tilavaraus}`
         : "",
-      [PROFILE_TOKEN_HEADER]: session?.apiTokens?.profile ?? "",
     },
   };
 });

--- a/admin-ui/src/common/apolloClient.ts
+++ b/admin-ui/src/common/apolloClient.ts
@@ -7,15 +7,12 @@ import { getSession, signOut } from "next-auth/react";
 import { GraphQLError } from "graphql/error/GraphQLError";
 import { ReservationTypeConnection } from "common/types/gql-types";
 
-import {
-  SESSION_EXPIRED_ERROR,
-  apiBaseUrl,
-  isBrowser,
-} from "./const";
+import { SESSION_EXPIRED_ERROR, publicUrl, isBrowser } from "./const";
 import { CustomFormData } from "./CustomFormData";
 
+const uri = `${publicUrl}/api/graphql`;
 const uploadLinkOptions = {
-  uri: `${apiBaseUrl}/graphql/`,
+  uri,
   FormData: CustomFormData,
 };
 
@@ -23,7 +20,7 @@ const uploadLinkOptions = {
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error FIXME
 const uploadLink = createUploadLink(uploadLinkOptions);
-const httpLink = new HttpLink({ uri: `${apiBaseUrl}/graphql/` });
+const httpLink = new HttpLink({ uri });
 
 const authLink = setContext(async (_request, previousContext) => {
   const headers = previousContext.headers ?? {};

--- a/admin-ui/src/common/const.ts
+++ b/admin-ui/src/common/const.ts
@@ -26,7 +26,6 @@ export const nextAuthRoute = `${publicUrl}/api/auth`;
 export const previewUrlPrefix =
   env.NEXT_PUBLIC_RESERVATION_UNIT_PREVIEW_URL_PREFIX;
 
-export const PROFILE_TOKEN_HEADER = "X-Authorization";
 export const SESSION_EXPIRED_ERROR = "JWT too old";
 
 export const LIST_PAGE_SIZE = 50;

--- a/admin-ui/src/modules/auth/axiosClient.ts
+++ b/admin-ui/src/modules/auth/axiosClient.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 import applyCaseMiddleware from "axios-case-converter";
 import { getSession } from "next-auth/react";
-import { PROFILE_TOKEN_HEADER } from "app/common/const";
 
 const axiosOptions = {
   timeout: 20000,
@@ -21,10 +20,6 @@ if (typeof window !== "undefined" && authEnabled) {
 
     if (session?.apiTokens?.tilavaraus) {
       req.headers.Authorization = `Bearer ${session.apiTokens.tilavaraus}`;
-    }
-
-    if (session?.apiTokens?.profile) {
-      req.headers[PROFILE_TOKEN_HEADER] = `${session?.apiTokens.profile}`;
     }
 
     return req;

--- a/admin-ui/src/pages/_app.tsx
+++ b/admin-ui/src/pages/_app.tsx
@@ -13,7 +13,13 @@ import ExternalScripts from "../common/ExternalScripts";
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
-      <SessionProvider session={pageProps.session} basePath={nextAuthRoute}>
+      <SessionProvider
+        session={pageProps.session}
+        basePath={nextAuthRoute}
+        refetchInterval={5 * 60}
+        // NOTE: too slow because causes a full refetch of the SPA
+        refetchOnWindowFocus={false}
+      >
         <ApolloProvider client={apolloClient}>
           <Component {...pageProps} />
         </ApolloProvider>

--- a/admin-ui/src/pages/api/auth/[...nextauth].ts
+++ b/admin-ui/src/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable camelcase */
 import { NextApiRequest, NextApiResponse } from "next";
 import NextAuth, { NextAuthOptions, Awaitable, User } from "next-auth";
@@ -18,9 +17,9 @@ type TunnistamoProfile = {
   auth_time: number;
   at_hash: string;
   name: string;
-  given_name: string;
-  family_name: string;
-  nickname: string;
+  given_name?: string;
+  family_name?: string;
+  nickname?: string;
   email: string;
   email_verified: boolean;
   azp: string;
@@ -61,9 +60,11 @@ const options = (): NextAuthOptions => {
         // TODO don't copy unneccessary fields just bloats the cookie
         // TODO replace casting with schema validation
         profile(profile: TunnistamoProfile): Awaitable<User> {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { sub, email_verified, nickname, ...rest } = profile;
           return {
-            id: profile.sub,
-            ...profile,
+            id: sub,
+            ...rest,
           };
         },
       },

--- a/admin-ui/src/pages/api/graphql.ts
+++ b/admin-ui/src/pages/api/graphql.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { apiBaseUrl } from "app/common/const";
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  // Remove large cookies on backend request
+  res.setHeader("Set-Cookie", [
+    "__Secure-next-auth.session-token.0; Max-Age=0; path=/",
+    "__Secure-next-auth.session-token.1; Max-Age=0; path=/",
+    "cookiehub; Max-Age=0; path=/",
+  ]);
+
+  return res.redirect(`${apiBaseUrl}/graphql/`);
+};

--- a/admin-ui/types/next-auth.d.ts
+++ b/admin-ui/types/next-auth.d.ts
@@ -35,12 +35,10 @@ declare module "next-auth" {
 
   interface User {
     id: string;
-    name: string;
-    given_name: string;
-    family_name: string;
-    nickname: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
     email: string;
-    email_verified: boolean;
   }
   interface Session {
     accessToken: string;

--- a/ui/modules/apolloClient.ts
+++ b/ui/modules/apolloClient.ts
@@ -8,7 +8,6 @@ import { GraphQLError } from "graphql";
 import {
   apiBaseUrl,
   isBrowser,
-  PROFILE_TOKEN_HEADER,
   SESSION_EXPIRED_ERROR,
 } from "./const";
 
@@ -22,7 +21,6 @@ const authLink = setContext(
         authorization: session?.apiTokens?.tilavaraus
           ? `Bearer ${session.apiTokens.tilavaraus}`
           : "",
-        [PROFILE_TOKEN_HEADER]: session?.apiTokens?.profile ?? "",
       },
     };
     return modifiedHeader;

--- a/ui/modules/auth/axiosClient.ts
+++ b/ui/modules/auth/axiosClient.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import applyCaseMiddleware from "axios-case-converter";
 
 import { getSession } from "next-auth/react";
-import { authEnabled, isBrowser, PROFILE_TOKEN_HEADER } from "../const";
+import { authEnabled, isBrowser } from "../const";
 
 const axiosOptions = {
   timeout: 20000,
@@ -20,10 +20,6 @@ if (isBrowser && authEnabled) {
 
     if (session?.apiTokens?.tilavaraus) {
       req.headers.Authorization = `Bearer ${session.apiTokens.tilavaraus}`;
-    }
-
-    if (session?.apiTokens?.profile) {
-      req.headers[PROFILE_TOKEN_HEADER] = `${session?.apiTokens.profile}`;
     }
 
     return req;

--- a/ui/modules/const.ts
+++ b/ui/modules/const.ts
@@ -106,8 +106,6 @@ export const defaultDuration = "01:30:00";
 
 export const isBrowser = typeof window !== "undefined";
 
-export const PROFILE_TOKEN_HEADER = "X-Authorization";
-
 export const SESSION_EXPIRED_ERROR = "JWT too old";
 
 const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();

--- a/ui/pages/api/auth/[...nextauth].ts
+++ b/ui/pages/api/auth/[...nextauth].ts
@@ -17,9 +17,9 @@ type TunnistamoProfile = {
   auth_time: number;
   at_hash: string;
   name: string;
-  given_name: string;
-  family_name: string;
-  nickname: string;
+  given_name?: string;
+  family_name?: string;
+  nickname?: string;
   email: string;
   email_verified: boolean;
   azp: string;
@@ -71,9 +71,11 @@ const options = (): NextAuthOptions => {
           },
         },
         profile(profile: TunnistamoProfile): Awaitable<User> {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/naming-convention
+          const { sub, email_verified, nickname, ...rest } = profile;
           return {
-            id: profile.sub,
-            ...profile,
+            id: sub,
+            ...rest,
           };
         },
       },

--- a/ui/types/next-auth.d.ts
+++ b/ui/types/next-auth.d.ts
@@ -35,12 +35,10 @@ declare module "next-auth" {
 
   interface User {
     id: string;
-    name: string;
-    given_name: string;
-    family_name: string;
-    nickname: string;
+    name?: string;
+    given_name?: string;
+    family_name?: string;
     email: string;
-    email_verified: boolean;
   }
   interface Session {
     accessToken: string;


### PR DESCRIPTION
Remove X-Authorization header, because too large headers break graphql endpoint.
Use next backend to redirect the graphql endpoint and remove cookies.
Don't refetch session on tab focus.