### PR TITLE
TILA-2812: Fixes the notification z-index and opacity

### DIFF
--- a/apps/admin-ui/src/component/ReservationUnits/ReservationUnitEditor/ReservationUnitEditor.tsx
+++ b/apps/admin-ui/src/component/ReservationUnits/ReservationUnitEditor/ReservationUnitEditor.tsx
@@ -5,7 +5,6 @@ import {
   IconAlertCircleFill,
   IconArrowLeft,
   IconLinkExternal,
-  Notification,
   NumberInput,
   RadioButton,
   SelectionGroup,
@@ -52,7 +51,11 @@ import {
   VerticalFlex,
 } from "../../../styles/layout";
 
-import { ButtonsStripe, WhiteButton } from "../../../styles/util";
+import {
+  ButtonsStripe,
+  StyledNotification,
+  WhiteButton,
+} from "../../../styles/util";
 import Loader from "../../Loader";
 import { useNotification } from "../../../context/NotificationContext";
 import ActivationGroup from "./ActivationGroup";
@@ -574,7 +577,7 @@ const ReservationUnitEditor = (): JSX.Element | null => {
   if (state.error && !state.reservationUnit) {
     return (
       <Wrapper>
-        <Notification
+        <StyledNotification
           type="error"
           label={t("errors.functionFailed")}
           position="top-center"
@@ -585,7 +588,7 @@ const ReservationUnitEditor = (): JSX.Element | null => {
           displayAutoCloseProgress={false}
         >
           {t(state.error.message)}
-        </Notification>
+        </StyledNotification>
       </Wrapper>
     );
   }
@@ -593,7 +596,7 @@ const ReservationUnitEditor = (): JSX.Element | null => {
   if (state.error) {
     return (
       <Wrapper>
-        <Notification
+        <StyledNotification
           type="error"
           label={t("ReservationUnitEditor.errorDataHeading")}
           position="top-center"
@@ -602,7 +605,7 @@ const ReservationUnitEditor = (): JSX.Element | null => {
           onClose={() => dispatch({ type: "clearError" })}
         >
           {t(state.error?.message)}
-        </Notification>
+        </StyledNotification>
       </Wrapper>
     );
   }

--- a/apps/admin-ui/src/component/ReservationUnits/ReservationUnitEditor/ReservationUnitEditor.tsx
+++ b/apps/admin-ui/src/component/ReservationUnits/ReservationUnitEditor/ReservationUnitEditor.tsx
@@ -539,7 +539,8 @@ const ReservationUnitEditor = (): JSX.Element | null => {
                 ? "ReservationUnitEditor.reservationUnitUpdatedNotification"
                 : "ReservationUnitEditor.reservationUnitCreatedNotification",
               { name: state.reservationUnitEdit.nameFi }
-            )
+            ),
+            { autoClose: true }
           );
         } else {
           notifyError("jokin meni pieleen");
@@ -600,6 +601,7 @@ const ReservationUnitEditor = (): JSX.Element | null => {
           type="error"
           label={t("ReservationUnitEditor.errorDataHeading")}
           position="top-center"
+          autoClose={false}
           dismissible
           closeButtonLabelText={t("common.close")}
           onClose={() => dispatch({ type: "clearError" })}

--- a/apps/admin-ui/src/context/NotificationContext.tsx
+++ b/apps/admin-ui/src/context/NotificationContext.tsx
@@ -34,6 +34,7 @@ export const NotificationContext =
 
 export type NotificationOptions = {
   dismissible?: boolean;
+  autoClose?: boolean;
 };
 
 export const useNotification = (): NotificationContextProps =>
@@ -55,11 +56,14 @@ export const NotificationContextProvider: React.FC<Props> = ({
   const showDisappearingNotification = (n: NotificationType) => {
     clearTimeout(cancel);
     setNotification(n);
-    const timeout = setTimeout(() => {
-      setNotification(null);
-    }, 1000 * 5);
-
-    setCancel(timeout);
+    if (n.options.autoClose) {
+      const timeout =
+        n.options.autoClose &&
+        setTimeout(() => {
+          setNotification(null);
+        }, 5 * 1000);
+      setCancel(timeout);
+    }
   };
 
   const notifyError = (

--- a/apps/admin-ui/src/styles/util.ts
+++ b/apps/admin-ui/src/styles/util.ts
@@ -147,7 +147,7 @@ export const InlineRowLink = styled(BasicLink).attrs({
 
 export const StyledHDSNavigation = styled(Navigation)`
   --breakpoint-xl: 9000px;
-  z-index: var(--tilavaraus-admin-stack-main-menu);
+  z-index: var(--tilavaraus-admin-stack-order-toast);
   .btn-logout {
     span {
       margin: 0;
@@ -240,6 +240,7 @@ export const StyledNotification = styled(Notification)`
   z-index: var(--tilavaraus-admin-stack-notification);
   margin: var(--spacing-xs) var(--spacing-layout-2-xs);
   width: auto;
+  opacity: 1 !important;
   @media (min-width: ${breakpoints.xl}) {
     margin: var(--spacing-s) var(--spacing-layout-xl);
   }

--- a/apps/admin-ui/src/styles/util.ts
+++ b/apps/admin-ui/src/styles/util.ts
@@ -147,7 +147,7 @@ export const InlineRowLink = styled(BasicLink).attrs({
 
 export const StyledHDSNavigation = styled(Navigation)`
   --breakpoint-xl: 9000px;
-  z-index: var(--tilavaraus-admin-stack-order-toast);
+  z-index: var(--tilavaraus-admin-stack-main-menu);
   .btn-logout {
     span {
       margin: 0;


### PR DESCRIPTION
Implemented into the StyledNotification component in styles/utils.ts. Also fixed ReservationUnitEditor.tsx, which was using a custom way for to display notifications, where the vanilla HDS Notification component was in use. It now uses the same StyledNotification which should be used throughout (at least until we unite the notifications of both the ui- and admin-ui sides. There might be some other views which have the same issue.