### PR TITLE
TILA-1585: use apollo caches

### DIFF
--- a/apps/admin-ui/src/common/apolloClient.ts
+++ b/apps/admin-ui/src/common/apolloClient.ts
@@ -26,7 +26,6 @@ const uploadLinkOptions = {
 
 // NOTE upload link typing is broken when updating apollo to 3.8
 // FIXME upload link is broken locally (it succeeds but no new image is available)
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error FIXME
 const uploadLink = createUploadLink(uploadLinkOptions) as unknown as ApolloLink;
 const httpLink = new HttpLink({

--- a/apps/admin-ui/src/component/ButtonLikeLink.tsx
+++ b/apps/admin-ui/src/component/ButtonLikeLink.tsx
@@ -1,0 +1,61 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+type ButtonProps = {
+  readonly variant?: "primary" | "secondary";
+  readonly size?: "normal" | "large";
+};
+
+/// @brief looks like a button but is a link
+/// @desc why? because nesting buttons and links is invalid html and HDS doesn't include this
+/// Looks like a HDS button (should have all the same styles)
+/// This requires react-router-dom (no next/link support yet)
+/// Differences to HDS: secondary is black themed since we don't use the standard light blue
+/// @param variant: 'primary' | 'secondary'
+/// @param size: 'normal' | 'large'
+export const ButtonLikeLink = styled(Link)<ButtonProps>`
+  --background-color-hover: ${({ variant }) =>
+    variant === "primary" ? "var(--color-bus-dark)" : "var(--color-black-5)"};
+  --color-hover: ${({ variant }) =>
+    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
+  --background-color-focus: ${({ variant }) =>
+    variant === "primary" ? "var(--color-bus)" : "transparent"};
+  --color-focus: ${({ variant }) =>
+    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
+  --focus-outline-color: var(--color-focus-outline);
+  --outline-gutter: 2px;
+  --outline-width: 3px;
+
+  text-decoration: none;
+  background-color: ${({ variant }) =>
+    variant === "primary" ? "var(--color-bus)" : "transparent"};
+  color: ${({ variant }) =>
+    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
+  padding: ${({ size }) => (size === "large" ? "4px 20px" : "0 20px")};
+  border: 2px solid
+    ${({ variant }) =>
+      variant === "primary" ? "var(--color-bus)" : "var(--color-black)"};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 80px;
+  line-height: 1;
+  text-align: center;
+  height: 44px;
+  &:hover,
+  &:focus-visible {
+    transition-property: background-color, border-color, color;
+    transition-duration: 85ms;
+    transition-timing-function: ease-out;
+  }
+  &:hover {
+    background-color: var(--background-color-hover);
+    color: var(--color-hover);
+  }
+  &:focus-visible {
+    background-color: var(--background-color-focus, transparent);
+    color: var(--color-focus);
+    outline-offset: var(--outline-gutter);
+    outline: var(--outline-width) solid var(--focus-outline-color);
+  }
+`;

--- a/apps/admin-ui/src/component/PageWrapper.tsx
+++ b/apps/admin-ui/src/component/PageWrapper.tsx
@@ -50,9 +50,7 @@ export default function PageWrapper({ children }: Props): JSX.Element {
           {hasAccess && <MainMenu placement="default" />}
           <Suspense fallback={<Loader />}>
             <Content>
-              {hasAccess && (
-                <BannerNotificationsList targetList={["STAFF", "ALL"]} />
-              )}
+              {hasAccess && <BannerNotificationsList />}
               {user ? children : <MainLander />}
             </Content>
           </Suspense>

--- a/apps/admin-ui/src/component/Resources/resource-editor/NewResourceModal.tsx
+++ b/apps/admin-ui/src/component/Resources/resource-editor/NewResourceModal.tsx
@@ -139,7 +139,6 @@ const NewResourceModal = ({
       return undefined;
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error: TODO: Joi should be deprecated so ignore this for now
     return t(`validation.${error.type}`, { ...error.context });
   };

--- a/apps/admin-ui/src/component/Spaces/space-editor/SpaceEditor.tsx
+++ b/apps/admin-ui/src/component/Spaces/space-editor/SpaceEditor.tsx
@@ -313,7 +313,6 @@ const SpaceEditor = ({ space, unit }: Props): JSX.Element | null => {
       return undefined;
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error: TODO: Joi should be deprecated so ignore this for now
     return t(`validation.${error.type}`, { ...error.context });
   };

--- a/apps/admin-ui/src/component/Spaces/space-editor/new-space-modal/Page2.tsx
+++ b/apps/admin-ui/src/component/Spaces/space-editor/new-space-modal/Page2.tsx
@@ -135,7 +135,6 @@ const Page2 = ({
         return undefined;
       }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error: TODO: Joi should be deprecated so ignore this for now
       return t(`validation.${error.type}`, { ...error.context });
     };

--- a/apps/admin-ui/src/component/notifications/index.tsx
+++ b/apps/admin-ui/src/component/notifications/index.tsx
@@ -31,7 +31,7 @@ const getColConfig = (t: TFunction) => [
     key: "name",
     isSortable: true,
     transform: (notification: NonNullable<BannerNotificationType>) =>
-      notification.pk != null ? (
+      notification.pk ? (
         <TableLink href={notificationUrl(notification.pk)}>
           {notification.name ?? t("Notifications.noName")}
         </TableLink>

--- a/apps/admin-ui/src/component/notifications/index.tsx
+++ b/apps/admin-ui/src/component/notifications/index.tsx
@@ -2,10 +2,12 @@ import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
 import { useTranslation } from "react-i18next";
 import { type TFunction } from "i18next";
+import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { Button } from "hds-react";
 import { BANNER_NOTIFICATIONS_ADMIN_LIST } from "common/src/components/BannerNotificationsQuery";
 import type { Query, BannerNotificationType } from "common/types/gql-types";
+import { H1 } from "common/src/common/typography";
 import { Container } from "app/styles/layout";
 import BreadcrumbWrapper from "app/component/BreadcrumbWrapper";
 import Loader from "app/component/Loader";
@@ -136,6 +138,11 @@ const NotificationsTable = ({
   );
 };
 
+const HeaderContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
 /// @brief this is the listing page for all notifications.
 const Page = () => {
   // TODO the default sort should be ["state", "-ends"] but the frontend sort doesn't support multiple options
@@ -175,15 +182,15 @@ const Page = () => {
 
   return (
     <>
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <h1>{t("Notifications.pageTitle")}</h1>
+      <HeaderContainer>
+        <H1 $legacy>{t("Notifications.pageTitle")}</H1>
         {/* TODO dont use nested button / link use something like ButtonLikeLink but it needs primary variant */}
         <Link to="/messaging/notifications/new">
           <Button variant="primary">
             {t("Notifications.newNotification")}
           </Button>
         </Link>
-      </div>
+      </HeaderContainer>
       <p>{t("Notifications.pageDescription")}</p>
       {isLoading ? (
         <Loader />

--- a/apps/admin-ui/src/component/notifications/index.tsx
+++ b/apps/admin-ui/src/component/notifications/index.tsx
@@ -5,11 +5,7 @@ import { type TFunction } from "i18next";
 import { Link } from "react-router-dom";
 import { Button } from "hds-react";
 import { BANNER_NOTIFICATIONS_ADMIN_LIST } from "common/src/components/BannerNotificationsQuery";
-import type {
-  Query,
-  BannerNotificationType,
-  PageInfo,
-} from "common/types/gql-types";
+import type { Query, BannerNotificationType } from "common/types/gql-types";
 import { Container } from "app/styles/layout";
 import BreadcrumbWrapper from "app/component/BreadcrumbWrapper";
 import Loader from "app/component/Loader";
@@ -204,29 +200,7 @@ const Page = () => {
               onClick={() => {
                 fetchMore({
                   variables: {
-                    offset: notifications.length,
-                  },
-                  // FIXME calling this once, change sort order -> creates an extra ghost as the first element
-                  // (probably the next element for the previous sort order)
-                  updateQuery: (prev, { fetchMoreResult }) => {
-                    if (!fetchMoreResult) {
-                      return prev;
-                    }
-                    const pageInfo =
-                      fetchMoreResult.bannerNotifications?.pageInfo ??
-                      prev.bannerNotifications?.pageInfo;
-                    return {
-                      ...prev,
-                      bannerNotifications: {
-                        ...prev.bannerNotifications,
-                        edges: [
-                          ...(prev.bannerNotifications?.edges ?? []),
-                          ...(fetchMoreResult.bannerNotifications?.edges ?? []),
-                        ],
-                        // NOTE there is something funny with Apollo they disallowed pageInfo undefined in types
-                        pageInfo: pageInfo as PageInfo,
-                      },
-                    };
+                    offset: notifications.length + 1,
                   },
                 });
               }}

--- a/apps/admin-ui/src/component/notifications/index.tsx
+++ b/apps/admin-ui/src/component/notifications/index.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@apollo/client";
 import { useTranslation } from "react-i18next";
 import { type TFunction } from "i18next";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
 import { Button } from "hds-react";
 import { BANNER_NOTIFICATIONS_ADMIN_LIST } from "common/src/components/BannerNotificationsQuery";
 import type { Query, BannerNotificationType } from "common/types/gql-types";
@@ -11,6 +10,7 @@ import { H1 } from "common/src/common/typography";
 import { Container } from "app/styles/layout";
 import BreadcrumbWrapper from "app/component/BreadcrumbWrapper";
 import Loader from "app/component/Loader";
+import { ButtonLikeLink } from "app/component/ButtonLikeLink";
 import { valueForDateInput, valueForTimeInput } from "app/helpers";
 import { GQL_MAX_RESULTS_PER_QUERY } from "app/common/const";
 import { CustomTable, TableLink } from "../lists/components";
@@ -184,12 +184,13 @@ const Page = () => {
     <>
       <HeaderContainer>
         <H1 $legacy>{t("Notifications.pageTitle")}</H1>
-        {/* TODO dont use nested button / link use something like ButtonLikeLink but it needs primary variant */}
-        <Link to="/messaging/notifications/new">
-          <Button variant="primary">
-            {t("Notifications.newNotification")}
-          </Button>
-        </Link>
+        <ButtonLikeLink
+          variant="primary"
+          size="large"
+          to="/messaging/notifications/new"
+        >
+          {t("Notifications.newNotification")}
+        </ButtonLikeLink>
       </HeaderContainer>
       <p>{t("Notifications.pageDescription")}</p>
       {isLoading ? (

--- a/apps/admin-ui/src/component/notifications/page.tsx
+++ b/apps/admin-ui/src/component/notifications/page.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import dynamic from "next/dynamic";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, gql } from "@apollo/client";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -38,6 +38,7 @@ import BreadcrumbWrapper from "app/component/BreadcrumbWrapper";
 import { publicUrl } from "app/common/const";
 import Loader from "app/component/Loader";
 import { useNotification } from "app/context/NotificationContext";
+import { ButtonLikeLink } from "app/component/ButtonLikeLink";
 import {
   checkValidDate,
   checkValidFutureDate,
@@ -611,12 +612,14 @@ const NotificationForm = ({
       />
       <ButtonContainer>
         <InnerButtons>
-          {/* TODO don't nest Link and Button */}
-          <Link to=".." style={{ marginRight: "auto" }}>
-            <Button variant="secondary" type="button" theme="black">
-              {t("form.cancel")}
-            </Button>
-          </Link>
+          <ButtonLikeLink
+            variant="secondary"
+            size="large"
+            to=".."
+            style={{ marginRight: "auto" }}
+          >
+            {t("form.cancel")}
+          </ButtonLikeLink>
           <Button
             variant="secondary"
             theme="black"
@@ -664,7 +667,6 @@ const PageWrapped = ({ pk }: { pk?: number }) => {
   const typename = "BannerNotificationType";
   const id = pk ? window?.btoa(`${typename}:${pk}`) : undefined;
 
-  // TODO there is neither singular version of this, nor a pk filter
   const { data, loading: isLoading } = useQuery<
     Query,
     QueryBannerNotificationArgs

--- a/apps/admin-ui/src/component/notifications/page.tsx
+++ b/apps/admin-ui/src/component/notifications/page.tsx
@@ -726,15 +726,17 @@ const PageWrapped = ({ id }: { id?: number }) => {
       <Container>
         <StatusTagContainer>
           <H1 $legacy>
-            {notification
-              ? notification?.name ?? t("noName")
+            {id !== 0
+              ? notification?.name ?? t("Notifications.error.notFound")
               : t("Notifications.newNotification")}
           </H1>
           {notification?.state && (
             <BannerNotificationStateTag state={notification.state} />
           )}
         </StatusTagContainer>
-        <NotificationForm notification={notification ?? undefined} />
+        {(notification || id === 0) && (
+          <NotificationForm notification={notification ?? undefined} />
+        )}
         {notification && (
           <ButtonContainer
             style={{ marginTop: "2rem", justifyContent: "flex-start" }}

--- a/apps/admin-ui/src/component/notifications/page.tsx
+++ b/apps/admin-ui/src/component/notifications/page.tsx
@@ -31,6 +31,7 @@ import {
 import { BANNER_NOTIFICATIONS_ADMIN_LIST } from "common/src/components/BannerNotificationsQuery";
 import { H1 } from "common/src/common/typography";
 import { fromUIDate } from "common/src/common/util";
+import { breakpoints } from "common";
 import { Container } from "app/styles/layout";
 import BreadcrumbWrapper from "app/component/BreadcrumbWrapper";
 import { publicUrl } from "app/common/const";
@@ -147,6 +148,14 @@ const StatusTagContainer = styled.div`
   display: flex;
   gap: 0.5rem;
   justify-content: space-between;
+  align-items: flex-start;
+  margin-top: var(--spacing-s);
+  & > h1 {
+    margin-top: 0;
+  }
+  @media (width > ${breakpoints.s}) {
+    margin-top: var(--spacing-l);
+  }
 `;
 
 const ButtonContainerCommon = styled.div`

--- a/apps/admin-ui/src/component/notifications/page.tsx
+++ b/apps/admin-ui/src/component/notifications/page.tsx
@@ -144,11 +144,9 @@ function BannerNotificationStateTag({
 }
 
 const StatusTagContainer = styled.div`
-  display: grid;
-  justify-items: justify-between;
-  grid-column: 1 / -1;
-  grid-template-columns: repeat(6, 1fr);
-  grid-template-rows: repeat(4, 1fr);
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
 `;
 
 /* TODO mobile styling */
@@ -236,7 +234,7 @@ type NotificationFormType = z.infer<typeof NotificationFormSchema>;
 const GridForm = styled.form`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: var(--spacing-l);
 `;
 
 // @brief inefficient way to destroy caches, normal INVALIDATE doesn't remove keys
@@ -255,7 +253,11 @@ const deleteQueryFromCache = (cache: any, matcher: string | RegExp): void => {
 };
 
 /// @brief This is the create / edit page for a single notification.
-const Page = ({ notification }: { notification?: BannerNotificationType }) => {
+const NotificationForm = ({
+  notification,
+}: {
+  notification?: BannerNotificationType;
+}) => {
   const { t } = useTranslation("translation", { keyPrefix: "Notifications" });
 
   const today = new Date();
@@ -420,9 +422,9 @@ const Page = ({ notification }: { notification?: BannerNotificationType }) => {
     errorMsg ? t(`form.errors.${errorMsg}`) : "";
 
   const levelOptions = [
-    { value: "NORMAL", label: t("level.NORMAL") },
-    { value: "WARNING", label: t("level.WARNING") },
-    { value: "EXCEPTION", label: t("level.EXCEPTION") },
+    { value: "NORMAL", label: t("form.levelEnum.NORMAL") },
+    { value: "WARNING", label: t("form.levelEnum.WARNING") },
+    { value: "EXCEPTION", label: t("form.levelEnum.EXCEPTION") },
   ];
   const targetGroupOptions = [
     { value: "ALL", label: t("target.ALL") },
@@ -432,16 +434,6 @@ const Page = ({ notification }: { notification?: BannerNotificationType }) => {
 
   return (
     <GridForm onSubmit={handleSubmit(onSubmit)} noValidate>
-      <StatusTagContainer>
-        <H1 $legacy style={{ gridColumn: "1 / span 5", gridRow: "1 / span 4" }}>
-          {notification
-            ? notification?.name ?? t("noName")
-            : t("newNotification")}
-        </H1>
-        {notification?.state && (
-          <BannerNotificationStateTag state={notification.state} />
-        )}
-      </StatusTagContainer>
       <Controller
         control={control}
         name="inFuture"
@@ -528,7 +520,7 @@ const Page = ({ notification }: { notification?: BannerNotificationType }) => {
             }
             value={{
               value,
-              label: value !== "" ? t(`level.${value}`) : "",
+              label: value !== "" ? t(`form.levelEnum.${value}`) : "",
             }}
             invalid={!!errors.level}
             error={translateError(errors.level?.message)}
@@ -723,7 +715,17 @@ const PageWrapped = ({ id }: { id?: number }) => {
         ]}
       />
       <Container>
-        <Page notification={notification ?? undefined} />
+        <StatusTagContainer>
+          <H1 $legacy>
+            {notification
+              ? notification?.name ?? t("noName")
+              : t("Notifications.newNotification")}
+          </H1>
+          {notification?.state && (
+            <BannerNotificationStateTag state={notification.state} />
+          )}
+        </StatusTagContainer>
+        <NotificationForm notification={notification ?? undefined} />
         {notification && (
           <ButtonContainer style={{ marginTop: "2rem" }}>
             <Button

--- a/apps/admin-ui/src/component/notifications/page.tsx
+++ b/apps/admin-ui/src/component/notifications/page.tsx
@@ -149,13 +149,17 @@ const StatusTagContainer = styled.div`
   justify-content: space-between;
 `;
 
-/* TODO mobile styling */
-const ButtonContainer = styled.div`
-  grid-column: 1 / -1;
+const ButtonContainerCommon = styled.div`
   display: flex;
-  width: 100%;
   justify-content: space-between;
-  gap: 1rem;
+  gap: var(--spacing-l);
+`;
+const ButtonContainer = styled(ButtonContainerCommon)`
+  grid-column: 1 / -1;
+`;
+
+const InnerButtons = styled(ButtonContainerCommon)`
+  flex-grow: 1;
   flex-wrap: wrap;
 `;
 
@@ -596,25 +600,30 @@ const NotificationForm = ({
         )}
       />
       <ButtonContainer>
-        {/* TODO don't nest Link and Button */}
-        <Link to="..">
-          <Button variant="secondary" type="button" theme="black">
-            {t("form.cancel")}
+        <InnerButtons>
+          {/* TODO don't nest Link and Button */}
+          <Link to=".." style={{ marginRight: "auto" }}>
+            <Button variant="secondary" type="button" theme="black">
+              {t("form.cancel")}
+            </Button>
+          </Link>
+          <Button
+            variant="secondary"
+            theme="black"
+            type="button"
+            onClick={() => {
+              setValue("isDraft", true);
+              handleSubmit(onSubmit)();
+            }}
+          >
+            {t("form.saveDraft")}
           </Button>
-        </Link>
-        <Button
-          style={{ marginLeft: "auto" }}
-          variant="secondary"
-          theme="black"
-          type="button"
-          onClick={() => {
-            setValue("isDraft", true);
-            handleSubmit(onSubmit)();
-          }}
-        >
-          {t("form.saveDraft")}
-        </Button>
-        <Button type="submit">{t("form.save")}</Button>
+        </InnerButtons>
+        <div>
+          <Button style={{ marginLeft: "auto" }} type="submit">
+            {t("form.save")}
+          </Button>
+        </div>
       </ButtonContainer>
     </GridForm>
   );
@@ -727,7 +736,9 @@ const PageWrapped = ({ id }: { id?: number }) => {
         </StatusTagContainer>
         <NotificationForm notification={notification ?? undefined} />
         {notification && (
-          <ButtonContainer style={{ marginTop: "2rem" }}>
+          <ButtonContainer
+            style={{ marginTop: "2rem", justifyContent: "flex-start" }}
+          >
             <Button
               onClick={removeNotification}
               variant="secondary"

--- a/apps/admin-ui/src/component/notifications/page.tsx
+++ b/apps/admin-ui/src/component/notifications/page.tsx
@@ -667,7 +667,7 @@ const PageWrapped = ({ id }: { id?: number }) => {
       cache.modify({
         fields: {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore; TODO: typechecking broke after upgrading apollo
+          // @ts-expect-error; TODO: typecheck broke after updating Apollo or Typescript
           bannerNotifications(existing: BannerNotificationTypeConnection) {
             const res = newData?.deleteBannerNotification;
             if (res?.errors) {

--- a/apps/admin-ui/src/component/notifications/router.tsx
+++ b/apps/admin-ui/src/component/notifications/router.tsx
@@ -6,7 +6,7 @@ import Page from "./page";
 const MyUnitsRouter = (): JSX.Element => (
   <Routes>
     <Route index element={<Index />} />
-    <Route path=":id" element={<Page />} />
+    <Route path=":pk" element={<Page />} />
   </Routes>
 );
 

--- a/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
+++ b/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
@@ -116,6 +116,7 @@ const DialogContent = ({ reservation, onAccept, onClose }: Props) => {
       cache.modify({
         fields: {
           // find the pk => slice the array => replace the state variable in the slice
+          // @ts-expect-error: TODO: typechecks broke with ts or apollo-client upgrade
           reservations(existing: ReservationTypeConnection) {
             const queryRes = data?.staffAdjustReservationTime;
             if (queryRes?.errors) {

--- a/apps/admin-ui/src/component/reservations/requested/ApprovalButtons.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/ApprovalButtons.tsx
@@ -6,11 +6,11 @@ import {
 import { useTranslation } from "react-i18next";
 import { addHours, isToday } from "date-fns";
 import { Button } from "hds-react";
+import { ButtonLikeLink } from "app/component/ButtonLikeLink";
 import DenyDialog from "./DenyDialog";
 import ApproveDialog from "./ApproveDialog";
 import ReturnToRequiredHandlingDialog from "./ReturnToRequiresHandlingDialog";
 import { useModal } from "../../../context/ModalContext";
-import { ButtonLikeLink } from "../../../styles/util";
 
 /* Rules
  * Approve only if REQUIRES_HANDLING

--- a/apps/admin-ui/src/component/reservations/requested/ApprovalButtonsRecurring.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/ApprovalButtonsRecurring.tsx
@@ -5,7 +5,7 @@ import {
 } from "common/types/gql-types";
 import { useTranslation } from "react-i18next";
 import { Button } from "hds-react";
-import { ButtonLikeLink } from "app/styles/util";
+import { ButtonLikeLink } from "app/component/ButtonLikeLink";
 import DenyDialog from "./DenyDialog";
 import { useModal } from "../../../context/ModalContext";
 import { useRecurringReservations } from "./hooks";

--- a/apps/admin-ui/src/component/reservations/requested/DenyDialog.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/DenyDialog.tsx
@@ -141,7 +141,7 @@ const DialogContent = ({
       cache.modify({
         fields: {
           // find the pk => slice the array => replace the state variable in the slice
-          // @ts-expect-error: TODO: typecheck broke after updating Apollo or Typescript
+          // @ts-expect-error; TODO: typecheck broke after updating Apollo or Typescript
           reservations(existing: ReservationTypeConnection) {
             const queryRes = data?.denyReservation;
             if (queryRes?.errors) {

--- a/apps/admin-ui/src/component/reservations/requested/DenyDialog.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/DenyDialog.tsx
@@ -141,7 +141,7 @@ const DialogContent = ({
       cache.modify({
         fields: {
           // find the pk => slice the array => replace the state variable in the slice
-          // @ts-expect-error: TODO: broken with either typescript or apollo upgrade
+          // @ts-expect-error: TODO: typecheck broke after updating Apollo or Typescript
           reservations(existing: ReservationTypeConnection) {
             const queryRes = data?.denyReservation;
             if (queryRes?.errors) {

--- a/apps/admin-ui/src/helpers/date.ts
+++ b/apps/admin-ui/src/helpers/date.ts
@@ -12,16 +12,20 @@ export const valueForTimeInput = (from: string): string => {
 };
 
 /* Construct date from dateinput + timeinput */
-// TODO move this to common/util and rename
 export const dateTime = (date: string, time: string): string => {
   return parse(`${date} ${time}`, "dd.MM.yyyy HH:mm", new Date()).toISOString();
 };
+
 export const parseDateTimeSafe = (
   date: string,
   time: string
 ): Date | undefined => {
   try {
-    return parse(`${date} ${time}`, "dd.MM.yyyy HH:mm", new Date());
+    const d = parse(`${date} ${time}`, "dd.MM.yyyy HH:mm", new Date());
+    if (Number.isNaN(d.getTime())) {
+      return undefined;
+    }
+    return d;
   } catch (e) {
     return undefined;
   }

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -960,6 +960,7 @@ const translations: ITranslations = {
         generic: ["Ilmoituksen tallennus epäonnistui"],
         alreadyExists: ["Ilmoitus on jo olemassa"],
         missingMessage: ["Ilmoituksen viesti puuttuu"],
+        noMutationPermission: ["Ei oikeutta muokata ilmoitusta"],
       },
       deleteFailed: {
         generic: ["Ilmoituksen poisto epäonnistui"],
@@ -990,14 +991,24 @@ const translations: ITranslations = {
       saveSuccessToast: ["Ilmoitus {{ name }} {{ state }}"],
       errors: {
         Required: ["Pakollinen"],
+        "Invalid date": ["Virheellinen päivämäärä"],
         "String must contain at least 1 character(s)": ["Pakollinen"],
         "Target group cannot be empty": ["Pakollinen"],
         "Level cannot be empty": ["Pakollinen"],
         "Date can't be in the past": ["Päivämäärä ei voi olla menneisyydessä"],
         "activeFromTime is not in time format.": ["Alkamisaika ei ole aika"],
         "activeUntilTime is not in time format.": ["Päättymisaika ei ole aika"],
+        "activeFromTime can't be more than 24 hours.": [
+          "Alkamisaika ei voi olla yli 24 tuntia",
+        ],
+        "activeUntilTime can't be more than 24 hours.": [
+          "Päättymisaika ei voi olla yli 24 tuntia",
+        ],
         "End time needs to be after start time.": [
           "Päättymisajan tulee olla alkamisajan jälkeen",
+        ],
+        "Date needs to be within three years.": [
+          "Päivämäärän tulee olla kolmen vuoden sisällä",
         ],
       },
     },

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -956,6 +956,7 @@ const translations: ITranslations = {
     noName: ["(ei nimeä)"],
     deleteButton: ["Poista"],
     error: {
+      notFound: ["Ilmoitusta ei löytynyt"],
       submit: {
         generic: ["Ilmoituksen tallennus epäonnistui"],
         alreadyExists: ["Ilmoitus on jo olemassa"],

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -951,6 +951,7 @@ const translations: ITranslations = {
     pageDescription: [
       "Alla näet yhteenvedon aiemmin luoduista ilmoituksista. Voit luoda uusia ilmoituksia Varaamon yläreunaan Luo ilmoitus -painikkeesta.",
     ],
+    isLoading: ["Ladataan ilmoitusta"],
     noNotifications: ["Ei ilmoituksia"],
     newNotification: ["Luo ilmoitus"],
     noName: ["(ei nimeä)"],

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -952,7 +952,7 @@ const translations: ITranslations = {
       "Alla näet yhteenvedon aiemmin luoduista ilmoituksista. Voit luoda uusia ilmoituksia Varaamon yläreunaan Luo ilmoitus -painikkeesta.",
     ],
     noNotifications: ["Ei ilmoituksia"],
-    newNotification: ["Uusi ilmoitus"],
+    newNotification: ["Luo ilmoitus"],
     noName: ["(ei nimeä)"],
     deleteButton: ["Poista"],
     error: {
@@ -984,11 +984,17 @@ const translations: ITranslations = {
       messageEn: ["Viesti en"],
       messageSv: ["Viesti sv"],
       cancel: ["Peruuta"],
-      saveDraft: ["Tallenna luonnoksena"],
+      saveDraft: ["Tallenna luonnos"],
       save: ["Julkaise"],
       created: ["luotu"],
       updated: ["päivitetty"],
       saveSuccessToast: ["Ilmoitus {{ name }} {{ state }}"],
+      levelEnum: {
+        noLevel: ["(ei tasoa)"],
+        EXCEPTION: ["Poikkeus (punainen)"],
+        WARNING: ["Varoitus (keltainen)"],
+        NORMAL: ["Normaali (sininen)"],
+      },
       errors: {
         Required: ["Pakollinen"],
         "Invalid date": ["Virheellinen päivämäärä"],
@@ -1022,7 +1028,7 @@ const translations: ITranslations = {
       noState: ["(ei tilaa)"],
       ACTIVE: ["Julkaistu"],
       DRAFT: ["Luonnos"],
-      SCHEDULED: ["Ajasitetu"],
+      SCHEDULED: ["Ajastettu"],
     },
     target: {
       noTarget: ["(ei kohderyhmää)"],

--- a/apps/admin-ui/src/schemas/recurringReservation.ts
+++ b/apps/admin-ui/src/schemas/recurringReservation.ts
@@ -3,13 +3,15 @@ import { ReservationUnitsReservationUnitReservationStartIntervalChoices } from "
 import { fromUIDate } from "common/src/common/util";
 import {
   ReservationTypeSchema,
-  checkDate,
   checkReservationInterval,
   checkStartEndTime,
-  checkTimeStringFormat,
 } from "./reservation";
+import {
+  checkDateNotInPast,
+  checkTimeStringFormat,
+  OptionSchema,
+} from "./schemaCommon";
 import { intervalToNumber } from "./utils";
-import { OptionSchema } from "./schemaCommon";
 
 // TODO handle metadata (variable form fields) instead of using .passthrough
 // It should be it's own schema object that is included in both forms
@@ -70,10 +72,10 @@ export const timeSelectionSchema = (
   timeSelectionSchemaBase
     .partial()
     .superRefine((val, ctx) =>
-      checkDate(convertToDate(val.startingDate), ctx, "startingDate")
+      checkDateNotInPast(convertToDate(val.startingDate), ctx, "startingDate")
     )
     .superRefine((val, ctx) =>
-      checkDate(convertToDate(val.endingDate), ctx, "endingDate")
+      checkDateNotInPast(convertToDate(val.endingDate), ctx, "endingDate")
     )
     .refine(
       (s) =>

--- a/apps/admin-ui/src/schemas/reservation.ts
+++ b/apps/admin-ui/src/schemas/reservation.ts
@@ -1,11 +1,8 @@
 import { z } from "zod";
 import { fromUIDate } from "common/src/common/util";
-import { subDays } from "date-fns";
 import { ReservationUnitsReservationUnitReservationStartIntervalChoices } from "common/types/gql-types";
 import { intervalToNumber } from "./utils";
-
-const THREE_YEARS_MS = 3 * 365 * 24 * 60 * 60 * 1000;
-const TIME_PATTERN = /^[0-2][0-9]:[0-5][0-9]$/;
+import { checkTimeStringFormat, checkValidFutureDate } from "./schemaCommon";
 
 export const ReservationTypes = [
   "STAFF",
@@ -40,59 +37,6 @@ const ReservationFormSchema = z
 // this shows refinement errors before required of course we need to either do a second
 // pass or add custom Required refinements
 const ReservationFormSchemaPartial = ReservationFormSchema.partial();
-
-export const checkDate = (
-  date: Date | undefined,
-  ctx: z.RefinementCtx,
-  path: string
-): void => {
-  if (!date) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: [path],
-      message: "Required",
-    });
-  } else if (date < subDays(new Date(), 1)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: [path],
-      message: "Date can't be in the past",
-    });
-  } else if (Math.abs(new Date().getTime() - date.getTime()) > THREE_YEARS_MS) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: [path],
-      message: "Date needs to be within three years.",
-    });
-  }
-};
-
-// TODO check that the latter half is not over 59 (since 11:60 is valid input in the field but shouldn't be)
-export const checkTimeStringFormat = (
-  data: string | undefined,
-  ctx: z.RefinementCtx,
-  path: string
-) => {
-  if (!data) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: [path],
-      message: `Required`,
-    });
-  } else if (!data.match(TIME_PATTERN)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: [path],
-      message: `${path} is not in time format.`,
-    });
-  } else if (Number(data.replace(":", ".")) >= 24) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: [path],
-      message: `${path} can't be more than 24 hours.`,
-    });
-  }
-};
 
 export const checkStartEndTime = (
   data: Pick<
@@ -136,7 +80,7 @@ const ReservationFormSchemaRefined = (
   ReservationFormSchema.partial()
     .superRefine((val, ctx) => {
       if (val.date) {
-        checkDate(fromUIDate(val.date), ctx, "date");
+        checkValidFutureDate(fromUIDate(val.date), ctx, "date");
       }
     })
     .superRefine((val, ctx) =>
@@ -169,7 +113,7 @@ export const TimeChangeFormSchemaRefined = (
   TimeFormSchema.partial()
     .superRefine((val, ctx) => {
       if (val.date) {
-        checkDate(fromUIDate(val.date), ctx, "date");
+        checkValidFutureDate(fromUIDate(val.date), ctx, "date");
       }
     })
     .superRefine((val, ctx) =>

--- a/apps/admin-ui/src/schemas/schemaCommon.ts
+++ b/apps/admin-ui/src/schemas/schemaCommon.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import { subDays } from "date-fns";
+
+const THREE_YEARS_MS = 3 * 365 * 24 * 60 * 60 * 1000;
+const TIME_PATTERN = /^[0-2][0-9]:[0-5][0-9]$/;
 
 // Common select prop type
 // normally a backend provided list that is transformed into
@@ -7,3 +11,91 @@ export const OptionSchema = z.object({
   value: z.number(),
   label: z.string(),
 });
+
+export const checkDateNotInPast = (
+  date: Date | undefined,
+  ctx: z.RefinementCtx,
+  path: string
+): void => {
+  if (date && date < subDays(new Date(), 1)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: "Date can't be in the past",
+    });
+  }
+};
+
+export const checkDateWithinThreeYears = (
+  date: Date | undefined,
+  ctx: z.RefinementCtx,
+  path: string
+): void => {
+  if (
+    date &&
+    Math.abs(new Date().getTime() - date.getTime()) > THREE_YEARS_MS
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: "Date needs to be within three years.",
+    });
+  }
+};
+
+// TODO doesn't check for valid days or months i.e. 2024-02-31 and 2024-13-41 are valid
+export const checkValidDate = (
+  date: Date | undefined,
+  ctx: z.RefinementCtx,
+  path: string
+): void => {
+  if (!date) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: "Required",
+    });
+  } else if (Number.isNaN(date.getTime())) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: "Invalid date",
+    });
+  }
+  checkDateWithinThreeYears(date, ctx, path);
+};
+
+export const checkValidFutureDate = (
+  date: Date | undefined,
+  ctx: z.RefinementCtx,
+  path: string
+): void => {
+  checkValidDate(date, ctx, path);
+  checkDateNotInPast(date, ctx, path);
+};
+
+export const checkTimeStringFormat = (
+  data: string | undefined,
+  ctx: z.RefinementCtx,
+  path: string
+) => {
+  if (!data) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: `Required`,
+    });
+  } else if (!data.match(TIME_PATTERN)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: `${path} is not in time format.`,
+    });
+  } else if (Number(data.replace(":", ".")) >= 24) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: `${path} can't be more than 24 hours.`,
+    });
+  }
+};

--- a/apps/admin-ui/src/styles/util.ts
+++ b/apps/admin-ui/src/styles/util.ts
@@ -121,41 +121,6 @@ export const InlineErrorSummary = styled(ErrorSummary)`
   width: 40%;
 `;
 
-// HDS doesn't have button looking link and their CSS is not resusable
-export const ButtonLikeLink = styled(Link)`
-  text-decoration: none;
-  border-style: solid;
-  border-width: ${(props) => props.theme.border ?? "2px"};
-  border-color: ${(props) => props.theme.fg ?? "var(--color-black)"};
-  color: ${(props) => props.theme.fg ?? "var(--color-black)"};
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 80px;
-  line-height: 1;
-  text-align: center;
-  height: 44px;
-  padding: 0 20px;
-  line-height: 1;
-  text-align: center;
-  &:hover,
-  &:focus-visible {
-    transition-property: background-color, border-color, color;
-    transition-duration: 85ms;
-    transition-timing-function: ease-out;
-  }
-  &:hover {
-    background-color: var(--background-color-hover);
-    color: var(--color-hover);
-  }
-  &:focus-visible {
-    background-color: var(--background-color-focus, transparent);
-    color: var(--color-focus);
-    outline-offset: 3px;
-    outline: 2px solid var(--focus-outline-color);
-  }
-`;
-
 export const BasicLink = styled(Link)`
   color: var(--tilavaraus-admin-content-text-color);
   text-decoration: none;
@@ -213,6 +178,7 @@ export const NotificationBox = styled.div`
   margin-bottom: var(--spacing-5-xl);
 `;
 
+/// @deprecated
 export const ButtonsStripe = styled.div`
   position: fixed;
   bottom: 0;
@@ -225,6 +191,7 @@ export const ButtonsStripe = styled.div`
   z-index: var(--tilavaraus-admin-stack-button-stripe);
 `;
 
+/// @deprecated use Standard Button instead
 export const WhiteButton = styled(Button)<{
   disabled: boolean;
   variant: "secondary" | "primary" | "supplementary";
@@ -255,7 +222,6 @@ export const WhiteButton = styled(Button)<{
         --hfg: var(--fg);
       `
       : null}
-
 
   height: 52px;
   border: 2px var(--border-color) solid !important;

--- a/apps/ui/components/common/PageWrapper.tsx
+++ b/apps/ui/components/common/PageWrapper.tsx
@@ -22,7 +22,7 @@ const PageWrapper = (props: Props): JSX.Element => {
     <>
       <Title>Tilavarauspalvelu</Title>
       <Navigation />
-      <BannerNotificationsList targetList={["USER", "ALL"]} centered />
+      <BannerNotificationsList centered />
       <UnpaidReservationNotification />
       <Main
         $bgColor={props.overrideBackgroundColor}

--- a/packages/common/codegen.yml
+++ b/packages/common/codegen.yml
@@ -1,4 +1,4 @@
-schema: ../tilavaraus.graphql
+schema: ../../tilavaraus.graphql
 generates:
   ./types/gql-types.ts:
     plugins:

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,7 +15,7 @@
     "test": "echo 'FIXME common tests are broken'",
     "generate-gql-types": "graphql-codegen",
     "format": "prettier --ignore-path \"../.prettierignore\" --write \"**/*.{js,jsx,ts,tsx,json}\"",
-    "update-schema": "npx --yes get-graphql-schema http://localhost:8000/graphql/ > ../tilavaraus.graphql",
+    "update-schema": "npx --yes get-graphql-schema http://localhost:8000/graphql/ > ../../tilavaraus.graphql",
     "generate-email-templates": "node ./email/convertToHTML.mjs"
   },
   "dependencies": {

--- a/packages/common/src/common/typography.ts
+++ b/packages/common/src/common/typography.ts
@@ -36,6 +36,7 @@ export const H1 = styled.h1<{ $legacy?: boolean }>`
   ${fontRegular}
   line-height: var(--lineheight-s);
   margin: var(--spacing-s) 0 var(--spacing-m);
+  word-break: break-word;
 
   @media (min-width: ${breakpoints.s}) {
     font-size: ${({ $legacy }) =>

--- a/packages/common/src/components/BannerNotificationsList.tsx
+++ b/packages/common/src/components/BannerNotificationsList.tsx
@@ -10,10 +10,8 @@ import { breakpoints } from "../common/style";
 import { BannerNotificationType, Query } from "../../types/gql-types";
 import { BANNER_NOTIFICATIONS_LIST } from "./BannerNotificationsQuery";
 
-type BannerNotificationTarget = "USER" | "STAFF" | "ALL";
 type BannerNotificationListProps = {
   displayAmount?: number;
-  targetList: BannerNotificationTarget[];
   centered?: boolean;
 };
 
@@ -106,12 +104,17 @@ const NotificationsListItem = ({
 /// @param centered {boolean} - whether the notification should be centered when page width exceeds xl-breakpoint
 /// @return A list of banner notifications targeted to the specified targets, ordered by level (EXCEPTION, WARNING, NORMAL)
 /// @desc A component which returns a list of styled banner notifications, clipped at the specified amount, targeted to the specified targets and ordered by level
+/// TODO under testing: can't do target checks to the query because backend doesn't allow querying target without can_manage_notifications permission
 const BannerNotificationsList = ({
   displayAmount = 2,
-  targetList = ["ALL"],
   centered,
 }: BannerNotificationListProps) => {
-  const { data: notificationData } = useQuery<Query>(BANNER_NOTIFICATIONS_LIST);
+  // no-cache is required because admin is caching bannerNotifications query and
+  // there is no key setup for this so this query returns garbage from the admin cache.
+  const { data: notificationData } = useQuery<Query>(
+    BANNER_NOTIFICATIONS_LIST,
+    { fetchPolicy: "no-cache" }
+  );
   const notificationsList =
     notificationData?.bannerNotifications?.edges
       .map((edge) => edge?.node)
@@ -137,12 +140,11 @@ const BannerNotificationsList = ({
     ...alertNotificationsList,
     ...infoNotificationsList,
   ];
-  // Filter out notifications that have been closed by the user, or aren't targeted to them
+  // Filter out notifications that have been closed by the user
   const displayedNotificationsList = groupedNotificationsList.filter(
     (item) =>
       closedNotificationsList != null &&
-      !closedNotificationsList.includes(String(item.id + item.activeFrom)) &&
-      targetList.map((x) => x === item?.target).includes(true)
+      !closedNotificationsList.includes(String(item.id + item.activeFrom))
   );
 
   return (

--- a/packages/common/src/components/BannerNotificationsQuery.ts
+++ b/packages/common/src/components/BannerNotificationsQuery.ts
@@ -1,30 +1,48 @@
 import { gql } from "@apollo/client";
 
-// TODO remove the extras that I added to this query (the UI side)
 export const BANNER_NOTIFICATION_COMMON = gql`
   fragment BannerNotificationCommon on BannerNotificationType {
     level
-    message
     activeFrom
+    message
     messageEn
     messageFi
     messageSv
   }
 `;
 
-export const BANNER_NOTIFICATIONS_ADMIN_LIST = gql`
+// TODO the list fragment doesn't need all the fields
+// it needs only the pk / id, name, target, activeUntil, activeFrom, state
+// so no draft or message*
+const BANNER_NOTIFICATION_ADMIN_FRAGMENT = gql`
   ${BANNER_NOTIFICATION_COMMON}
+  fragment BannerNotificationsAdminFragment on BannerNotificationType {
+    pk
+    ...BannerNotificationCommon
+    target
+    name
+    activeUntil
+    draft
+    state
+  }
+`;
+
+export const BANNER_NOTIFICATIONS_ADMIN = gql`
+  ${BANNER_NOTIFICATION_ADMIN_FRAGMENT}
+  query BannerNotificationsAdmin($id: ID!) {
+    bannerNotification(id: $id) {
+      ...BannerNotificationsAdminFragment
+    }
+  }
+`;
+
+export const BANNER_NOTIFICATIONS_ADMIN_LIST = gql`
+  ${BANNER_NOTIFICATION_ADMIN_FRAGMENT}
   query BannerNotificationsList($first: Int, $offset: Int, $orderBy: String) {
     bannerNotifications(first: $first, offset: $offset, orderBy: $orderBy) {
       edges {
         node {
-          pk
-          ...BannerNotificationCommon
-          target
-          name
-          activeUntil
-          draft
-          state
+          ...BannerNotificationsAdminFragment
         }
       }
       pageInfo {

--- a/packages/common/src/components/BannerNotificationsQuery.ts
+++ b/packages/common/src/components/BannerNotificationsQuery.ts
@@ -3,14 +3,12 @@ import { gql } from "@apollo/client";
 // TODO remove the extras that I added to this query (the UI side)
 export const BANNER_NOTIFICATION_COMMON = gql`
   fragment BannerNotificationCommon on BannerNotificationType {
-    name
     level
     message
     activeFrom
     messageEn
     messageFi
     messageSv
-    target
   }
 `;
 
@@ -22,6 +20,8 @@ export const BANNER_NOTIFICATIONS_ADMIN_LIST = gql`
         node {
           pk
           ...BannerNotificationCommon
+          target
+          name
           activeUntil
           draft
           state

--- a/packages/common/types/gql-types.ts
+++ b/packages/common/types/gql-types.ts
@@ -1728,6 +1728,7 @@ export type Query = {
   applicationEvents?: Maybe<ApplicationEventTypeConnection>;
   applicationRounds?: Maybe<ApplicationRoundTypeConnection>;
   applications?: Maybe<ApplicationTypeConnection>;
+  bannerNotification?: Maybe<BannerNotificationType>;
   bannerNotifications?: Maybe<BannerNotificationTypeConnection>;
   cities?: Maybe<CityTypeConnection>;
   currentUser?: Maybe<UserType>;
@@ -1824,6 +1825,10 @@ export type QueryApplicationsArgs = {
   status?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["ID"]["input"]>>>;
   user?: InputMaybe<Scalars["ID"]["input"]>;
+};
+
+export type QueryBannerNotificationArgs = {
+  id: Scalars["ID"]["input"];
 };
 
 export type QueryBannerNotificationsArgs = {

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -1843,6 +1843,10 @@ type Query {
   cities(offset: Int, before: String, after: String, first: Int, last: Int): CityTypeConnection
   metadataSets(offset: Int, before: String, after: String, first: Int, last: Int): ReservationMetadataSetTypeConnection
   order(orderUuid: String): PaymentOrderType
+  bannerNotification(
+    """The ID of the object"""
+    id: ID!
+  ): BannerNotificationType
   bannerNotifications(
     offset: Int
     before: String
@@ -3224,21 +3228,21 @@ input ReservationUnitCreateMutationInput {
   pricingTerms: String
   paymentTypes: [String]
   pricings: [ReservationUnitPricingCreateSerializerInput]
-  termsOfUseFi: String
-  termsOfUseEn: String
-  termsOfUseSv: String
-  reservationConfirmedInstructionsFi: String
-  reservationConfirmedInstructionsEn: String
-  reservationConfirmedInstructionsSv: String
   descriptionFi: String
   descriptionEn: String
   descriptionSv: String
-  reservationPendingInstructionsFi: String
-  reservationPendingInstructionsEn: String
-  reservationPendingInstructionsSv: String
+  reservationConfirmedInstructionsFi: String
+  reservationConfirmedInstructionsEn: String
+  reservationConfirmedInstructionsSv: String
+  termsOfUseFi: String
+  termsOfUseEn: String
+  termsOfUseSv: String
   reservationCancelledInstructionsFi: String
   reservationCancelledInstructionsEn: String
   reservationCancelledInstructionsSv: String
+  reservationPendingInstructionsFi: String
+  reservationPendingInstructionsEn: String
+  reservationPendingInstructionsSv: String
   nameFi: String
   nameEn: String
   nameSv: String
@@ -3348,21 +3352,21 @@ type ReservationUnitCreateMutationPayload {
   pricingTerms: String
   paymentTypes: [String]
   pricings: [ReservationUnitPricingType]
-  termsOfUseFi: String
-  termsOfUseEn: String
-  termsOfUseSv: String
-  reservationConfirmedInstructionsFi: String
-  reservationConfirmedInstructionsEn: String
-  reservationConfirmedInstructionsSv: String
   descriptionFi: String
   descriptionEn: String
   descriptionSv: String
-  reservationPendingInstructionsFi: String
-  reservationPendingInstructionsEn: String
-  reservationPendingInstructionsSv: String
+  reservationConfirmedInstructionsFi: String
+  reservationConfirmedInstructionsEn: String
+  reservationConfirmedInstructionsSv: String
+  termsOfUseFi: String
+  termsOfUseEn: String
+  termsOfUseSv: String
   reservationCancelledInstructionsFi: String
   reservationCancelledInstructionsEn: String
   reservationCancelledInstructionsSv: String
+  reservationPendingInstructionsFi: String
+  reservationPendingInstructionsEn: String
+  reservationPendingInstructionsSv: String
   nameFi: String
   nameEn: String
   nameSv: String
@@ -3895,21 +3899,21 @@ input ReservationUnitUpdateMutationInput {
   pricingTerms: String
   paymentTypes: [String]
   pricings: [ReservationUnitPricingUpdateSerializerInput]!
-  termsOfUseFi: String
-  termsOfUseEn: String
-  termsOfUseSv: String
-  reservationConfirmedInstructionsFi: String
-  reservationConfirmedInstructionsEn: String
-  reservationConfirmedInstructionsSv: String
   descriptionFi: String
   descriptionEn: String
   descriptionSv: String
-  reservationPendingInstructionsFi: String
-  reservationPendingInstructionsEn: String
-  reservationPendingInstructionsSv: String
+  reservationConfirmedInstructionsFi: String
+  reservationConfirmedInstructionsEn: String
+  reservationConfirmedInstructionsSv: String
+  termsOfUseFi: String
+  termsOfUseEn: String
+  termsOfUseSv: String
   reservationCancelledInstructionsFi: String
   reservationCancelledInstructionsEn: String
   reservationCancelledInstructionsSv: String
+  reservationPendingInstructionsFi: String
+  reservationPendingInstructionsEn: String
+  reservationPendingInstructionsSv: String
   nameFi: String
   nameEn: String
   nameSv: String
@@ -4018,21 +4022,21 @@ type ReservationUnitUpdateMutationPayload {
   state: String
   pricingTerms: String
   paymentTypes: [String]
-  termsOfUseFi: String
-  termsOfUseEn: String
-  termsOfUseSv: String
-  reservationConfirmedInstructionsFi: String
-  reservationConfirmedInstructionsEn: String
-  reservationConfirmedInstructionsSv: String
   descriptionFi: String
   descriptionEn: String
   descriptionSv: String
-  reservationPendingInstructionsFi: String
-  reservationPendingInstructionsEn: String
-  reservationPendingInstructionsSv: String
+  reservationConfirmedInstructionsFi: String
+  reservationConfirmedInstructionsEn: String
+  reservationConfirmedInstructionsSv: String
+  termsOfUseFi: String
+  termsOfUseEn: String
+  termsOfUseSv: String
   reservationCancelledInstructionsFi: String
   reservationCancelledInstructionsEn: String
   reservationCancelledInstructionsSv: String
+  reservationPendingInstructionsFi: String
+  reservationPendingInstructionsEn: String
+  reservationPendingInstructionsSv: String
   nameFi: String
   nameEn: String
   nameSv: String
@@ -4772,15 +4776,15 @@ input UnitUpdateMutationInput {
   webPage: String
   email: String
   phone: String
-  descriptionFi: String
-  descriptionEn: String
-  descriptionSv: String
-  nameFi: String
-  nameEn: String
-  nameSv: String
   shortDescriptionFi: String
   shortDescriptionEn: String
   shortDescriptionSv: String
+  nameFi: String
+  nameEn: String
+  nameSv: String
+  descriptionFi: String
+  descriptionEn: String
+  descriptionSv: String
   clientMutationId: String
 }
 
@@ -4790,15 +4794,15 @@ type UnitUpdateMutationPayload {
   webPage: String
   email: String
   phone: String
-  descriptionFi: String
-  descriptionEn: String
-  descriptionSv: String
-  nameFi: String
-  nameEn: String
-  nameSv: String
   shortDescriptionFi: String
   shortDescriptionEn: String
   shortDescriptionSv: String
+  nameFi: String
+  nameEn: String
+  nameSv: String
+  descriptionFi: String
+  descriptionEn: String
+  descriptionSv: String
 
   """May contain more than one error for same field."""
   errors: [ErrorType]


### PR DESCRIPTION
Fix: notifications query broken for regular users
Add: Apollo caches for admin notification
Fix: Invalidate admin notifications caches when mutated
Fix: form validation schema (dates + times validation)
Fix: update mutation didn't report errors
Fix: styling and translations based on UI review
 