### PR TITLE
fix: navigation dropdown doesn't go outside the page

### DIFF
--- a/apps/ui/components/common/Navigation/NavigationUserMenu/NavigationUserMenu.tsx
+++ b/apps/ui/components/common/Navigation/NavigationUserMenu/NavigationUserMenu.tsx
@@ -11,10 +11,12 @@ const StyledUserMenu = styled(HDSNavigation.User)<{
   $active?: boolean;
 }>`
   @media (min-width: ${(props) => props.theme.spacing.m}) {
+    /* stylelint-disable -- Using HDS naming convention to overwrite styles */
     #userDropdown-menu {
       left: auto;
       right: 0;
     }
+    /* stylelint-enable */
   }
   ${({ $active }) =>
     $active &&

--- a/apps/ui/components/common/Navigation/NavigationUserMenu/NavigationUserMenu.tsx
+++ b/apps/ui/components/common/Navigation/NavigationUserMenu/NavigationUserMenu.tsx
@@ -10,6 +10,12 @@ import { MenuItem } from "../types";
 const StyledUserMenu = styled(HDSNavigation.User)<{
   $active?: boolean;
 }>`
+  @media (min-width: ${(props) => props.theme.spacing.m}) {
+    #userDropdown-menu {
+      left: auto;
+      right: 0;
+    }
+  }
   ${({ $active }) =>
     $active &&
     css`


### PR DESCRIPTION
- aligns the navigation dropdown to the button's right edge instead of left
- doesn't touch mobile styles

Ref: TILA-2819