### PR TITLE
Fix reserving with zero participants

### DIFF
--- a/packages/common/src/reservation-form/MetaFields.tsx
+++ b/packages/common/src/reservation-form/MetaFields.tsx
@@ -240,7 +240,10 @@ export const ReservationMetaFields = ({
           headingKey="COMMON"
           params={{
             numPersons: {
-              min: reservationUnit.minPersons ?? 0,
+              min:
+                !reservationUnit.minPersons || reservationUnit.minPersons === 0
+                  ? 1
+                  : reservationUnit.minPersons,
               max:
                 reservationUnit.maxPersons != null &&
                 !Number.isNaN(reservationUnit.maxPersons) &&


### PR DESCRIPTION
Warnings/validation works like it should, but it was a case where minimum number of participants want's specified. Fixed by making minimum participants 1 if it is not specified, or if it has a value of 0 (as there always needs to be at least one participant).
Ref: TILA-2837