### PR TITLE
fix: Increase BlackButton style specificity to get rid of !important

### DIFF
--- a/apps/ui/styles/util.ts
+++ b/apps/ui/styles/util.ts
@@ -17,10 +17,12 @@ export const MediumButton = styled(Button)`
 `;
 
 export const BlackButton = styled(Button)`
-  color: var(--color-black-90);
-  border-color: var(--color-black-90) !important;
-  font-size: var(--fontsize-body-m);
-  ${fontMedium};
+  &&& {
+    color: var(--color-black-90);
+    border-color: var(--color-black-90);
+    font-size: var(--fontsize-body-m);
+    ${fontMedium};
+  }
 `;
 
 export const SupplementaryButton = styled(Button).attrs({


### PR DESCRIPTION
Increase BlackButton style specificity to get style definitions to stick, and to get rid of !important

REF: TILA-2779