### PR TITLE
TILA-2890: Adds type-filter to own reservations gql queries

### DIFF
--- a/apps/ui/components/reservation/ReservationEdit.tsx
+++ b/apps/ui/components/reservation/ReservationEdit.tsx
@@ -263,6 +263,7 @@ const ReservationEdit = ({ id }: Props): JSX.Element => {
         user: currentUser?.pk?.toString(),
         reservationUnit: [reservationUnit?.pk?.toString() ?? ""],
         state: allowedReservationStates,
+        type: ReservationsReservationStateChoices.Normal,
       },
     }
   );

--- a/apps/ui/hooks/reservation.tsx
+++ b/apps/ui/hooks/reservation.tsx
@@ -12,7 +12,7 @@ import {
   ReservationDeleteMutationPayload,
   ReservationType,
   ReservationsReservationStateChoices,
-  UserType,
+  UserType, ReservationsReservationTypeChoices,
 } from "common/types/gql-types";
 import {
   DELETE_RESERVATION,
@@ -140,12 +140,14 @@ type UseReservationsProps = {
   currentUser?: UserType;
   states?: ReservationsReservationStateChoices[];
   orderBy?: string;
+  type?: ReservationsReservationTypeChoices;
 };
 
 export const useReservations = ({
   currentUser,
   states,
   orderBy,
+  type,
 }: UseReservationsProps): {
   reservations: ReservationType[];
   error?: ApolloError;
@@ -158,6 +160,7 @@ export const useReservations = ({
       variables: {
         ...(states != null && states?.length > 0 && { state: states }),
         ...(orderBy && { orderBy }),
+        ...(type && { type }),
         user: currentUser?.pk?.toString(),
       },
       fetchPolicy: "no-cache",

--- a/apps/ui/modules/queries/reservation.ts
+++ b/apps/ui/modules/queries/reservation.ts
@@ -117,6 +117,7 @@ export const LIST_RESERVATIONS = gql`
     $end: DateTime
     $state: [String]
     $user: ID
+    $type: ReservationsReservationReserveeTypeChoices
     $reservationUnit: [ID]
     $orderBy: String
   ) {
@@ -129,6 +130,7 @@ export const LIST_RESERVATIONS = gql`
       end: $end
       state: $state
       user: $user
+      type: $type
       reservationUnit: $reservationUnit
       orderBy: $orderBy
     ) {

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -460,6 +460,7 @@ const ReservationUnit = ({
         user: currentUser?.pk?.toString(),
         reservationUnit: [reservationUnit?.pk?.toString() ?? ""],
         state: allowedReservationStates,
+        type: ReservationsReservationTypeChoices.Normal,
       },
     }
   );

--- a/apps/ui/pages/reservations/index.tsx
+++ b/apps/ui/pages/reservations/index.tsx
@@ -12,7 +12,7 @@ import { breakpoints } from "common/src/common/style";
 import {
   Query,
   QueryReservationsArgs,
-  ReservationsReservationStateChoices,
+  ReservationsReservationStateChoices, ReservationsReservationTypeChoices,
   ReservationType,
 } from "common/types/gql-types";
 import { Container } from "common";
@@ -114,6 +114,7 @@ const Reservations = (): JSX.Element | null => {
       ],
       orderBy: "-begin",
       user: currentUser?.pk?.toString(),
+      type: ReservationsReservationTypeChoices.Normal,
     },
     fetchPolicy: "no-cache",
   });


### PR DESCRIPTION
This requires the backend to handle `type` as an argument for LIST_RESERVATIONS gql-query.
Breaks LIST_RESERVATIONS with the current backend, so can't be merged until then there is backend support for `type`