### PR TITLE
TILA-2781: clamp reservation interval to 30 mins

### DIFF
--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   ReservationsReservationTypeChoices,
+  ReservationUnitsReservationUnitReservationStartIntervalChoices,
   type ReservationUnitType,
 } from "common/types/gql-types";
 import { camelCase, get } from "lodash";
@@ -179,10 +180,15 @@ const MyUnitRecurringReservationForm = ({ reservationUnits }: Props) => {
   const translateError = (errorMsg?: string) =>
     errorMsg ? t(`reservationForm:errors.${errorMsg}`) : "";
 
+  const interval =
+    reservationUnit?.reservationStartInterval ===
+    ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins
+      ? ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins
+      : ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_30Mins;
   const newReservations = useMultipleReservation({
     form,
     reservationUnit,
-    interval: reservationUnit?.reservationStartInterval,
+    interval,
   });
 
   const reservationType =

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/RecurringReservationDone.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/RecurringReservationDone.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { ErrorType } from "common/types/gql-types";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useLocation } from "react-router-dom";
 import styled from "styled-components";
@@ -33,21 +32,14 @@ const ReservationMadeSchema = z.object({
   startTime: z.string(),
   endTime: z.string(),
   date: z.date(),
-  error: z.string().or(z.array(z.unknown())).optional(), // string | ErrorType[];
+  error: z.string().or(z.unknown()).optional(),
 });
+export type ReservationMade = z.infer<typeof ReservationMadeSchema>;
 
 const RecurringReservationDoneParamsSchema = z.object({
   reservations: z.array(ReservationMadeSchema),
   recurringPk: z.number(),
 });
-
-export type ReservationMade = {
-  reservationPk?: number;
-  startTime: string;
-  endTime: string;
-  date: Date;
-  error?: string | ErrorType[];
-};
 
 const RecurringReservationDone = () => {
   const location = useLocation();

--- a/admin-ui/src/component/my-units/MyUnitRecurringReservation/ReservationsList.test.tsx
+++ b/admin-ui/src/component/my-units/MyUnitRecurringReservation/ReservationsList.test.tsx
@@ -199,9 +199,7 @@ describe("ReservationsList", () => {
 
     const screen = render(<ReservationList items={items} />);
     expect(await screen.findAllByText(/19:00/)).toHaveLength(1);
-    expect(
-      screen.getByText(/Overlapping reservations are not allowed./)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/overlap/)).toBeInTheDocument();
   });
 
   test("Error message that has no translation has a default message", async () => {

--- a/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
+++ b/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
@@ -8,6 +8,7 @@ import {
   type ReservationStaffCreateMutationPayload,
   type ReservationUnitType,
   ReservationsReservationTypeChoices,
+  ReservationUnitsReservationUnitReservationStartIntervalChoices,
 } from "common/types/gql-types";
 import styled from "styled-components";
 import { camelCase, get } from "lodash";
@@ -199,10 +200,13 @@ const DialogContent = ({
   start: Date;
 }) => {
   const { t, i18n } = useTranslation();
+  const interval =
+    reservationUnit.reservationStartInterval ===
+    ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins
+      ? ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins
+      : ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_30Mins;
   const form = useForm<FormValueType>({
-    resolver: zodResolver(
-      ReservationFormSchema(reservationUnit.reservationStartInterval)
-    ),
+    resolver: zodResolver(ReservationFormSchema(interval)),
     // TODO onBlur or onChange? onChange is anoying because it highlights even untouched fields
     // onBlur on the other hand does no validation on the focused field till it's blurred
 

--- a/admin-ui/src/i18n/messages.ts
+++ b/admin-ui/src/i18n/messages.ts
@@ -381,12 +381,9 @@ const translations: ITranslations = {
           "Voit halutessasi etsiä näille toistoille uuden ajan varauksen sivulta.",
         ],
         failureMessages: {
-          "ApolloError: Reservation new begin cannot be in the past": [
-            "Aika menneisyydessä",
-          ],
-          "ApolloError: Overlapping reservations are not allowed.": [
-            "Aika ei saatavilla",
-          ],
+          reservationInPast: ["Aika menneisyydessä"],
+          overlap: ["Päällekkäinen varaus"],
+          interval: ["Ei sallittu varauksen aloitus aika"],
           default: ["Aika ei saatavilla"],
         },
         buttonToUnit: ["Palaa toimipisteen sivulle"],


### PR DESCRIPTION
Add: staff reservations interval is always either 15 mins or 30 mins.
Fix: converting GQL errors to i18n strings.
Fix: error handling issue (unknown type causing validation error). 

Refs: TILA-2781, TILA-2782