### PR TITLE
Shows the first reservation units schedule on Page2

### DIFF
--- a/apps/ui/components/application/Page2.tsx
+++ b/apps/ui/components/application/Page2.tsx
@@ -8,11 +8,8 @@ import type { ApplicationEventSchedulePriority } from "common/types/common";
 import type {
   ApplicationEventScheduleNode,
   ApplicationNode,
-  Query,
-  QueryReservationByPkArgs,
 } from "common/types/gql-types";
 import { filterNonNullable } from "common/src/helpers";
-import { useQuery } from "@apollo/client";
 import { MediumButton } from "@/styles/util";
 import { getReadableList } from "@/modules/util";
 import { AccordionWithState as Accordion } from "../common/Accordion";
@@ -23,7 +20,6 @@ import type {
   ApplicationEventScheduleFormType,
   ApplicationFormValues,
 } from "./Form";
-import { RESERVATION_UNIT } from "@/modules/queries/reservationUnit";
 
 type Props = {
   application: ApplicationNode;
@@ -216,23 +212,14 @@ const getApplicationEventsWhichMinDurationsIsNotFulfilled = (
 
 const Page2 = ({ application, onNext }: Props): JSX.Element => {
   const { t } = useTranslation();
-  const { data: applicationRound } = useQuery<Query, QueryReservationByPkArgs>(
-    RESERVATION_UNIT,
-    {
-      variables: {
-        pk: application.applicationRound.pk ?? 0,
-      },
-      skip: !application.applicationRound.pk,
-      fetchPolicy: "no-cache",
-    }
-  );
+
   const [successMsg, setSuccessMsg] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
   const [minDurationMsg, setMinDurationMsg] = useState(true);
   const router = useRouter();
   const openingHours =
-    applicationRound?.reservationUnitByPk?.applicationRoundTimeSlots ?? [];
-
+    filterNonNullable(application.applicationRound.reservationUnits)[0]
+      .applicationRoundTimeSlots ?? [];
   const { getValues, setValue, watch, handleSubmit } =
     useFormContext<ApplicationFormValues>();
 

--- a/apps/ui/components/application/Page2.tsx
+++ b/apps/ui/components/application/Page2.tsx
@@ -200,11 +200,7 @@ const getApplicationEventsWhichMinDurationsIsNotFulfilled = (
   const selectedHours = getLongestChunks(selectorData);
   return applicationEvents
     .map((applicationEvent, index) => {
-      const minDuration =
-        applicationEvent.minDuration ??
-        0; /* applicationEvent.minDuration != null
-        ? convertHMSToSeconds(applicationEvent.minDuration)
-        : 0 */
+      const minDuration = applicationEvent.minDuration ?? 0;
       return selectedHours[index] < minDuration / 3600 ? index : null;
     })
     .filter((n): n is NonNullable<typeof n> => n != null);
@@ -217,9 +213,10 @@ const Page2 = ({ application, onNext }: Props): JSX.Element => {
   const [errorMsg, setErrorMsg] = useState("");
   const [minDurationMsg, setMinDurationMsg] = useState(true);
   const router = useRouter();
-  const openingHours =
-    filterNonNullable(application.applicationRound.reservationUnits)[0]
-      .applicationRoundTimeSlots ?? [];
+  const openingHours = filterNonNullable(
+    application?.applicationEvents?.[0]?.eventReservationUnits?.[0]
+      ?.reservationUnit.applicationRoundTimeSlots
+  );
   const { getValues, setValue, watch, handleSubmit } =
     useFormContext<ApplicationFormValues>();
 

--- a/packages/common/src/queries/application.ts
+++ b/packages/common/src/queries/application.ts
@@ -29,12 +29,6 @@ const APPLICATION_FRAGMENT = gql`
         nameEn
         minPersons
         maxPersons
-        applicationRoundTimeSlots {
-          reservableTimes {
-            begin
-            end
-          }
-        }
         images {
           imageType
           mediumUrl
@@ -123,6 +117,12 @@ const APPLICATION_FRAGMENT = gql`
         pk
         preferredOrder
         reservationUnit {
+          applicationRoundTimeSlots {
+            reservableTimes {
+              begin
+              end
+            }
+          }
           pk
           nameFi
           nameEn

--- a/packages/common/src/queries/application.ts
+++ b/packages/common/src/queries/application.ts
@@ -29,6 +29,12 @@ const APPLICATION_FRAGMENT = gql`
         nameEn
         minPersons
         maxPersons
+        applicationRoundTimeSlots {
+          reservableTimes {
+            begin
+            end
+          }
+        }
         images {
           imageType
           mediumUrl


### PR DESCRIPTION
Fixes the bug where recurring reservations page 2 showed the wrong available times. It was using the applicationRound pk, when it should have used the reservationUnits pk. This also resulted in one less query, as the needed info could be added to the application query.