### PR TITLE
fix: protected route error translations

### DIFF
--- a/apps/ui/components/reservation-unit/ReservationInfoContainer.tsx
+++ b/apps/ui/components/reservation-unit/ReservationInfoContainer.tsx
@@ -2,7 +2,7 @@ import { formatSecondDuration } from "common/src/common/util";
 import { ReservationUnitByPkType } from "common/types/gql-types";
 import ClientOnly from "common/src/ClientOnly";
 import React, { useMemo } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "next-i18next";
 import { daysByMonths } from "../../modules/const";
 import { formatDate } from "../../modules/util";
 import { Content, Subheading } from "./ReservationUnitStyles";

--- a/apps/ui/components/reservation/DeleteCancelled.tsx
+++ b/apps/ui/components/reservation/DeleteCancelled.tsx
@@ -1,7 +1,7 @@
 import { breakpoints } from "common/src/common/style";
 import { H2, fontMedium } from "common/src/common/typography";
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import Link from "next/link";
 import { IconArrowRight, IconSignout } from "hds-react";

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -23,7 +23,7 @@ import classNames from "classnames";
 import { IconArrowRight, IconCross } from "hds-react";
 import { useRouter } from "next/router";
 import React, { Children, useCallback, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { useMedia } from "react-use";
 import styled from "styled-components";
 import { Toolbar } from "common/src/calendar/Toolbar";

--- a/apps/ui/components/reservation/ReservationFail.tsx
+++ b/apps/ui/components/reservation/ReservationFail.tsx
@@ -3,7 +3,7 @@ import { fontMedium, H2 } from "common/src/common/typography";
 import { IconArrowRight, IconSignout } from "hds-react";
 import Link from "next/link";
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { Container } from "common";
 import { signOut } from "~/hooks/auth";

--- a/apps/ui/components/reservations/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/reservations/UnpaidReservationNotification.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useRouter } from "next/router";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { breakpoints } from "common/src/common/style";
 import { ReservationsReservationStateChoices } from "common/types/gql-types";

--- a/apps/ui/pages/reservation/cancel.tsx
+++ b/apps/ui/pages/reservation/cancel.tsx
@@ -5,7 +5,7 @@ import React, { useEffect } from "react";
 import { breakpoints } from "common/src/common/style";
 import { LoadingSpinner } from "hds-react";
 import styled from "styled-components";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { Container } from "common";
 import { useSession } from "@/hooks/auth";
 import { redirectProtectedRoute } from "@/modules/protectedRoute";

--- a/apps/ui/pages/reservation/confirmation/[id].tsx
+++ b/apps/ui/pages/reservation/confirmation/[id].tsx
@@ -6,7 +6,7 @@ import { Query, QueryReservationByPkArgs } from "common/types/gql-types";
 import { LoadingSpinner } from "hds-react";
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { Container } from "common";
 import { redirectProtectedRoute } from "@/modules/protectedRoute";

--- a/apps/ui/pages/reservations/[...params].tsx
+++ b/apps/ui/pages/reservations/[...params].tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { GetServerSideProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { isFinite } from "lodash";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { useSession } from "@/hooks/auth";
 import { redirectProtectedRoute } from "@/modules/protectedRoute";
 import ReservationCancellation from "../../components/reservation/ReservationCancellation";

--- a/apps/ui/pages/success.tsx
+++ b/apps/ui/pages/success.tsx
@@ -7,7 +7,7 @@ import { breakpoints } from "common/src/common/style";
 import { ReservationsReservationStateChoices } from "common/types/gql-types";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { Container } from "common";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { useSession } from "@/hooks/auth";
 import { useOrder, useReservation } from "@/hooks/reservation";
 import ReservationFail from "@/components/reservation/ReservationFail";
@@ -44,6 +44,7 @@ const StyledContainer = styled(Container)`
 const ReservationSuccess = () => {
   const { isAuthenticated } = useSession();
   const router = useRouter();
+  const { t } = useTranslation(["common"]);
   const { orderId } = router.query as { orderId: string };
 
   const [isReservationInvalid, setIsReservationInvalid] =
@@ -123,8 +124,6 @@ const ReservationSuccess = () => {
         router.replace(`/reservation/confirmation/${reservation.pk}`);
     }
   }, [orderId, reservation, router, isOrderValid, reservationError]);
-
-  const { t } = useTranslation("common");
 
   // NOTE Should never end up here (SSR redirect to login)
   if (!isAuthenticated) {

--- a/apps/ui/public/locales/en/common.json
+++ b/apps/ui/public/locales/en/common.json
@@ -50,6 +50,7 @@
   "error": {
     "dataError": "Information could not be retrieved",
     "error": "Error",
+    "notAuthenticated": "Please login first",
     "closeErrorMsg": "Close error message"
   },
   "applicationNavigationName": "Application",

--- a/apps/ui/public/locales/en/errors.json
+++ b/apps/ui/public/locales/en/errors.json
@@ -5,7 +5,6 @@
   "500": {
     "body": "Something unexpected happened"
   },
-  "notAuthenticated": "Please login first",
   "general_error": "Undefined error.",
   "RESERVATION_UNIT_NOT_RESERVABLE": "The item cannot be booked.",
   "OVERLAPPING_RESERVATIONS": "There are duplicate bookings.",

--- a/apps/ui/public/locales/fi/common.json
+++ b/apps/ui/public/locales/fi/common.json
@@ -50,6 +50,7 @@
   "error": {
     "dataError": "Tietoja ei saatu haettua",
     "error": "Virhe",
+    "notAuthenticated": "Kirjaudu sisään ensin",
     "closeErrorMsg": "Sulje virheilmoitus"
   },
   "applicationNavigationName": "Hakemus",

--- a/apps/ui/public/locales/fi/errors.json
+++ b/apps/ui/public/locales/fi/errors.json
@@ -5,7 +5,6 @@
   "500": {
     "body": "Jotain meni pieleen"
   },
-  "notAuthenticated": "Kirjaudu sisään ensin",
   "general_error": "Tapahtui määrittämätön virhe.",
   "RESERVATION_UNIT_NOT_RESERVABLE": "Kohde ei ole varattavissa.",
   "OVERLAPPING_RESERVATIONS": "Päällekkäisiä varauksia.",

--- a/apps/ui/public/locales/sv/common.json
+++ b/apps/ui/public/locales/sv/common.json
@@ -50,6 +50,7 @@
   "error": {
     "dataError": "Uppgifterna hittades inte",
     "error": "Fel",
+    "notAuthenticated": "Var god och logga in.",
     "closeErrorMsg": "Stäng felmeddelandet"
   },
   "applicationNavigationName": "Ansökan",

--- a/apps/ui/public/locales/sv/errors.json
+++ b/apps/ui/public/locales/sv/errors.json
@@ -5,7 +5,6 @@
   "500": {
     "body": "Något oväntat hände"
   },
-  "notAuthenticated": "Var god och logga in.",
   "general_error": "Odefinierat fel.",
   "RESERVATION_UNIT_NOT_RESERVABLE": "Objektet går inte att boka.",
   "OVERLAPPING_RESERVATIONS": "Överlappande bokningar.",


### PR DESCRIPTION
Use common for errors for now.
Load translations in SSR automatically with next-i18next.