### PR TITLE
TILA-2933: fix general terms link

### DIFF
--- a/apps/ui/components/reservation/EditStep1.tsx
+++ b/apps/ui/components/reservation/EditStep1.tsx
@@ -20,11 +20,11 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import TermsBox from "common/src/termsbox/TermsBox";
-import { TERMS_OF_USE } from "../../modules/queries/reservationUnit";
-import { capitalize, getTranslation } from "../../modules/util";
+import { TERMS_OF_USE } from "@/modules/queries/reservationUnit";
+import { capitalize, getTranslation } from "@/modules/util";
 import Sanitize from "../common/Sanitize";
-import { BlackButton, MediumButton } from "../../styles/util";
-import { reservationsPrefix } from "../../modules/const";
+import { BlackButton, MediumButton } from "@/styles/util";
+import { reservationsPrefix } from "@/modules/const";
 
 type Props = {
   reservation: ReservationType;
@@ -312,7 +312,7 @@ const EditStep1 = ({
             hasTermsOfUse
               ? [
                   {
-                    href: "/terms/general",
+                    href: "/terms/booking",
                     text: t("reservationCalendar:heading.generalTerms"),
                   },
                 ]

--- a/apps/ui/components/reservation/Step1.tsx
+++ b/apps/ui/components/reservation/Step1.tsx
@@ -15,12 +15,12 @@ import {
   Subheading,
   TwoColumnContainer,
 } from "common/src/reservation-form/styles";
-import { ReservationStep } from "../../modules/types";
-import { capitalize, getTranslation } from "../../modules/util";
+import { ReservationStep } from "@/modules/types";
+import { capitalize, getTranslation } from "@/modules/util";
 import { ActionContainer } from "./styles";
 import Sanitize from "../common/Sanitize";
-import { MediumButton } from "../../styles/util";
-import { JustForMobile } from "../../modules/style/layout";
+import { MediumButton } from "@/styles/util";
+import { JustForMobile } from "@/modules/style/layout";
 import {
   ErrorAnchor,
   ErrorBox,

--- a/apps/ui/components/reservation/Step1.tsx
+++ b/apps/ui/components/reservation/Step1.tsx
@@ -280,7 +280,7 @@ const Step1 = ({
         links={
           termsOfUse.genericTerms && [
             {
-              href: "/terms/general",
+              href: "/terms/booking",
               text: t("reservationCalendar:heading.generalTerms"),
             },
           ]


### PR DESCRIPTION
Fixes the old links to generalTerms with the proper href for the terms, as they're now known as boooking and not general