### PR TITLE
Hide time-filters and showOnlyAvailable-checkbox

### DIFF
--- a/apps/ui/components/single-search/FilterTagList.tsx
+++ b/apps/ui/components/single-search/FilterTagList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { Tag } from "hds-react";
+import { omit } from "lodash";
 
 type FilterTagProps = {
   formValueKeys: string[];
@@ -136,7 +137,7 @@ const FilterTagList = ({
             </StyledTag>
           );
         })}
-      {formValueKeys.length > 0 && (
+      {omit(formValueKeys, "showOnlyAvailable").length > 0 && (
         <ResetButton
           onClick={() => removeValue && removeValue()}
           onDelete={() => removeValue && removeValue()}

--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -316,6 +316,7 @@ const SearchForm = ({
     maxPersons: "",
     reservationUnitType: "",
     showOnlyAvailable: true,
+    textSearch: "",
   };
 
   const { register, watch, handleSubmit, setValue, getValues, control } =

--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -95,6 +95,8 @@ const StyledSelect = styled(Select<OptionType>)`
 
 const StyledCheckBox = styled(Checkbox)`
   &&& {
+    /* TODO: Remove the following style declaration once backend supports showing only available results */
+    display: none !important;
     @media (min-width: ${breakpoints.m}) {
       margin-top: -70px;
       grid-column: 3 / span 1;
@@ -433,66 +435,71 @@ const SearchForm = ({
             title={t("searchForm:equipmentsFilter")}
             value={watch("equipments")?.split(",") || [""]}
           />
-          <DateRangeWrapper>
-            <DateRangePicker
-              startDate={fromUIDate(String(getValues("dateBegin")))}
-              endDate={fromUIDate(String(getValues("dateEnd")))}
-              onChangeStartDate={(date: Date | null) =>
-                setValue("dateBegin", date != null ? toUIDate(date) : "")
-              }
-              onChangeEndDate={(date: Date | null) =>
-                setValue("dateEnd", date != null ? toUIDate(date) : "")
-              }
-              labels={{
-                begin: t("searchForm:dateFilter"),
-                end: " ",
-              }}
-              required={{ begin: false, end: false }}
-              limits={{
-                startMinDate: new Date(),
-                startMaxDate: getValues("dateEnd")
-                  ? fromUIDate(String(getValues("dateEnd")))
-                  : undefined,
-                endMinDate: getValues("dateBegin")
-                  ? fromUIDate(String(getValues("dateBegin")))
-                  : undefined,
-                endMaxDate: addYears(new Date(), 2),
-              }}
-            />
-          </DateRangeWrapper>
+          {/* TODO: Remove the following div once backend supports time-related filters */}
+          <div style={{ display: "none" }}>
+            <DateRangeWrapper>
+              <DateRangePicker
+                startDate={fromUIDate(String(getValues("dateBegin")))}
+                endDate={fromUIDate(String(getValues("dateEnd")))}
+                onChangeStartDate={(date: Date | null) =>
+                  setValue("dateBegin", date != null ? toUIDate(date) : "")
+                }
+                onChangeEndDate={(date: Date | null) =>
+                  setValue("dateEnd", date != null ? toUIDate(date) : "")
+                }
+                labels={{
+                  begin: t("searchForm:dateFilter"),
+                  end: " ",
+                }}
+                required={{ begin: false, end: false }}
+                limits={{
+                  startMinDate: new Date(),
+                  startMaxDate: getValues("dateEnd")
+                    ? fromUIDate(String(getValues("dateEnd")))
+                    : undefined,
+                  endMinDate: getValues("dateBegin")
+                    ? fromUIDate(String(getValues("dateBegin")))
+                    : undefined,
+                  endMaxDate: addYears(new Date(), 2),
+                }}
+              />
+            </DateRangeWrapper>
 
-          <TimeRangeWrapper>
-            <TimeRangePicker
-              control={control}
-              name={{ begin: "timeBegin", end: "timeEnd" }}
-              label={{ begin: t("searchForm:timeFilter"), end: " " }}
-              placeholder={{
-                begin: t("common:beginLabel"),
-                end: t("common:endLabel"),
-              }}
-              clearable={{ begin: true, end: true }}
-            />
-          </TimeRangeWrapper>
+            <TimeRangeWrapper>
+              <TimeRangePicker
+                control={control}
+                name={{ begin: "timeBegin", end: "timeEnd" }}
+                label={{ begin: t("searchForm:timeFilter"), end: " " }}
+                placeholder={{
+                  begin: t("common:beginLabel"),
+                  end: t("common:endLabel"),
+                }}
+                clearable={{ begin: true, end: true }}
+              />
+            </TimeRangeWrapper>
 
-          <StyledSelect
-            id="durationFilter"
-            placeholder={t("common:minimum")}
-            options={[emptyOption(t("common:minimum"))].concat(durationOptions)}
-            label={t("searchForm:durationFilter", { duration: "" })}
-            onChange={(selection: OptionType): void => {
-              setValue(
-                "duration",
-                !Number.isNaN(Number(selection.value))
-                  ? Math.round(Number(selection.value) * 10) / 10
-                  : null
-              );
-            }}
-            defaultValue={getSelectedOption(
-              getValues("duration"),
-              durationOptions
-            )}
-            key={`duration${getValues("duration")}`}
-          />
+            <StyledSelect
+              id="durationFilter"
+              placeholder={t("common:minimum")}
+              options={[emptyOption(t("common:minimum"))].concat(
+                durationOptions
+              )}
+              label={t("searchForm:durationFilter", { duration: "" })}
+              onChange={(selection: OptionType): void => {
+                setValue(
+                  "duration",
+                  !Number.isNaN(Number(selection.value))
+                    ? Math.round(Number(selection.value) * 10) / 10
+                    : null
+                );
+              }}
+              defaultValue={getSelectedOption(
+                getValues("duration"),
+                durationOptions
+              )}
+              key={`duration${getValues("duration")}`}
+            />
+          </div>
 
           <OptionalFilters
             showAllLabel={t("searchForm:showMoreFilters")}

--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -505,6 +505,7 @@ const SearchForm = ({
             showAllLabel={t("searchForm:showMoreFilters")}
             showLessLabel={t("searchForm:showLessFilters")}
             maximumNumber={0}
+            data-testid="search-form__filters--optional"
             initiallyOpen={
               formValues.reservationUnitType != null ||
               formValues.minPersons != null ||


### PR DESCRIPTION
Hides the time related search filters (date/timeBegin, date/timeEnd and duration), as well as the showOnlyAvailable checkbox - as they aren't yet supported by the backend.

Also:
- fixes textSearch showing "undefined" as value on initial pageload
- doesn't show the empty button in the filter tag list, if showOnlyAvailable is the only search parameter (this might be needed for dateBegin in the future too, as it is "on by default" (=== no searches into the past))