### PR TITLE
Reservation unit card status tags

### DIFF
--- a/apps/ui/components/single-search/ReservationUnitCard.tsx
+++ b/apps/ui/components/single-search/ReservationUnitCard.tsx
@@ -246,7 +246,7 @@ const ReservationUnitCard = ({ reservationUnit }: Props): JSX.Element => {
       },
       {
         closed: false,
-        availableAt: addDays(today, 3),
+        availableAt: undefined,
       },
     ];
     return mockData[Math.floor(Math.random() * mockData.length)];

--- a/apps/ui/public/locales/en/common.json
+++ b/apps/ui/public/locales/en/common.json
@@ -13,6 +13,7 @@
   "timeWithPrefix": "{{date, ',' H.mm}}",
   "timeWithPrefixInForm": "{{date, ',' H:mm}}",
   "today": "Today",
+  "tomorrow": "Tomorrow",
   "day": "Day",
   "week": "Week",
   "month": "Month",

--- a/apps/ui/public/locales/en/reservationUnitCard.json
+++ b/apps/ui/public/locales/en/reservationUnitCard.json
@@ -8,5 +8,8 @@
   },
   "address": "Address",
   "type": "Service type",
-  "seeMore": "Show more"
+  "seeMore": "Show more",
+  "available": "Available",
+  "noTimes": "No available times",
+  "closed": "Closed"
 }

--- a/apps/ui/public/locales/fi/common.json
+++ b/apps/ui/public/locales/fi/common.json
@@ -13,6 +13,7 @@
   "timeWithPrefix": "{{date, 'klo' H.mm}}",
   "timeWithPrefixInForm": "{{date, 'klo' H:mm}}",
   "today": "Tänään",
+  "tomorrow": "Huomenna",
   "day": "Päivä",
   "week": "Viikko",
   "month": "Kuukausi",

--- a/apps/ui/public/locales/fi/reservationUnitCard.json
+++ b/apps/ui/public/locales/fi/reservationUnitCard.json
@@ -9,5 +9,8 @@
   },
   "address": "Katuosoite",
   "type": "Palvelun tyyppi",
-  "seeMore": "Katso lisää"
+  "seeMore": "Katso lisää",
+  "available": "Vapaa",
+  "noTimes": "Ei vapaita aikoja",
+  "closed": "Suljettu"
 }

--- a/apps/ui/public/locales/sv/common.json
+++ b/apps/ui/public/locales/sv/common.json
@@ -13,6 +13,7 @@
   "timeWithPrefix": "{{date, 'kl' H.mm}}",
   "timeWithPrefixInForm": "{{date, 'kl' H:mm}}",
   "today": "I dag",
+  "tomorrow": "I morgon",
   "day": "Dag",
   "week": "Vecka",
   "month": "Månad",

--- a/apps/ui/public/locales/sv/reservationUnitCard.json
+++ b/apps/ui/public/locales/sv/reservationUnitCard.json
@@ -8,5 +8,8 @@
   },
   "address": "Adress",
   "type": "",
-  "seeMore": "Visa mer"
+  "seeMore": "Visa mer",
+  "available": "Ledigt",
+  "noTimes": "Inga lediga tider",
+  "closed": "Stängt"
 }


### PR DESCRIPTION
Adds tags about the next possible reservation or lack thereof into search results. Mock data in use, so using `display: hidden` by default so as to not screw up the proper search results, change to `block` to view (originally `inline-flex` but `block` works too).