### PR TITLE
TILA-1585: fix notifications validators, styling, lang

### DIFF
--- a/apps/admin-ui/src/component/notifications/page.tsx
+++ b/apps/admin-ui/src/component/notifications/page.tsx
@@ -43,6 +43,7 @@ import {
   checkValidDate,
   checkValidFutureDate,
   checkTimeStringFormat,
+  checkLengthWithoutHtml,
 } from "app/schemas";
 import {
   valueForDateInput,
@@ -206,8 +207,8 @@ const NotificationFormSchema = z
     activeFromTime: z.string(),
     activeUntil: z.string(),
     activeUntilTime: z.string(),
-    // TODO max length doesn't account for the length of an url real max we want is 500 (without links)
-    messageFi: z.string().min(1).max(1000),
+    // NOTE max length is because backend doesn't allow over 1000 characters
+    messageFi: z.string().max(1000),
     messageEn: z.string().max(1000),
     messageSv: z.string().max(1000),
     // refinement is not empty for these two (not having empty as an option forces a default value)
@@ -220,6 +221,17 @@ const NotificationFormSchema = z
         message: "Level cannot be empty",
       }),
     pk: z.number(),
+  })
+  // strip HTML when validating string length
+  // for now only finnish is mandatory but all have max length
+  .superRefine((x, ctx) => {
+    checkLengthWithoutHtml(x.messageFi, ctx, "messageFi", 1, 500);
+  })
+  .superRefine((x, ctx) => {
+    checkLengthWithoutHtml(x.messageEn, ctx, "messageEn", 0, 500);
+  })
+  .superRefine((x, ctx) => {
+    checkLengthWithoutHtml(x.messageSv, ctx, "messageSv", 0, 500);
   })
   // skip date time validation for drafts if both fields are empty
   // if draft and time or date input validate both (can't construct date without both)

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -1018,6 +1018,15 @@ const translations: ITranslations = {
         "Date needs to be within three years.": [
           "Päivämäärän tulee olla kolmen vuoden sisällä",
         ],
+        "Message cannot be shorter than 1 characters": [
+          "Viesti ei saa olla tyhjä",
+        ],
+        "Message cannot be longer than 500 characters": [
+          "Viesti ei saa olla yli 500 merkkiä",
+        ],
+        "String must contain at most 1000 character(s)": [
+          "Viesti ei saa olla yli 1000 merkkiä",
+        ],
       },
     },
     level: {

--- a/apps/admin-ui/src/schemas/schemaCommon.ts
+++ b/apps/admin-ui/src/schemas/schemaCommon.ts
@@ -99,3 +99,28 @@ export const checkTimeStringFormat = (
     });
   }
 };
+
+export const checkLengthWithoutHtml = (
+  str: string,
+  ctx: z.RefinementCtx,
+  path: string,
+  min?: number,
+  max?: number
+) => {
+  const stripped = str.replaceAll(/<[^>]*>/g, "");
+
+  if (min != null && stripped.length < min) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: `Message cannot be shorter than ${min} characters`,
+    });
+  }
+  if (max != null && stripped.length > max) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [path],
+      message: `Message cannot be longer than ${max} characters`,
+    });
+  }
+};

--- a/packages/common/src/common/util.ts
+++ b/packages/common/src/common/util.ts
@@ -134,14 +134,26 @@ export const sortAgeGroups = (ageGroups: Parameter[]): Parameter[] => {
   });
 };
 
+/// @param options.fallbackLang - use a fallback language instead of returning an empty string
 export const getTranslation = (
   parent: Record<string, unknown>,
-  key: string
+  key: string,
+  options?: {
+    fallbackLang?: "fi" | "sv" | "en";
+  }
 ): string => {
   const keyString = `${key}${capitalize(i18n?.language)}`;
   if (parent && parent[keyString]) {
     if (typeof parent[keyString] === "string") {
       return String(parent[keyString]);
+    }
+  }
+  if (options?.fallbackLang) {
+    const fallbackKeyString = `${key}${capitalize(options.fallbackLang)}`;
+    if (parent && parent[fallbackKeyString]) {
+      if (typeof parent[fallbackKeyString] === "string") {
+        return String(parent[fallbackKeyString]);
+      }
     }
   }
 

--- a/packages/common/src/components/BannerNotificationsList.tsx
+++ b/packages/common/src/components/BannerNotificationsList.tsx
@@ -41,7 +41,7 @@ const BannerNotificationBackground = styled.div`
   }
 `;
 
-const BannerNotificationText = styled.span`
+const BannerNotificationText = styled.div`
   font-size: var(--fontsize-body-m);
   p {
     display: inline;
@@ -89,7 +89,9 @@ const NotificationsListItem = ({
           <BannerNotificationText
             dangerouslySetInnerHTML={{
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              __html: getTranslation(notification, "message"),
+              __html: getTranslation(notification, "message", {
+                fallbackLang: "fi",
+              }),
             }}
           />
         )}


### PR DESCRIPTION
Fix: Admin styling: remove extra bracket.
Fix: UI styling: padding around text so the close button doesn't overlap.
Fix: Admin validators: validate html text content length without tags.
Fix: UI: fallback to Fi translation if the actual translation is missing. 