### PR TITLE
fix: calendar day localization

### DIFF
--- a/apps/ui/components/application/ApplicationEvent.tsx
+++ b/apps/ui/components/application/ApplicationEvent.tsx
@@ -5,11 +5,12 @@ import { Checkbox, DateInput, NumberInput, Select, TextInput } from "hds-react";
 import { useTranslation } from "next-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import styled from "styled-components";
-import { LocalizationLanguages, OptionType } from "common/types/common";
+import { OptionType } from "common/types/common";
 import type { ApplicationRoundNode } from "common/types/gql-types";
 import { fontRegular, H5 } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import { CheckboxWrapper } from "common/src/reservation-form/components";
+import { getLocalizationLang } from "common/src/helpers";
 import { ReservationUnitList } from "./ReservationUnitList";
 import {
   apiDateToUIDate,
@@ -286,7 +287,7 @@ const ApplicationEventInner = ({
       <PeriodContainer>
         <DateInput
           disableConfirmation
-          language={i18n.language as LocalizationLanguages}
+          language={getLocalizationLang(i18n.language)}
           {...register(`applicationEvents.${index}.begin`)}
           onChange={(v) => {
             clearErrors([
@@ -311,7 +312,7 @@ const ApplicationEventInner = ({
         <DateInput
           {...register(`applicationEvents.${index}.end`)}
           disableConfirmation
-          language={i18n.language as LocalizationLanguages}
+          language={getLocalizationLang(i18n.language)}
           onChange={(v) => {
             clearErrors([
               `applicationEvents.${index}.begin`,

--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -36,7 +36,7 @@ import {
   getDayIntervals,
   isRangeReservable,
 } from "common/src/calendar/util";
-import { Language, OptionType, PendingReservation } from "common/types/common";
+import type { OptionType, PendingReservation } from "common/types/common";
 import {
   fontBold,
   fontMedium,
@@ -44,6 +44,7 @@ import {
 } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import { ReservationUnitByPkType } from "common/types/gql-types";
+import { getLocalizationLang } from "common/src/helpers";
 import { MediumButton, truncatedText } from "../../styles/util";
 import { ReservationProps } from "../../context/DataContext";
 import { getDurationOptions } from "../../modules/reservation";
@@ -698,7 +699,7 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
               id="reservation__input--date"
               initialMonth={new Date()}
               label={t("reservationCalendar:startDate")}
-              language={i18n.language as Language}
+              language={getLocalizationLang(i18n.language)}
               minDate={new Date()}
               maxDate={
                 lastOpeningDate?.date

--- a/apps/ui/components/form/DateRangePicker.tsx
+++ b/apps/ui/components/form/DateRangePicker.tsx
@@ -6,7 +6,7 @@ import React, { useEffect } from "react";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { toUIDate } from "common/src/common/util";
-import { Language } from "common/types/common";
+import { getLocalizationLang } from "common/src/helpers";
 import { isValidDateString } from "../../modules/util";
 
 const initDate = (date: Date | null): string => {
@@ -146,7 +146,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         initialMonth={new Date()}
         label={labels?.begin ?? t("dateSelector:labelStartDate")}
         aria-label={labels?.ariaBegin ?? t("dateSelector:labelStartDate")}
-        language={i18n.language as Language}
+        language={getLocalizationLang(i18n.language)}
         onChange={(date) => setInternalStartDateString(date)}
         errorText={
           errors.startDateIsInvalid
@@ -173,7 +173,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         initialMonth={startDate ?? new Date()}
         label={labels?.end ?? t("dateSelector:labelEndDate")}
         aria-label={labels?.ariaEnd ?? t("dateSelector:labelEndDate")}
-        language={i18n.language as Language}
+        language={getLocalizationLang(i18n.language)}
         onChange={(date) => setInternalEndDateString(date)}
         errorText={
           endDateIsBeforeStartDate

--- a/apps/ui/components/reservation-unit/QuickReservation.tsx
+++ b/apps/ui/components/reservation-unit/QuickReservation.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { getAvailableTimes, getOpenDays } from "common/src/calendar/util";
 import { chunkArray, toUIDate } from "common/src/common/util";
-import { Language, OptionType, PendingReservation } from "common/types/common";
+import type { OptionType, PendingReservation } from "common/types/common";
 import {
   addDays,
   addHours,
@@ -13,10 +13,10 @@ import {
 } from "date-fns";
 import { DateInput, IconAngleDown, Select, TimeInput } from "hds-react";
 import { maxBy, padStart } from "lodash";
-
 import { useTranslation } from "next-i18next";
 import { useLocalStorage } from "react-use";
 import styled from "styled-components";
+import { getLocalizationLang } from "common/src/helpers";
 import { fontBold, fontMedium, H4 } from "common/src/common/typography";
 import ClientOnly from "common/src/ClientOnly";
 import { ReservationUnitByPkType } from "common/types/gql-types";
@@ -467,7 +467,7 @@ const QuickReservation = ({
           id={`${idPrefix}-quick-reservation-date`}
           label={t("reservationCalendar:quickReservation.date")}
           initialMonth={new Date()}
-          language={i18n.language as Language}
+          language={getLocalizationLang(i18n.language)}
           onChange={(_val, valueAsDate) => {
             if (isValid(valueAsDate) && valueAsDate.getFullYear() > 1970) {
               setSlot(null);

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from "next-i18next";
 import { useMedia } from "react-use";
 import styled from "styled-components";
 import { Toolbar } from "common/src/calendar/Toolbar";
+import { getLocalizationLang } from "common/src/helpers";
 import {
   canReservationTimeBeChanged,
   isReservationReservable,
@@ -436,7 +437,7 @@ const EditStep0 = ({
             }
             step={30}
             timeslots={getTimeslots(reservationUnit.reservationStartInterval)}
-            culture={i18n.language}
+            culture={getLocalizationLang(i18n.language)}
             aria-hidden
             longPressThreshold={100}
           />

--- a/apps/ui/hooks/useOptions.ts
+++ b/apps/ui/hooks/useOptions.ts
@@ -1,9 +1,10 @@
 import { useQuery, gql } from "@apollo/client";
 import { useTranslation } from "next-i18next";
-import type { LocalizationLanguages, OptionType } from "common/types/common";
+import type { OptionType } from "common/types/common";
 import type { Query, AgeGroupType, Maybe } from "common/types/gql-types";
 import { participantCountOptions } from "@/modules/const";
 import { mapOptions } from "@/modules/util";
+import { getLocalizationLang } from "common/src/helpers";
 
 export type OptionTypes = {
   ageGroupOptions: OptionType[];
@@ -111,12 +112,6 @@ export const useOptions = () => {
     .filter((node): node is NonNullable<typeof node> => node !== null) ?? [];
   */
 
-  const convertLang = (lang: string): LocalizationLanguages => {
-    if (lang === "fi" || lang === "en" || lang === "sv") {
-      return lang;
-    }
-    return "fi";
-  }
   const params = {
     ageGroups,
     cities,
@@ -128,7 +123,7 @@ export const useOptions = () => {
     ageGroupOptions: mapOptions(
       sortAgeGroups(ageGroups),
       undefined,
-      convertLang(i18n.language)
+      getLocalizationLang(i18n.language)
     ),
     abilityGroupOptions: [],
       /* TODO
@@ -142,19 +137,19 @@ export const useOptions = () => {
       cities.map((city) => maybeOption(city))
         .filter((city): city is NonNullable<typeof city> => city != null),
       undefined,
-      convertLang(i18n.language)
+      getLocalizationLang(i18n.language)
     ),
     purposeOptions: mapOptions(
       purposes.map((p) => maybeOption(p))
         .filter((p): p is NonNullable<typeof p> => p != null),
       undefined,
-      convertLang(i18n.language)
+      getLocalizationLang(i18n.language)
     ),
     reservationUnitTypeOptions: mapOptions(
       reservationUnitTypes.map((p) => maybeOption(p))
         .filter((p): p is NonNullable<typeof p> => p != null),
       undefined,
-      convertLang(i18n.language)
+      getLocalizationLang(i18n.language)
     ),
     participantCountOptions,
   }

--- a/apps/ui/modules/util.ts
+++ b/apps/ui/modules/util.ts
@@ -9,11 +9,7 @@ import {
   isValidDate,
   getTranslation,
 } from "common/src/common/util";
-import {
-  type LocalizationLanguages,
-  type OptionType,
-  type ReducedApplicationStatus,
-} from "common/types/common";
+import type { OptionType, ReducedApplicationStatus } from "common/types/common";
 import {
   type ReservationUnitImageType,
   type ReservationUnitType,
@@ -28,6 +24,7 @@ import {
   reservationsPrefix,
   isBrowser,
 } from "./const";
+import type { LocalizationLanguages } from "common/src/helpers";
 
 export { getTranslation };
 

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -57,7 +57,7 @@ import {
   TermsOfUseType,
 } from "common/types/gql-types";
 
-import { filterNonNullable } from "common/src/helpers";
+import { filterNonNullable, getLocalizationLang } from "common/src/helpers";
 import Head from "../../components/reservation-unit/Head";
 import Address from "../../components/reservation-unit/Address";
 import Sanitize from "../../components/common/Sanitize";
@@ -1022,7 +1022,7 @@ const ReservationUnit = ({
                     timeslots={getTimeslots(
                       reservationUnit.reservationStartInterval
                     )}
-                    culture={i18n.language}
+                    culture={getLocalizationLang(i18n.language)}
                     aria-hidden
                     longPressThreshold={100}
                   />

--- a/packages/common/src/calendar/Calendar.tsx
+++ b/packages/common/src/calendar/Calendar.tsx
@@ -9,6 +9,8 @@ import {
   startOfDay,
 } from "date-fns";
 import fi from "date-fns/locale/fi";
+import en from "date-fns/locale/en-GB";
+import sv from "date-fns/locale/sv";
 import {
   Calendar as BigCalendar,
   dateFnsLocalizer,
@@ -18,6 +20,7 @@ import withDragAndDrop from "react-big-calendar/lib/addons/dragAndDrop";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
 import { parseDate } from "../common/util";
+import { LocalizationLanguages } from "../helpers";
 
 export type CalendarEvent<T> = {
   title?: string;
@@ -77,7 +80,7 @@ type Props<T> = {
   overflowBreakpoint?: string;
   step?: number;
   timeslots?: number;
-  culture?: string;
+  culture?: LocalizationLanguages;
   longPressThreshold?: number;
   underlineEvents?: boolean;
 };
@@ -439,25 +442,28 @@ const StyledCalendarDND = styled(withDragAndDrop(StyledCalendar))``;
 
 const locales = {
   fi,
+  en,
+  sv,
 };
 
-const localizer = dateFnsLocalizer({
-  format: (date: Date, originalFormat: string) => {
-    let fmt = "";
-    switch (originalFormat) {
-      case "h:mma":
-        fmt = "H:mm";
-        break;
-      default:
-        fmt = originalFormat;
-    }
-    return format(date, fmt, { locale: locales.fi });
-  },
-  parse: parseDate,
-  startOfWeek: (date: Date) => startOfWeek(date, { weekStartsOn: 1 }),
-  getDay,
-  locales,
-});
+const localizer = (locale: LocalizationLanguages) =>
+  dateFnsLocalizer({
+    format: (date: Date, originalFormat: string) => {
+      let fmt = "";
+      switch (originalFormat) {
+        case "h:mma":
+          fmt = "H:mm";
+          break;
+        default:
+          fmt = originalFormat;
+      }
+      return format(date, fmt, { locale: locales[locale] });
+    },
+    parse: parseDate,
+    startOfWeek: (date: Date) => startOfWeek(date, { weekStartsOn: 1 }),
+    getDay,
+    locales,
+  });
 
 const Calendar = <T extends Record<string, unknown>>({
   events,
@@ -511,7 +517,7 @@ const Calendar = <T extends Record<string, unknown>>({
       onView={onView}
       min={min || addHours(startOfDay(begin), 6)}
       max={max || endOfMonth(begin)}
-      localizer={localizer}
+      localizer={localizer(culture)}
       toolbar={showToolbar}
       views={["day", "week", "month"]}
       className={`view-${viewType}`}

--- a/packages/common/src/helpers.ts
+++ b/packages/common/src/helpers.ts
@@ -25,3 +25,18 @@ export const fromMondayFirstUnsafe = (day: number) => {
 
 export const fromMondayFirst = (day: 0 | 1 | 2 | 3 | 4 | 5 | 6) =>
   day === 6 ? 0 : day + 1;
+
+export type LocalizationLanguages = "fi" | "sv" | "en";
+
+export const getLocalizationLang = (code: string): LocalizationLanguages => {
+  if (code.startsWith("fi")) {
+    return "fi";
+  }
+  if (code.startsWith("sv")) {
+    return "sv";
+  }
+  if (code.startsWith("en")) {
+    return "en";
+  }
+  return "fi";
+};

--- a/packages/common/types/common.ts
+++ b/packages/common/types/common.ts
@@ -157,9 +157,6 @@ export type OptionType = {
   value?: number | string;
 };
 
-export type LocalizationLanguages = "fi" | "sv" | "en";
-export type Language = "fi" | "en" | "sv";
-
 export interface HMS {
   h: number;
   m: number;


### PR DESCRIPTION
- Fix calendar always showing days in Finnish.
- Set the calendar localization to user language (not fi).
- Add type safe conversion function from locale -> what we have translated.