### PR TITLE
fix: dont allow moving reservation units

### DIFF
--- a/apps/admin-ui/src/common/Error404.tsx
+++ b/apps/admin-ui/src/common/Error404.tsx
@@ -37,11 +37,12 @@ const Content = styled.div`
 `;
 
 // TODO should there be an image here?
-function Error404(): JSX.Element {
+function Error404({ message }: { message?: string }): JSX.Element {
   return (
     <Wrapper>
       <Content>
         <H1 $legacy>404: Sivua ei löytynyt</H1>
+        {message && <p>{message}</p>}
         <Link href={publicUrl ?? "/"}>Siirry etusivulle</Link>
       </Content>
     </Wrapper>

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -173,6 +173,7 @@ const translations: ITranslations = {
     router: {
       invalidApplicationNumber: ["Virheellinen hakemusnumero"],
       invalidApplicationRoundNumber: ["Virheellinen hakukierroksen numero"],
+      unitPkMismatch: ["Varausyksikkö ei kuulu osoitteen yksikköön"],
     },
     applicationRoundNotFound: ["Haettua hakukierrosta ei löydy"],
     errorFetchingData: ["Virhe haettaessa tietoja"],

--- a/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
@@ -2193,12 +2193,19 @@ function EditorWrapper() {
   if (unitPk == null || Number(unitPk) === 0 || Number.isNaN(Number(unitPk))) {
     return <Error404 />;
   }
+
   // we use null for "new" units (could also be "new" slug)
-  if (reservationUnitPk != null && Number.isNaN(Number(reservationUnitPk))) {
+  const isNew = reservationUnitPk == null;
+  // TODO the unitPk should be removed from the url, not needed since the reservationUnitPk is unique
+  // without this we'd move the reservation unit to another unit on save
+  if (!isNew && reservationUnit?.unit?.pk !== Number(unitPk)) {
+    return <Error404 message={t("errors.router.unitPkMismatch")} />;
+  }
+  if (!isNew && Number.isNaN(Number(reservationUnitPk))) {
     return <Error404 />;
   }
   // the pk is valid but not found in the backend
-  if (reservationUnitPk != null && reservationUnit == null) {
+  if (!isNew && reservationUnit == null) {
     return <Error404 />;
   }
 


### PR DESCRIPTION
Using an incorrect unit pk param in the url allowed user to move reservation unit to another unit on save.