### PR TITLE
TILA-2595: fix don't check buffers for BLOCKED

### DIFF
--- a/admin-ui/__mocks__/fileMock.js
+++ b/admin-ui/__mocks__/fileMock.js
@@ -1,2 +1,1 @@
-module.exports = 'test-file-stub';
-
+module.exports = "test-file-stub";

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { ReservationUnitType } from "common/types/gql-types";
+import {
+  ReservationsReservationTypeChoices,
+  type ReservationUnitType,
+} from "common/types/gql-types";
 import { camelCase, get } from "lodash";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -182,11 +185,13 @@ const MyUnitRecurringReservationForm = ({ reservationUnits }: Props) => {
     interval: reservationUnit?.reservationStartInterval,
   });
 
+  const reservationType = watch("type");
   const checkedReservations = useFilteredReservationList({
     items: newReservations.reservations,
     reservationUnitPk: reservationUnit?.pk ?? undefined,
     begin: fromUIDate(getValues("startingDate")),
     end: fromUIDate(getValues("endingDate")),
+    reservationType: reservationType as ReservationsReservationTypeChoices,
   });
 
   const navigate = useNavigate();

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/queries.ts
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/queries.ts
@@ -33,6 +33,7 @@ export const GET_RESERVATIONS_IN_INTERVAL = gql`
         end
         bufferTimeBefore
         bufferTimeAfter
+        type
       }
     }
   }

--- a/admin-ui/src/helpers/index.ts
+++ b/admin-ui/src/helpers/index.ts
@@ -1,0 +1,62 @@
+/// Plain js / ts helper functions
+import {
+  ReservationsReservationTypeChoices,
+  ReservationType,
+} from "common/types/gql-types";
+
+import { addSeconds } from "date-fns";
+
+export type CollisionInterval = {
+  start: Date;
+  end: Date;
+  buffers: { before: number; after: number };
+  type?: ReservationsReservationTypeChoices;
+};
+
+/// @brief Check if two intervals collide
+export const doesIntervalCollide = (
+  a: CollisionInterval,
+  b: CollisionInterval
+): boolean => {
+  const aEndBuffer = Math.max(a.buffers.after, b.buffers.before);
+  const bEndBuffer = Math.max(a.buffers.before, b.buffers.after);
+  if (a.start < b.start && addSeconds(a.end, aEndBuffer) <= b.start)
+    return false;
+  if (a.start >= addSeconds(b.end, bEndBuffer) && a.end > b.end) return false;
+  return true;
+};
+
+/// @brief Create a collision interval from a reservation
+/// @param x Reservation
+/// @param comparisonReservationType the type of the reservation that is being compared to
+/// @return Interval
+/// @desc Special handling for Blocked reservations since they don't collide with buffers.
+export const reservationToInterval = (
+  x: ReservationType,
+  comparisonReservationType: ReservationsReservationTypeChoices
+): CollisionInterval | undefined => {
+  if (!x || !x.begin || !x.end) {
+    return undefined;
+  }
+  return {
+    start: new Date(x.begin),
+    end: new Date(x.end),
+    buffers: {
+      before:
+        comparisonReservationType !==
+          ReservationsReservationTypeChoices.Blocked &&
+        x.type !== ReservationsReservationTypeChoices.Blocked &&
+        x.bufferTimeBefore
+          ? x.bufferTimeBefore
+          : 0,
+      after:
+        comparisonReservationType !==
+          ReservationsReservationTypeChoices.Blocked &&
+        x.type !== ReservationsReservationTypeChoices.Blocked &&
+        x.bufferTimeAfter
+          ? x.bufferTimeAfter
+          : 0,
+    },
+    type: x.type ?? undefined,
+  };
+};


### PR DESCRIPTION
Reuse the single staff reservation logic for recurring reservations, so if either the existing or the new reservation is BLOCKED we don't need to include the buffers in collisions.