### PR TITLE
Tila 1585: Display notifications correctly

### DIFF
--- a/packages/common/src/components/BannerNotificationsList.tsx
+++ b/packages/common/src/components/BannerNotificationsList.tsx
@@ -56,10 +56,9 @@ const BannerNotificationDate = styled.span`
 const BannerCloseButton = styled.button`
   position: absolute;
   top: var(--spacing-m);
-  right: var(--spacing-m);
+  right: 0;
   transform: translateY(-50%);
   padding: var(--spacing-xs);
-  padding-right: 0;
   background-color: transparent;
   border: none;
   cursor: pointer;

--- a/packages/common/src/components/BannerNotificationsList.tsx
+++ b/packages/common/src/components/BannerNotificationsList.tsx
@@ -42,6 +42,12 @@ const BannerNotificationBackground = styled.div`
 
 const BannerNotificationText = styled.span`
   font-size: var(--fontsize-body-m);
+  p {
+    display: inline;
+  }
+  a {
+    text-decoration: underline;
+  }
   @media (width < ${breakpoints.xl}) {
     padding-right: var(--spacing-l);
   }
@@ -94,9 +100,14 @@ const NotificationsListItem = ({
         {notification.activeFrom && (
           <BannerNotificationDate>{`${displayDate.getDate()}.${displayDate.getMonth()}.`}</BannerNotificationDate>
         )}
-        <BannerNotificationText>
-          {notification && getTranslation(notification, "message")}
-        </BannerNotificationText>
+        {notification && (
+          <BannerNotificationText
+            dangerouslySetInnerHTML={{
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              __html: getTranslation(notification, "message"),
+            }}
+          />
+        )}
         <BannerCloseButton
           onClick={() => handleCloseButtonClick(notification.id ?? "")}
         >

--- a/packages/common/src/components/BannerNotificationsList.tsx
+++ b/packages/common/src/components/BannerNotificationsList.tsx
@@ -98,7 +98,9 @@ const NotificationsListItem = ({
     <BannerNotificationBackground>
       <NotificationWrapper type={notificationType} centered={centered}>
         {notification.activeFrom && (
-          <BannerNotificationDate>{`${displayDate.getDate()}.${displayDate.getMonth()}.`}</BannerNotificationDate>
+          <BannerNotificationDate>
+            {`${displayDate.getDate()}.${displayDate.getMonth() + 1}.`}
+          </BannerNotificationDate>
         )}
         {notification && (
           <BannerNotificationText

--- a/packages/common/src/components/BannerNotificationsList.tsx
+++ b/packages/common/src/components/BannerNotificationsList.tsx
@@ -78,10 +78,10 @@ const NotificationsListItem = ({
   let notificationType: NotificationType = "info" as const;
   switch (notification.level) {
     case "EXCEPTION":
-      notificationType = "alert";
+      notificationType = "error";
       break;
     case "WARNING":
-      notificationType = "error";
+      notificationType = "alert";
       break;
     default:
       notificationType = "info";
@@ -131,10 +131,10 @@ const BannerNotificationsList = ({
 
   // Separate notifications by level
   const errorNotificationsList = notificationsList.filter(
-    (item) => item?.level === "WARNING"
+    (item) => item?.level === "EXCEPTION"
   );
   const alertNotificationsList = notificationsList.filter(
-    (item) => item?.level === "EXCEPTION"
+    (item) => item?.level === "WARNING"
   );
   const infoNotificationsList = notificationsList.filter(
     (item) => item?.level === "NORMAL"


### PR DESCRIPTION
FIxes to the notifications, as requested.

- notification contents displayed as HTML correctly
- close button repositioned
- notification levels fixed, both display/color-wise and the prioritisation of notificatinos
- show correct month (was showing current month - 1)