### PR TITLE
Adds opening hours to recurring reservation time selection

### DIFF
--- a/apps/ui/components/application/Form.tsx
+++ b/apps/ui/components/application/Form.tsx
@@ -28,7 +28,7 @@ export const ApplicationEventScheduleFormTypeSchema = z.object({
   day: z.number().min(0).max(6),
   begin: z.string(),
   end: z.string(),
-  priority: z.union([z.literal(100), z.literal(200), z.literal(300)]),
+  priority: z.number(),
 });
 
 export type ApplicationEventScheduleFormType = z.infer<

--- a/apps/ui/components/application/Form.tsx
+++ b/apps/ui/components/application/Form.tsx
@@ -103,20 +103,20 @@ export const transformApplicationEventToForm = (
     applicationEvent.applicationEventSchedules
   ).map((aes) => ({
     pk: aes.pk ?? undefined,
-    day: (aes.day ?? 0) as Day,
+    day: aes.day ?? 0,
     begin: aes.begin ?? "",
     end: aes.end ?? "",
-    priority: aes.priority === 200 || aes.priority === 300 ? aes.priority : 100,
+    priority: aes.priority ?? 50,
   })),
   // TODO remove the format hacks
   begin:
-    applicationEvent?.begin != null && applicationEvent?.begin?.includes("-")
+    applicationEvent.begin != null && applicationEvent.begin.includes("-")
       ? apiDateToUIDate(applicationEvent.begin)
       : applicationEvent?.begin ?? undefined,
   end:
-    applicationEvent?.end != null && applicationEvent?.end?.includes("-")
+    applicationEvent.end != null && applicationEvent.end.includes("-")
       ? apiDateToUIDate(applicationEvent.end)
-      : applicationEvent?.end ?? undefined,
+      : applicationEvent.end ?? undefined,
   accordianOpen: false,
 });
 

--- a/apps/ui/components/application/Page2.tsx
+++ b/apps/ui/components/application/Page2.tsx
@@ -286,7 +286,7 @@ const Page2 = ({ application, onNext }: Props): JSX.Element => {
   const resetCells = (index: number) => {
     const updated = [...selectorData];
     updated[index] = selectorData[index].map((n) =>
-      n.map((nn) => ({ ...nn, state: 100 as const }))
+      n.map((nn) => ({ ...nn, state: 100 }))
     );
     setSelectorData(updated);
   };
@@ -318,12 +318,6 @@ const Page2 = ({ application, onNext }: Props): JSX.Element => {
       .map((aes) =>
         aes
           .filter((ae) => ae.priority === 300 || ae.priority === 200)
-          .map((ae) => {
-            return {
-              ...ae,
-              priority: ae.priority === 300 ? (300 as const) : (200 as const),
-            };
-          })
       )
       .flat();
     if (selectedAppEvents.length === 0) {

--- a/apps/ui/components/application/TimeSelector.tsx
+++ b/apps/ui/components/application/TimeSelector.tsx
@@ -53,9 +53,7 @@ const TimeSelectionButton = styled.button<{
 
   display: block;
   width: 100%;
-  font-family: var(--font-bold);
   font-size: var(--fontsize-heading-m);
-  font-weight: bold;
   color: ${(props) =>
     props.state ? "var(--color-white)" : "var(--color-black)"};
   padding: 0.24em 0.5em;
@@ -85,9 +83,11 @@ const TimeSelectionButton = styled.button<{
     }
     background: var(--tilavaraus-calendar-selected-secondary);
     color: var(--color-black);
+    font-weight: bold;
   `
       : `
-    background: #e5e5e5;
+    background: ${props.state === 100 ? "#ffffff" : "#e5e5e5"};
+    font-weight: ${props.state === 100 ? "bold" : "normal"};
     color: var(--color-black);
   `};
   white-space: nowrap;

--- a/apps/ui/components/application/TimeSelector.tsx
+++ b/apps/ui/components/application/TimeSelector.tsx
@@ -86,7 +86,9 @@ const TimeSelectionButton = styled.button<{
     font-weight: bold;
   `
       : `
-    background: ${props.state === 100 ? "#ffffff" : "#e5e5e5"};
+    background: ${
+      props.state === 100 ? "var(--color-white)" : "var(--color-black-10)"
+    };
     font-weight: ${props.state === 100 ? "bold" : "normal"};
     color: var(--color-black);
   `};
@@ -97,6 +99,7 @@ const TimeSelectionButton = styled.button<{
 
 const Day = ({
   head,
+  labelHead,
   cells,
   setCellValue,
   paintState,
@@ -106,6 +109,7 @@ const Day = ({
   priority,
 }: {
   head: string;
+  labelHead: string;
   cells: Cell[];
   setCellValue: (
     selection: Cell,
@@ -137,6 +141,14 @@ const Day = ({
           case 200:
             ariaLabel = t("application:Page2.legend.selected-2");
             break;
+          /* TODO: use aria-labels for priority 100 & 50 once we have them
+          case 100:
+            ariaLabel = t("application:Page2.legend.available");
+            break;
+          case 50:
+            ariaLabel = t("application:Page2.legend.unavailable");
+            break;
+          */
           default:
         }
 
@@ -171,8 +183,10 @@ const Day = ({
               }
             }}
             role="option"
-            aria-label={ariaLabel}
-            aria-selected={!!cell.state}
+            aria-label={`${ariaLabel ? `${ariaLabel}: ` : ""}${labelHead} ${
+              cell.label
+            }`}
+            aria-selected={cell.state > 100}
             data-testid={`time-selector__button--${cell.key}`}
           >
             {cell.label}
@@ -386,6 +400,7 @@ const TimeSelector = ({
             setPainting={setPainting}
             key={`day-${c}`}
             head={t(`common:weekDayLong.${fromMondayFirstUnsafe(i)}`)}
+            labelHead={t(`common:weekDay.${fromMondayFirstUnsafe(i)}`)}
             cells={cells[i]}
             setCellValue={setCellValue}
             priority={priority}

--- a/apps/ui/modules/util.ts
+++ b/apps/ui/modules/util.ts
@@ -51,10 +51,12 @@ export const formatDate = (date: string, formatStr?: string): string => {
   return toUIDate(parseISO(date), formatStr);
 };
 
+// Takes a date string in format "yyyy-MM-dd" and returns a Date-object with the same date
 export const fromUIDate = (date: string): Date => {
   return parse(date, "d.M.yyyy", new Date());
 };
 
+// Takes a date string in format "yyyy-MM-dd" and returns a string in format "d.M.yyyy"
 export const apiDateToUIDate = (date: string): string => {
   return toUIDate(fromAPIDate(date));
 };

--- a/packages/common/types/common.ts
+++ b/packages/common/types/common.ts
@@ -103,7 +103,7 @@ export type ApplicationEvent = {
 
 export type DAY = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-export type ApplicationEventSchedulePriority = 100 | 200 | 300;
+export type ApplicationEventSchedulePriority = 50 | 100 | 200 | 300;
 
 // @deprecated required by pdf export
 export type ReservationState =

--- a/packages/common/types/common.ts
+++ b/packages/common/types/common.ts
@@ -103,7 +103,7 @@ export type ApplicationEvent = {
 
 export type DAY = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-export type ApplicationEventSchedulePriority = 50 | 100 | 200 | 300;
+export type ApplicationEventSchedulePriority = number;
 
 // @deprecated required by pdf export
 export type ReservationState =


### PR DESCRIPTION
Adds handling, styling and aria-fixes to the second page when making recurring reservations. The aria-labels now include the day and time of each slot. The label texts for opening hours are yet to be finalised, but should be added along with the updated legend (now it doesn't contain descriptions for open/not open times, only for the primary and secondary selections).