### PR TITLE
fix: check working memo mutation errors

### DIFF
--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -186,6 +186,7 @@ const translations: ITranslations = {
       "Virhe. Varaus tehty, mutta sen näyttäminen epäonnistui.",
     ],
     noPermission: ["Sinulla ei ole käyttöoikeutta."],
+    mutationNoDataReturned: ["Odottamaton vastaus."],
     descriptive: {
       "Reservation overlaps with reservation before due to buffer time.": [
         "Varaus menee päällekkäin edellisen varauksen kanssa tauon takia.",


### PR DESCRIPTION
Wasn't checking GraphQL field errors at all so any request that was valid GQL was reported successful to the user, regardless if it was successful in the backend.