### PR TITLE
One word translation update

### DIFF
--- a/apps/ui/public/locales/en/common.json
+++ b/apps/ui/public/locales/en/common.json
@@ -93,7 +93,7 @@
   "name": "Name",
   "thanksForUsingVaraamo": "Thank you for using Varaamo!",
   "sendFeedback": "Send feedback about the service.",
-  "gotoFrontpage": "Return to front page",
+  "gotoFrontpage": "Back to front page",
   "readMore": "Read more",
   "seeDetails": "See details",
   "minimum": "At least",

--- a/packages/common/src/components/IconButton.tsx
+++ b/packages/common/src/components/IconButton.tsx
@@ -113,7 +113,7 @@ const LinkWrapper = ({ label, icon, href, ...rest }: LinkWrapperProps) =>
   );
 /*
  *  @param {string} label - the button label text (required)
- *  @param {React.ReactNode | null} icon - an HDS-icon element (required, use `null` if no icon is desired)
+ *  @param {React.ReactNode} icon - an HDS-icon element (required)
  *  @param {string} [href] - the link URI (optional) if none is provided, renders a non-link button
  *  @param {boolean} [openInNewTab] - should the link open in a new tab (optional, default true if href begins "http...")
  *  @param {function} [onClick] - a function to execute upon clicking the button (optional)


### PR DESCRIPTION
A minimal update to the translation texts, which I missed. Also removed the reference to using `null` in IconButton @params, as its doesn't have a special meaning anymore. (Not that it _actually_ had one earlier either, since I now know that ReactNode accepts both `null` and `undefined` as valid values. 😅) 
