### PR TITLE
TILA-2535: fix (admin): 502 error because of request size

### DIFF
--- a/admin-ui/src/common/apolloClient.ts
+++ b/admin-ui/src/common/apolloClient.ts
@@ -7,10 +7,10 @@ import { getSession, signOut } from "next-auth/react";
 import { GraphQLError } from "graphql/error/GraphQLError";
 import { ReservationTypeConnection } from "common/types/gql-types";
 
-import { SESSION_EXPIRED_ERROR, apiBaseUrl, isBrowser } from "./const";
+import { SESSION_EXPIRED_ERROR, publicUrl, isBrowser } from "./const";
 import { CustomFormData } from "./CustomFormData";
 
-const uri = `${apiBaseUrl}/graphql/`;
+const uri = `${publicUrl}/api/graphql`;
 const uploadLinkOptions = {
   uri,
   FormData: CustomFormData,

--- a/admin-ui/src/pages/api/graphql/index.ts
+++ b/admin-ui/src/pages/api/graphql/index.ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { apiBaseUrl } from "app/common/const";
+
+/// Mask graphql endpoint for the client so we can drop cookies
+/// otherwise the large request size causes a 502
+/// TODO we can move authentication here using server getSession
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST" && req.method !== "OPTIONS") {
+    return res.status(405).send("Only POST is allowed");
+  }
+
+  const auth = req.headers.authorization;
+  if (auth == null) {
+    return res.status(401).send("No authorization token");
+  }
+
+  const uri = `${apiBaseUrl}/graphql/`;
+  const response = await fetch(uri, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: auth,
+    },
+    body: JSON.stringify(req.body),
+  });
+
+  return res.status(response.status).json(await response.json());
+}


### PR DESCRIPTION
Use an api endpoint to create the actual fetch request instead of doing it on the client.

Removes unused cookies and headers when making the request.