### PR TITLE
fix: filter users reservations on backend

### DIFF
--- a/apps/ui/hooks/reservation.tsx
+++ b/apps/ui/hooks/reservation.tsx
@@ -160,7 +160,7 @@ export const useReservations = ({
       variables: {
         ...(states != null && states?.length > 0 && { state: states }),
         ...(orderBy && { orderBy }),
-        ...(type && { type }),
+        ...(type && { reservationType: [type.toLowerCase()] }),
         user: currentUser?.pk?.toString(),
       },
       fetchPolicy: "no-cache",

--- a/apps/ui/modules/queries/reservation.ts
+++ b/apps/ui/modules/queries/reservation.ts
@@ -119,6 +119,7 @@ export const LIST_RESERVATIONS = gql`
     $user: ID
     $reservationUnit: [ID]
     $orderBy: String
+    $reservationType: [String]
   ) {
     reservations(
       before: $before
@@ -131,6 +132,7 @@ export const LIST_RESERVATIONS = gql`
       user: $user
       reservationUnit: $reservationUnit
       orderBy: $orderBy
+      reservationType: $reservationType
     ) {
       edges {
         node {


### PR DESCRIPTION
Because there is no pagination users were shown zero reservations on the frontend when they had a lot of reservations.

Replace frontend filtering with query filters. Every reservation tab has it's own query with it's own query params. Automatically cache tab queries.

Refs: TILA-2893