### PR TITLE
TILA-2893: adds type to own reservations gql queries

### DIFF
--- a/apps/ui/components/reservation/ReservationEdit.tsx
+++ b/apps/ui/components/reservation/ReservationEdit.tsx
@@ -9,6 +9,7 @@ import {
   ReservationAdjustTimeMutationInput,
   ReservationAdjustTimeMutationPayload,
   ReservationsReservationStateChoices,
+  ReservationsReservationTypeChoices,
   ReservationType,
   ReservationUnitByPkType,
   ReservationUnitByPkTypeOpeningHoursArgs,
@@ -38,8 +39,8 @@ import { getTranslation } from "../../modules/util";
 import Sanitize from "../common/Sanitize";
 import ReservationInfoCard from "./ReservationInfoCard";
 import {
-  RESERVATION_UNIT,
   OPENING_HOURS,
+  RESERVATION_UNIT,
 } from "../../modules/queries/reservationUnit";
 import { mockOpeningTimes } from "../../modules/reservationUnit";
 import EditStep0 from "./EditStep0";
@@ -257,7 +258,6 @@ const ReservationEdit = ({ id }: Props): JSX.Element => {
         user: currentUser?.pk?.toString(),
         reservationUnit: [reservationUnit?.pk?.toString() ?? ""],
         state: allowedReservationStates,
-        type: ReservationsReservationStateChoices.Normal,
       },
     }
   );
@@ -265,7 +265,10 @@ const ReservationEdit = ({ id }: Props): JSX.Element => {
   useEffect(() => {
     const reservations = userReservationsData?.reservations?.edges
       ?.map((e) => e?.node)
-      .filter((n): n is ReservationType => n != null)
+      .filter(
+        (n): n is ReservationType =>
+          n != null && n.type === ReservationsReservationTypeChoices.Normal
+      )
       .filter((n) => allowedReservationStates.includes(n.state));
     setUserReservations(reservations || []);
   }, [userReservationsData]);

--- a/apps/ui/components/reservation/ReservationEdit.tsx
+++ b/apps/ui/components/reservation/ReservationEdit.tsx
@@ -257,6 +257,7 @@ const ReservationEdit = ({ id }: Props): JSX.Element => {
         user: currentUser?.pk?.toString(),
         reservationUnit: [reservationUnit?.pk?.toString() ?? ""],
         state: allowedReservationStates,
+        type: ReservationsReservationStateChoices.Normal,
       },
     }
   );

--- a/apps/ui/components/reservations/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/reservations/UnpaidReservationNotification.tsx
@@ -3,7 +3,10 @@ import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { breakpoints } from "common/src/common/style";
-import { ReservationsReservationStateChoices } from "common/types/gql-types";
+import {
+  ReservationsReservationStateChoices,
+  ReservationsReservationTypeChoices,
+} from "common/types/gql-types";
 import NotificationWrapper from "common/src/components/NotificationWrapper";
 import { useCurrentUser } from "@/hooks/user";
 import { BlackButton, Toast } from "@/styles/util";
@@ -46,7 +49,9 @@ const ReservationNotification = () => {
   });
 
   const reservation = reservations?.find(
-    (r) => r.state === ReservationsReservationStateChoices.WaitingForPayment
+    (r) =>
+      r.state === ReservationsReservationStateChoices.WaitingForPayment &&
+      r.type === ReservationsReservationTypeChoices.Normal
   );
 
   const { order } = useOrder({

--- a/apps/ui/hooks/reservation.tsx
+++ b/apps/ui/hooks/reservation.tsx
@@ -12,7 +12,7 @@ import {
   ReservationDeleteMutationPayload,
   ReservationType,
   ReservationsReservationStateChoices,
-  UserType,
+  UserType, ReservationsReservationTypeChoices,
 } from "common/types/gql-types";
 import {
   DELETE_RESERVATION,
@@ -140,12 +140,14 @@ type UseReservationsProps = {
   currentUser?: UserType;
   states?: ReservationsReservationStateChoices[];
   orderBy?: string;
+  type?: ReservationsReservationTypeChoices;
 };
 
 export const useReservations = ({
   currentUser,
   states,
   orderBy,
+  type,
 }: UseReservationsProps): {
   reservations: ReservationType[];
   error?: ApolloError;
@@ -158,6 +160,7 @@ export const useReservations = ({
       variables: {
         ...(states != null && states?.length > 0 && { state: states }),
         ...(orderBy && { orderBy }),
+        ...(type && { type }),
         user: currentUser?.pk?.toString(),
       },
       fetchPolicy: "no-cache",

--- a/apps/ui/modules/queries/reservation.ts
+++ b/apps/ui/modules/queries/reservation.ts
@@ -117,7 +117,6 @@ export const LIST_RESERVATIONS = gql`
     $end: DateTime
     $state: [String]
     $user: ID
-    $type: ReservationsReservationReserveeTypeChoices
     $reservationUnit: [ID]
     $orderBy: String
   ) {
@@ -130,7 +129,6 @@ export const LIST_RESERVATIONS = gql`
       end: $end
       state: $state
       user: $user
-      type: $type
       reservationUnit: $reservationUnit
       orderBy: $orderBy
     ) {
@@ -146,6 +144,7 @@ export const LIST_RESERVATIONS = gql`
           bufferTimeAfter
           orderUuid
           isBlocked
+          type
           reservationUnits {
             pk
             nameFi

--- a/apps/ui/modules/queries/reservation.ts
+++ b/apps/ui/modules/queries/reservation.ts
@@ -117,6 +117,7 @@ export const LIST_RESERVATIONS = gql`
     $end: DateTime
     $state: [String]
     $user: ID
+    $type: ReservationsReservationReserveeTypeChoices
     $reservationUnit: [ID]
     $orderBy: String
   ) {
@@ -129,6 +130,7 @@ export const LIST_RESERVATIONS = gql`
       end: $end
       state: $state
       user: $user
+      type: $type
       reservationUnit: $reservationUnit
       orderBy: $orderBy
     ) {

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -21,15 +21,15 @@ import {
 } from "date-fns";
 import { toApiDate, toUIDate } from "common/src/common/util";
 import {
-  RoundPeriod,
   getEventBuffers,
   getNewReservation,
   getSlotPropGetter,
   getTimeslots,
   isReservationStartInFuture,
   isReservationUnitReservable,
+  RoundPeriod,
 } from "common/src/calendar/util";
-import { formatters as getFormatters, Container } from "common";
+import { Container, formatters as getFormatters } from "common";
 import { useLocalStorage, useMedia, useSessionStorage } from "react-use";
 import { breakpoints } from "common/src/common/style";
 import Calendar, { CalendarEvent } from "common/src/calendar/Calendar";
@@ -48,6 +48,7 @@ import {
   ReservationCreateMutationInput,
   ReservationCreateMutationPayload,
   ReservationsReservationStateChoices,
+  ReservationsReservationTypeChoices,
   ReservationType,
   ReservationUnitByPkType,
   ReservationUnitByPkTypeOpeningHoursArgs,
@@ -504,7 +505,7 @@ const ReservationUnit = ({
         user: currentUser?.pk?.toString(),
         reservationUnit: [reservationUnit?.pk?.toString() ?? ""],
         state: allowedReservationStates,
-        type: ReservationsReservationTypeChoices.Normal,
+        reservationType: ["NORMAL"],
       },
     }
   );
@@ -513,7 +514,9 @@ const ReservationUnit = ({
     const reservations = filterNonNullable(
       userReservationsData?.reservations?.edges?.map((e) => e?.node)
     ).filter(
-      (n) => allowedReservationStates.find((s) => s === n.state) != null
+      (n) =>
+        allowedReservationStates.find((s) => s === n.state) != null &&
+        n.type === ReservationsReservationTypeChoices.Normal
     );
     setUserReservations(reservations || []);
   }, [userReservationsData]);

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -504,6 +504,7 @@ const ReservationUnit = ({
         user: currentUser?.pk?.toString(),
         reservationUnit: [reservationUnit?.pk?.toString() ?? ""],
         state: allowedReservationStates,
+        type: ReservationsReservationTypeChoices.Normal,
       },
     }
   );

--- a/apps/ui/pages/reservations/index.tsx
+++ b/apps/ui/pages/reservations/index.tsx
@@ -12,7 +12,7 @@ import { breakpoints } from "common/src/common/style";
 import {
   Query,
   QueryReservationsArgs,
-  ReservationsReservationStateChoices,
+  ReservationsReservationStateChoices, ReservationsReservationTypeChoices,
   ReservationType,
 } from "common/types/gql-types";
 import { Container } from "common";
@@ -114,6 +114,7 @@ const Reservations = (): JSX.Element | null => {
       ],
       orderBy: "-begin",
       user: currentUser?.pk?.toString(),
+      type: ReservationsReservationTypeChoices.Normal,
     },
     fetchPolicy: "no-cache",
   });

--- a/apps/ui/pages/reservations/index.tsx
+++ b/apps/ui/pages/reservations/index.tsx
@@ -12,7 +12,8 @@ import { breakpoints } from "common/src/common/style";
 import {
   Query,
   QueryReservationsArgs,
-  ReservationsReservationStateChoices, ReservationsReservationTypeChoices,
+  ReservationsReservationStateChoices,
+  ReservationsReservationTypeChoices,
   ReservationType,
 } from "common/types/gql-types";
 import { Container } from "common";
@@ -114,7 +115,6 @@ const Reservations = (): JSX.Element | null => {
       ],
       orderBy: "-begin",
       user: currentUser?.pk?.toString(),
-      type: ReservationsReservationTypeChoices.Normal,
     },
     fetchPolicy: "no-cache",
   });
@@ -123,7 +123,11 @@ const Reservations = (): JSX.Element | null => {
     const reservations =
       reservationData?.reservations?.edges
         ?.map((edge) => edge?.node)
-        .filter((reservation): reservation is ReservationType => !!reservation)
+        .filter(
+          (reservation): reservation is ReservationType =>
+            !!reservation &&
+            reservation.type === ReservationsReservationTypeChoices.Normal
+        )
         .reduce(
           (acc, reservation) => {
             if (


### PR DESCRIPTION
Checks that `reservation.type` is `ReservationsReservationTypeChoices.Normal` in the listings mentioned in TILA-2893.