### PR TITLE
fix (admin): notification toast auto close

### DIFF
--- a/apps/admin-ui/src/component/GlobalElements.tsx
+++ b/apps/admin-ui/src/component/GlobalElements.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { useModal } from "../context/ModalContext";
-import { useNotification } from "../context/NotificationContext";
-import { StyledNotification } from "../styles/util";
+import { Notification } from "hds-react";
+import { useModal } from "@/context/ModalContext";
+import { useNotification } from "@/context/NotificationContext";
 import Modal from "./Modal";
 
 const GlobalElements = (): JSX.Element => {
@@ -20,15 +20,23 @@ const GlobalElements = (): JSX.Element => {
     <>
       {modalContent.content ? modal : null}
       {notification ? (
-        <StyledNotification
+        <Notification
           type={notification.type}
           label={notification.title}
           position="top-center"
           closeButtonLabelText={`${t("common.close")}`}
           onClose={clearNotification}
+          dismissible
+          // NOTE: there is something funny with the HDS notification styling so forcing it
+          // TODO: figure out what is causing this and remove the style override
+          style={{
+            transform: "translate3d(-50%, 0px, 0px)",
+            opacity: 1,
+          }}
+          autoClose={notification.type === "success"}
         >
           {notification.message}
-        </StyledNotification>
+        </Notification>
       ) : null}
     </>
   );

--- a/apps/admin-ui/src/component/ReservationUnits/ReservationUnitEditor/ReservationUnitEditor.tsx
+++ b/apps/admin-ui/src/component/ReservationUnits/ReservationUnitEditor/ReservationUnitEditor.tsx
@@ -539,8 +539,7 @@ const ReservationUnitEditor = (): JSX.Element | null => {
                 ? "ReservationUnitEditor.reservationUnitUpdatedNotification"
                 : "ReservationUnitEditor.reservationUnitCreatedNotification",
               { name: state.reservationUnitEdit.nameFi }
-            ),
-            { autoClose: true }
+            )
           );
         } else {
           notifyError("jokin meni pieleen");

--- a/apps/admin-ui/src/component/Resources/resource-editor/ResourceEditor.tsx
+++ b/apps/admin-ui/src/component/Resources/resource-editor/ResourceEditor.tsx
@@ -181,7 +181,6 @@ const ResourceEditor = ({ resourcePk, unitPk }: Props) => {
       if (data?.updateResource?.errors === null) {
         notifySuccess(
           t("ResourceEditor.resourceUpdatedNotification"),
-          undefined,
           t("ResourceEditor.resourceUpdated")
         );
       } else {

--- a/apps/admin-ui/src/component/Spaces/space-editor/SpaceEditor.tsx
+++ b/apps/admin-ui/src/component/Spaces/space-editor/SpaceEditor.tsx
@@ -17,6 +17,7 @@ import {
   SpaceUpdateMutationPayload,
   UnitType,
 } from "common/types/gql-types";
+import { StyledNotification } from "@/styles/util";
 import { schema } from "./util";
 import { useNotification } from "../../../context/NotificationContext";
 import { SPACE_QUERY, UPDATE_SPACE } from "./queries";
@@ -163,14 +164,6 @@ const reducer = (state: State, action: Action): State => {
 
 const Wrapper = styled.div``;
 
-const StyledNotification = styled(Notification)`
-  margin: var(--spacing-xs) var(--spacing-layout-2-xs);
-  width: auto;
-  @media (min-width: ${breakpoints.xl}) {
-    margin: var(--spacing-s) var(--spacing-layout-xl);
-  }
-`;
-
 const EditorContainer = styled.div`
   margin: 0;
   @media (min-width: ${breakpoints.l}) {
@@ -264,7 +257,6 @@ const SpaceEditor = ({ space, unit }: Props): JSX.Element | null => {
       if (data?.data?.updateSpace.errors === null) {
         notifySuccess(
           t("SpaceEditor.spaceUpdatedNotification"),
-          undefined,
           t("SpaceEditor.spaceUpdated")
         );
         refetch();

--- a/apps/admin-ui/src/component/Unit/SpacesResources.tsx
+++ b/apps/admin-ui/src/component/Unit/SpacesResources.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import { useQuery } from "@apollo/client";
-import { breakpoints } from "common/src/common/style";
 import {
   Query,
   QueryUnitByPkArgs,
@@ -18,12 +17,13 @@ import {
   UnitByPkType,
   UnitType,
 } from "common/types/gql-types";
-import { useModal } from "../../context/ModalContext";
+import { StyledNotification } from "@/styles/util";
+import { useModal } from "@/context/ModalContext";
 import {
   ContentContainer,
   IngressContainer,
   WideContainer,
-} from "../../styles/layout";
+} from "@/styles/layout";
 import Loader from "../Loader";
 import InfoModalContent from "./InfoModalContent";
 import ResourcesTable from "./ResourcesTable";
@@ -132,14 +132,6 @@ const ActionButton = styled(Button)`
     padding: 0;
     color: var(--color-black);
     font-family: var(--tilavaraus-admin-font-bold);
-  }
-`;
-
-const StyledNotification = styled(Notification)`
-  margin: var(--spacing-xs) var(--spacing-layout-2-xs);
-  width: auto;
-  @media (min-width: ${breakpoints.xl}) {
-    margin: var(--spacing-s) var(--spacing-layout-xl);
   }
 `;
 

--- a/apps/admin-ui/src/component/Unit/SpacesTable.tsx
+++ b/apps/admin-ui/src/component/Unit/SpacesTable.tsx
@@ -225,7 +225,6 @@ const SpacesTable = ({
                       ) {
                         notifyError(
                           t("SpaceTable.removeConflictMessage"),
-                          undefined,
                           t("SpaceTable.removeConflictTitle")
                         );
                         return;

--- a/apps/admin-ui/src/component/Unit/Unit.tsx
+++ b/apps/admin-ui/src/component/Unit/Unit.tsx
@@ -7,7 +7,6 @@ import {
   IconLocate,
   IconMap,
   IconPlusCircleFill,
-  Notification,
 } from "hds-react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -21,6 +20,7 @@ import {
   ReservationUnitType,
   UnitByPkType,
 } from "common/types/gql-types";
+import { StyledNotification } from "@/styles/util";
 import { UNIT_QUERY } from "../../common/queries";
 import { parseAddress } from "../../common/util";
 import { useModal } from "../../context/ModalContext";
@@ -91,14 +91,6 @@ const Prop = styled.div<{ $disabled: boolean }>`
   margin-bottom: var(--spacing-xs);
 
   ${({ $disabled }) => $disabled && "opacity: 0.4;"}
-`;
-
-const StyledNotification = styled(Notification)`
-  margin: var(--spacing-xs) var(--spacing-layout-2-xs);
-  width: auto;
-  @media (min-width: ${breakpoints.xl}) {
-    margin: var(--spacing-s) var(--spacing-layout-xl);
-  }
 `;
 
 const HeadingLarge = styled.div`

--- a/apps/admin-ui/src/context/NotificationContext.tsx
+++ b/apps/admin-ui/src/context/NotificationContext.tsx
@@ -3,16 +3,8 @@ import React, { useContext, useMemo } from "react";
 export type NotificationContextProps = {
   notification: NotificationType | null;
   setNotification: (notification: NotificationType) => void;
-  notifyError: (
-    message?: string,
-    options?: NotificationOptions,
-    title?: string
-  ) => void;
-  notifySuccess: (
-    message?: string,
-    options?: NotificationOptions,
-    title?: string
-  ) => void;
+  notifyError: (message?: string, title?: string) => void;
+  notifySuccess: (message?: string, title?: string) => void;
   clearNotification: () => void;
 };
 
@@ -47,56 +39,27 @@ export const NotificationContextProvider: React.FC<Props> = ({
 }: Props) => {
   const [notification, setNotification] =
     React.useState<NotificationType | null>(null);
-  const [cancel, setCancel] = React.useState<NodeJS.Timeout>();
 
   const clearNotification = () => setNotification(null);
 
-  const showDisappearingNotification = (
-    n: NotificationType,
-    options?: NotificationOptions
-  ) => {
-    clearTimeout(cancel);
-    setNotification(n);
-    if (options?.autoClose) {
-      const timeout = setTimeout(() => {
-        setNotification(null);
-      }, 5 * 1000);
-      setCancel(timeout);
-    }
+  const notifyError = (message?: string, title?: string) => {
+    setNotification({
+      type: "error",
+      title,
+      message,
+    });
   };
 
-  const notifyError = (
-    message?: string,
-    options?: NotificationOptions,
-    title?: string
-  ) => {
-    showDisappearingNotification(
-      {
-        type: "error",
-        title,
-        message,
-      },
-      options
-    );
-  };
-
-  const notifySuccess = (
-    message?: string,
-    options?: NotificationOptions,
-    title?: string
-  ) => {
-    showDisappearingNotification(
-      {
-        type: "success",
-        title,
-        message,
-      },
-      options
-    );
+  const notifySuccess = (message?: string, title?: string) => {
+    setNotification({
+      type: "success",
+      title,
+      message,
+    });
   };
 
   const [state] = React.useState({
-    setNotification: showDisappearingNotification,
+    setNotification,
     clearNotification,
     notifyError,
     notifySuccess,

--- a/apps/admin-ui/src/styles/util.ts
+++ b/apps/admin-ui/src/styles/util.ts
@@ -236,10 +236,10 @@ export const WhiteButton = styled(Button)<{
   margin: 0;
 `;
 
+/// @deprecated use Notification context instead
 export const StyledNotification = styled(Notification)`
   z-index: var(--tilavaraus-admin-stack-notification);
   margin: var(--spacing-xs) var(--spacing-layout-2-xs);
-  width: auto;
   opacity: 1 !important;
   @media (min-width: ${breakpoints.xl}) {
     margin: var(--spacing-s) var(--spacing-layout-xl);

--- a/apps/admin-ui/src/variables.css
+++ b/apps/admin-ui/src/variables.css
@@ -65,3 +65,8 @@
   --tilavaraus-event-booking-internal-border: var(--color-bus-dark);
   --tilavaraus-event-booking-closed-border: var(--color-black);
 }
+
+/* override HDS variables */
+* {
+  --notification-z-index-toast: var(--tilavaraus-admin-stack-notification) !important;
+}


### PR DESCRIPTION
Fix autoClose / dismissable toasts that got broken because of previous changes.
Remove unused autoClose override settings.
Remove custom autoClose using a timer (use the one in HDS instead).
All toasts are dismissable.
Success toasts are auto closed, error toasts are not.