### PR TITLE
fix: don't show units without permissions

### DIFF
--- a/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
@@ -20,6 +20,8 @@ import { useNotification } from "@/context/NotificationContext";
 import { useAllocationContext } from "@/context/AllocationContext";
 import Loader from "@/component/Loader";
 import LinkPrev from "@/component/LinkPrev";
+import usePermission from "@/hooks/usePermission";
+import { Permission } from "@/modules/permissionHelper";
 import { APPLICATIONS_BY_APPLICATION_ROUND_QUERY } from "../queries";
 import { getFilteredApplicationEvents } from "./modules/applicationRoundAllocation";
 import { ApplicationEvents } from "./ApplicationEvents";
@@ -95,7 +97,10 @@ function ApplicationRoundAllocation({
       )
     )
   );
-  const units = uniqBy(unitData, "pk");
+  const { hasUnitPermission } = usePermission();
+  const units = uniqBy(unitData, "pk").filter((unit) =>
+    hasUnitPermission(Permission.CAN_VALIDATE_APPLICATIONS, unit)
+  );
 
   const unitOptions = units.map((unit) => ({
     value: unit.pk ?? 0,

--- a/apps/admin-ui/src/hooks/usePermission.ts
+++ b/apps/admin-ui/src/hooks/usePermission.ts
@@ -1,11 +1,38 @@
 import { useSession } from "app/hooks/auth";
-import { type ReservationType, type UserType } from "common/types/gql-types";
+import {
+  UnitType,
+  type ReservationType,
+  type UserType,
+} from "common/types/gql-types";
 import {
   hasPermission as baseHasPermission,
   hasSomePermission as baseHasSomePermission,
   hasAnyPermission as baseHasAnyPermission,
   Permission,
 } from "app/modules/permissionHelper";
+
+const hasUnitPermission = (
+  user: UserType | undefined,
+  permissionName: Permission,
+  unit: UnitType | undefined
+): boolean => {
+  if (user == null || unit?.pk == null) {
+    return false;
+  }
+
+  const serviceSectorPks =
+    unit?.serviceSectors
+      ?.map((x) => x?.pk)
+      ?.filter((x): x is number => x != null) ?? [];
+
+  const permission = baseHasPermission(user)(
+    permissionName,
+    unit.pk,
+    serviceSectorPks
+  );
+
+  return permission;
+};
 
 const hasPermission = (
   user: UserType | undefined,
@@ -64,6 +91,8 @@ const usePermission = () => {
     ) => hasPermission(user, reservation, permissionName, includeOwn),
     hasSomePermission,
     hasAnyPermission,
+    hasUnitPermission: (permission: Permission, unit: UnitType) =>
+      hasUnitPermission(user, permission, unit),
   };
 };
 


### PR DESCRIPTION
Filter out units that the user is not supposed to see after the query, these are returned on purpose for other functionaility but should not be displayed in the ui.

Refs: TILA-2507