### PR TITLE
Fix allocation reservation unit selection

### DIFF
--- a/apps/admin-ui/src/component/Unit/UnitsTable.tsx
+++ b/apps/admin-ui/src/component/Unit/UnitsTable.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from "react-i18next";
 import { memoize } from "lodash";
 import { UnitType } from "common/types/gql-types";
 import { TFunction } from "i18next";
-import { myUnitUrl, unitUrl } from "../../common/urls";
-import { CustomTable, TableLink } from "../lists/components";
+import { truncate } from "@/helpers";
+import { myUnitUrl, unitUrl } from "@/common/urls";
+import { CustomTable, TableLink } from "@/component/lists/components";
 
 export type Sort = {
   field: string;
@@ -18,14 +19,6 @@ type Props = {
   isMyUnits?: boolean;
 };
 
-function truncateMaybeString(
-  str: string | undefined,
-  maxLength: number
-): string {
-  if (!str) return "";
-  return str.length > maxLength ? `${str.slice(0, maxLength)}...` : str;
-}
-
 const MAX_NAME_LENGTH = 40;
 
 const getColConfig = (t: TFunction, isMyUnits?: boolean) => [
@@ -34,7 +27,7 @@ const getColConfig = (t: TFunction, isMyUnits?: boolean) => [
     key: "nameFi",
     transform: ({ nameFi, pk }: UnitType) => (
       <TableLink href={isMyUnits ? myUnitUrl(pk ?? 0) : unitUrl(pk ?? 0)}>
-        {truncateMaybeString(nameFi ?? undefined, MAX_NAME_LENGTH)}
+        {truncate(nameFi ?? "-", MAX_NAME_LENGTH)}
       </TableLink>
     ),
     width: "50%",

--- a/apps/admin-ui/src/component/lists/Tags.tsx
+++ b/apps/admin-ui/src/component/lists/Tags.tsx
@@ -1,9 +1,10 @@
 import React, { Dispatch } from "react";
 import { Tag as HDSTag } from "hds-react";
-import { get, omit, truncate } from "lodash";
-import { TFunction } from "i18next";
+import { get, omit } from "lodash";
+import type { TFunction } from "i18next";
 import styled from "styled-components";
-import { OptionType } from "../../common/types";
+import { truncate } from "@/helpers";
+import type { OptionType } from "@/common/types";
 
 export type Tag<T> = {
   key: string;
@@ -40,7 +41,7 @@ export const toTags = <T,>(
         (v: OptionType) =>
           ({
             key: `${String(key)}.${v.value}`,
-            value: truncate(v.label, { length: 25 }),
+            value: truncate(v.label, 25),
             ac: { type: "deleteTag", field: key, value: v.value },
           } as Tag<T>)
       );

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventCard.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventCard.tsx
@@ -3,12 +3,10 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Strong } from "common/src/common/typography";
-import {
-  ApplicationEventNode,
-  ReservationUnitByPkType,
-} from "common/types/gql-types";
+import type { ApplicationEventNode } from "common/types/gql-types";
+import type { ReservationUnitNode } from "common";
+import type { AllocationApplicationEventCardType } from "@/common/types";
 import { publicUrl } from "@/common/const";
-import { AllocationApplicationEventCardType } from "@/common/types";
 import { formatDuration } from "@/common/util";
 import { getApplicantName } from "@/component/applications/util";
 import { ageGroup } from "@/component/reservations/requested/util";
@@ -17,7 +15,7 @@ type Props = {
   applicationEvent: ApplicationEventNode;
   selectedApplicationEvent?: ApplicationEventNode;
   setSelectedApplicationEvent: (val?: ApplicationEventNode) => void;
-  reservationUnit: ReservationUnitByPkType;
+  reservationUnit: ReservationUnitNode;
   type: AllocationApplicationEventCardType;
 };
 

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventScheduleCard.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationEventScheduleCard.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Strong } from "common/src/common/typography";
 import { useMutation } from "@apollo/client";
-import {
+import type {
   ApplicationEventNode,
-  ReservationUnitByPkType,
   Mutation,
   MutationApproveApplicationEventScheduleArgs,
 } from "common/types/gql-types";
 import { filterNonNullable } from "common/src/helpers";
+import type { ReservationUnitNode } from "common";
 import { getApplicantName } from "@/component/applications/util";
 import { formatDuration } from "@/common/util";
 import { SmallRoundButton } from "@/styles/buttons";
@@ -25,7 +25,7 @@ import { APPROVE_APPLICATION_EVENT_SCHEDULE } from "../queries";
 
 type Props = {
   applicationEvent: ApplicationEventNode;
-  reservationUnit: ReservationUnitByPkType;
+  reservationUnit: ReservationUnitNode;
   selection: string[];
   applicationEventScheduleResultStatuses: ApplicationEventScheduleResultStatuses;
 };

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationEvents.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationEvents.tsx
@@ -3,10 +3,8 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { sortBy } from "lodash";
 import { H5 } from "common/src/common/typography";
-import type {
-  ApplicationEventNode,
-  ReservationUnitByPkType,
-} from "common/types/gql-types";
+import type { ApplicationEventNode } from "common/types/gql-types";
+import { ReservationUnitNode } from "common";
 import { Accordion } from "@/component/Accordion";
 import type { AllocationApplicationEventCardType } from "@/common/types";
 import AllocationCalendar from "./AllocationCalendar";
@@ -62,7 +60,7 @@ const EventGroupList = ({
   setSelectedApplicationEvent: (
     applicationEvent?: ApplicationEventNode
   ) => void;
-  reservationUnit: ReservationUnitByPkType;
+  reservationUnit: ReservationUnitNode;
   type: AllocationApplicationEventCardType;
 }): JSX.Element => {
   if (applicationEvents.length < 1) {
@@ -86,7 +84,7 @@ const EventGroupList = ({
 
 type ApplicationEventsProps = {
   applicationEvents: ApplicationEventNode[] | null;
-  reservationUnit: ReservationUnitByPkType;
+  reservationUnit: ReservationUnitNode;
 };
 
 /// TODO what is this doing? when is it shown and what does it look like?

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationRoundAllocationActions.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/ApplicationRoundAllocationActions.tsx
@@ -4,11 +4,9 @@ import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { Strong, Strongish } from "common/src/common/typography";
 import styled from "styled-components";
-import type {
-  ApplicationEventNode,
-  ReservationUnitByPkType,
-} from "common/types/gql-types";
+import type { ApplicationEventNode } from "common/types/gql-types";
 import { ShowAllContainer } from "common/src/components/";
+import type { ReservationUnitNode } from "common";
 import { ALLOCATION_CALENDAR_TIMES } from "@/common/const";
 import { OptionType } from "@/common/types";
 import { Accordion } from "@/component/Accordion";
@@ -22,7 +20,7 @@ import { ApplicationEventScheduleCard } from "./ApplicationEventScheduleCard";
 
 type Props = {
   applicationEvents: ApplicationEventNode[] | null;
-  reservationUnit: ReservationUnitByPkType;
+  reservationUnit: ReservationUnitNode;
   paintedApplicationEvents: ApplicationEventNode[];
   paintApplicationEvents: (val: ApplicationEventNode[]) => void;
   selection: string[] | null;

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
@@ -26,12 +26,15 @@ import { useAllocationContext } from "@/context/AllocationContext";
 import { VALID_ALLOCATION_APPLICATION_STATUSES } from "@/common/const";
 import usePermission from "@/hooks/usePermission";
 import { Permission } from "@/modules/permissionHelper";
+import { truncate } from "@/helpers";
 import {
   ALL_EVENTS_PER_UNIT_QUERY,
   APPLICATION_EVENTS_FOR_ALLOCATION,
   ALLOCATION_UNFILTERED_QUERY,
 } from "../queries";
 import { ApplicationEvents } from "./ApplicationEvents";
+
+const MAX_RES_UNIT_NAME_LENGTH = 35;
 
 type IParams = {
   applicationRoundId: string;
@@ -572,7 +575,7 @@ function ApplicationRoundAllocation({
                 onClick={() => setSelectedReservationUnit(ru.pk ?? null)}
                 key={ru?.pk}
               >
-                {ru?.nameFi}
+                {truncate(ru?.nameFi ?? "-", MAX_RES_UNIT_NAME_LENGTH)}
               </Tab>
             ))}
           </TabList>

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
@@ -643,11 +643,8 @@ function AllocationWrapper({
     data?.applications?.edges?.map((edge) => edge?.node)
   );
 
-  const reservationUnits = applications
-    .flatMap((a) => a.applicationEvents)
-    .flatMap((ae) =>
-      ae?.eventReservationUnits?.flatMap((eru) => eru?.reservationUnit)
-    );
+  const appRound = applications?.[0]?.applicationRound ?? undefined;
+  const reservationUnits = filterNonNullable(appRound?.reservationUnits);
   const unitData = reservationUnits.map((ru) => ru?.unit);
 
   // TODO sort by name (they are in a random order because of the nested structure)

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
@@ -9,13 +9,12 @@ import { H1, fontBold, fontMedium } from "common/src/common/typography";
 import { ShowAllContainer } from "common/src/components";
 import {
   type Query,
-  type ReservationUnitByPkType,
   type QueryApplicationEventsArgs,
   type UnitType,
   type QueryApplicationsArgs,
   ApplicantTypeChoice,
 } from "common/types/gql-types";
-import { breakpoints } from "common";
+import { type ReservationUnitNode, breakpoints } from "common";
 import { filterNonNullable } from "common/src/helpers";
 import { SearchTags } from "@/component/SearchTags";
 import Loader from "@/component/Loader";
@@ -125,7 +124,7 @@ function ApplicationRoundAllocation({
 }: {
   applicationRoundId: number;
   units: UnitType[];
-  reservationUnits: ReservationUnitByPkType[];
+  reservationUnits: ReservationUnitNode[];
   roundName: string;
 }): JSX.Element {
   const { refreshApplicationEvents, setRefreshApplicationEvents } =

--- a/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/allocation/index.tsx
@@ -15,6 +15,7 @@ import {
   type QueryApplicationsArgs,
   ApplicantTypeChoice,
 } from "common/types/gql-types";
+import { breakpoints } from "common";
 import { filterNonNullable } from "common/src/helpers";
 import { SearchTags } from "@/component/SearchTags";
 import Loader from "@/component/Loader";
@@ -100,6 +101,17 @@ const MoreWrapper = styled(ShowAllContainer)`
   }
   .ShowAllContainer__Content {
     ${autoGridCss}
+  }
+`;
+
+// Tab causes horizontal overflow without this
+// because it's inside a grid so an element with fixed width and no max-width breaks the grid
+const TabWrapper = styled.div`
+  max-width: 95vw;
+  @media (width > ${breakpoints.m}) {
+    max-width: calc(
+      95vw - var(--main-menu-width) - 2 * var(--spacing-layout-m)
+    );
   }
 `;
 
@@ -550,23 +562,25 @@ function ApplicationRoundAllocation({
       {/* using a key here is a hack to force remounting the tabs
        * remount causes flickering but HDS doesn't allow programmatically changing the active tab
        */}
-      <Tabs
-        initiallyActiveTab={initiallyActiveTab >= 0 ? initiallyActiveTab : 0}
-        key={unitFilter ?? "unit-none"}
-      >
-        <TabList>
-          {unitReservationUnits.map((ru) => (
-            <Tab
-              onClick={() => setSelectedReservationUnit(ru.pk ?? null)}
-              key={ru?.pk}
-            >
-              {ru?.nameFi}
-            </Tab>
-          ))}
-        </TabList>
-        {/* NOTE: we want the tabs as buttons, without this the HDS tabs break */}
-        <Tabs.TabPanel />
-      </Tabs>
+      <TabWrapper>
+        <Tabs
+          initiallyActiveTab={initiallyActiveTab >= 0 ? initiallyActiveTab : 0}
+          key={unitFilter ?? "unit-none"}
+        >
+          <TabList>
+            {unitReservationUnits.map((ru) => (
+              <Tab
+                onClick={() => setSelectedReservationUnit(ru.pk ?? null)}
+                key={ru?.pk}
+              >
+                {ru?.nameFi}
+              </Tab>
+            ))}
+          </TabList>
+          {/* NOTE: we want the tabs as buttons, without this the HDS tabs break */}
+          <Tabs.TabPanel />
+        </Tabs>
+      </TabWrapper>
       <NumberOfResultsContainer>
         {applicationEvents.length === totalNumberOfEvents ? (
           t("Allocation.countAllResults", { count: totalNumberOfEvents })

--- a/apps/admin-ui/src/component/recurring-reservations/queries.ts
+++ b/apps/admin-ui/src/component/recurring-reservations/queries.ts
@@ -63,16 +63,12 @@ export const ALLOCATION_UNFILTERED_QUERY = gql`
         node {
           applicationRound {
             nameFi
-          }
-          applicationEvents {
-            eventReservationUnits {
-              reservationUnit {
+            reservationUnits {
+              pk
+              nameFi
+              unit {
                 pk
                 nameFi
-                unit {
-                  pk
-                  nameFi
-                }
               }
             }
           }

--- a/apps/admin-ui/src/component/reservation-units/ReservationUnitsTable.tsx
+++ b/apps/admin-ui/src/component/reservation-units/ReservationUnitsTable.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { truncate } from "lodash";
-import { ReservationUnitType } from "common/types/gql-types";
 import { TFunction } from "i18next";
+import { ReservationUnitType } from "common/types/gql-types";
+import { truncate } from "@/helpers";
+import { reservationUnitUrl } from "@/common/urls";
 import { CustomTable, TableLink } from "../lists/components";
-import { reservationUnitUrl } from "../../common/urls";
 
 export type Sort = {
   field: string;
@@ -17,16 +17,14 @@ type Props = {
   reservationUnits: ReservationUnitType[];
 };
 
+const MAX_NAME_LENGTH = 22;
 const getColConfig = (t: TFunction) => [
   {
     headerName: t("ReservationUnits.headings.name"),
     key: "nameFi",
     transform: ({ nameFi, pk, unit }: ReservationUnitType) => (
       <TableLink href={reservationUnitUrl(pk ?? 0, unit?.pk ?? 0)}>
-        {truncate(nameFi ?? "-", {
-          length: 22,
-          omission: "...",
-        })}
+        {truncate(nameFi ?? "-", MAX_NAME_LENGTH)}
       </TableLink>
     ),
     isSortable: true,

--- a/apps/admin-ui/src/component/reservations/ReservationsTable.tsx
+++ b/apps/admin-ui/src/component/reservations/ReservationsTable.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
-import { memoize, truncate } from "lodash";
+import { memoize } from "lodash";
 import { ReservationType } from "common/types/gql-types";
+import { truncate } from "@/helpers";
+import { reservationUrl } from "@/common/urls";
+import { formatDateTime } from "@/common/util";
 import { CustomTable, TableLink } from "../lists/components";
-import { reservationUrl } from "../../common/urls";
 import { getReserveeName, reservationDateTimeString } from "./requested/util";
-import { formatDateTime } from "../../common/util";
 
 export type Sort = {
   field: string;
@@ -26,6 +27,7 @@ type Props = {
   reservations: ReservationType[];
 };
 
+const MAX_NAME_LENGTH = 22;
 const getColConfig = (t: TFunction): ReservationTableColumn[] => [
   {
     headerName: t("Reservations.headings.id"),
@@ -47,20 +49,14 @@ const getColConfig = (t: TFunction): ReservationTableColumn[] => [
     key: "reservation_unit_name_fi",
     isSortable: true,
     transform: ({ reservationUnits }: ReservationType) =>
-      truncate(reservationUnits?.[0]?.nameFi || "-", {
-        length: 22,
-        omission: "...",
-      }),
+      truncate(reservationUnits?.[0]?.nameFi || "-", MAX_NAME_LENGTH),
   },
   {
     headerName: t("Reservations.headings.unit"),
     key: "unit_name_fi",
     isSortable: true,
     transform: ({ reservationUnits }: ReservationType) =>
-      truncate(reservationUnits?.[0]?.unit?.nameFi || "-", {
-        length: 22,
-        omission: "...",
-      }),
+      truncate(reservationUnits?.[0]?.unit?.nameFi || "-", MAX_NAME_LENGTH),
   },
   {
     headerName: t("Reservations.headings.datetime"),
@@ -74,7 +70,7 @@ const getColConfig = (t: TFunction): ReservationTableColumn[] => [
     key: "created_at",
     isSortable: true,
     transform: ({ createdAt }: ReservationType) =>
-      formatDateTime(createdAt as string),
+      createdAt ? formatDateTime(createdAt) : "-",
   },
   {
     headerName: t("Reservations.headings.paymentStatus"),

--- a/apps/admin-ui/src/component/reservations/requested/util.ts
+++ b/apps/admin-ui/src/component/reservations/requested/util.ts
@@ -1,10 +1,4 @@
 import {
-  formatters as getFormatters,
-  getReservationPrice,
-  getUnRoundedReservationVolume,
-} from "common";
-
-import {
   differenceInHours,
   differenceInMinutes,
   format,
@@ -12,7 +6,12 @@ import {
   isSameDay,
 } from "date-fns";
 import { TFunction } from "i18next";
-import { trim, truncate } from "lodash";
+import { trim } from "lodash";
+import {
+  formatters as getFormatters,
+  getReservationPrice,
+  getUnRoundedReservationVolume,
+} from "common";
 import {
   AgeGroupType,
   Maybe,
@@ -26,6 +25,7 @@ import {
 } from "common/types/gql-types";
 import { fromApiDate } from "common/src/common/util";
 import { toMondayFirst } from "common/src/helpers";
+import { truncate } from "@/helpers";
 import { DATE_FORMAT, formatDate, formatTime } from "@/common/util";
 
 export const reservationDateTime = (
@@ -212,8 +212,7 @@ export const getTranslationKeyForReserveeType = (
 export const getReserveeName = (
   reservation: ReservationType,
   length = 50
-): string =>
-  truncate(reservation.reserveeName?.trim() ?? "", { length, omission: "…" });
+): string => truncate(reservation.reserveeName?.trim() ?? "-", length);
 
 export const getName = (reservation: ReservationType, t: TFunction) => {
   if (reservation.name) {

--- a/apps/admin-ui/src/helpers/index.ts
+++ b/apps/admin-ui/src/helpers/index.ts
@@ -64,4 +64,4 @@ export const reservationToInterval = (
 };
 
 export const truncate = (val: string, maxLen: number): string =>
-  val.length > maxLen ? `${val.substring(0, maxLen)}…` : val;
+  val.length > maxLen ? `${val.substring(0, maxLen - 1)}…` : val;

--- a/apps/ui/components/application/Form.tsx
+++ b/apps/ui/components/application/Form.tsx
@@ -13,10 +13,12 @@ import {
 } from "common/types/gql-types";
 import { type Maybe } from "graphql/jsutils/Maybe";
 import { z } from "zod";
-import { ApplicationEventSchedulePriority } from "common";
+import type {
+  ApplicationEventSchedulePriority,
+  ReservationUnitNode,
+} from "common";
 import { toApiDate } from "common/src/common/util";
 import { apiDateToUIDate, fromUIDate } from "@/modules/util";
-import { ReservationUnitUnion } from "@/hooks/useReservationUnitList";
 
 // NOTE the zod schemas have a lot of undefineds because the form is split into four pages
 // so you can't trust some of the zod validation (e.g. mandatory fields)
@@ -323,7 +325,7 @@ export const transformApplication = (
 
 export const convertApplicationToForm = (
   app: Maybe<ApplicationNode> | undefined,
-  reservationUnits: ReservationUnitUnion[]
+  reservationUnits: ReservationUnitNode[]
 ): ApplicationFormValues => {
   const formAes = filterNonNullable(app?.applicationEvents).map((ae) =>
     transformApplicationEventToForm(ae)

--- a/apps/ui/components/reservation-unit/Address.tsx
+++ b/apps/ui/components/reservation-unit/Address.tsx
@@ -2,18 +2,14 @@ import React from "react";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { H4 } from "common/src/common/typography";
-import {
-  LocationType,
-  ReservationUnitByPkType,
-  ReservationUnitType,
-  UnitType,
-} from "common/types/gql-types";
+import type { LocationType, UnitType } from "common/types/gql-types";
 import { IconLinkExternal } from "hds-react";
 import { IconButton } from "common/src/components";
+import type { ReservationUnitNode } from "common";
 import { getTranslation } from "../../modules/util";
 
 type Props = {
-  reservationUnit: ReservationUnitByPkType | ReservationUnitType;
+  reservationUnit: ReservationUnitNode;
 };
 
 const Container = styled.div`

--- a/apps/ui/components/reservation/ReservationCancellation.tsx
+++ b/apps/ui/components/reservation/ReservationCancellation.tsx
@@ -218,9 +218,7 @@ const ReservationCancellation = ({ id }: Props): JSX.Element => {
     register("description");
   }, [register]);
 
-  const reservationUnit = reservation?.reservationUnits
-    ? reservation.reservationUnits[0]
-    : undefined;
+  const reservationUnit = reservation?.reservationUnits?.[0] ?? null;
 
   const bylineContent = useMemo(() => {
     return (

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -1,39 +1,32 @@
-import {
-  getReservationPrice,
-  formatters as getFormatters,
-  PendingReservation,
-} from "common";
-import { breakpoints } from "common/src/common/style";
-import { H4, Strong } from "common/src/common/typography";
-import { differenceInMinutes, parseISO } from "date-fns";
-import Link from "next/link";
-import { trim } from "lodash";
 import React, { useMemo } from "react";
+import Link from "next/link";
+import { differenceInMinutes, parseISO } from "date-fns";
+import { trim } from "lodash";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import {
-  ReservationType,
-  ReservationUnitByPkType,
-  ReservationUnitType,
-} from "common/types/gql-types";
-import { getReservationUnitPrice } from "../../modules/reservationUnit";
+  getReservationPrice,
+  formatters as getFormatters,
+  type PendingReservation,
+  type ReservationUnitNode,
+} from "common";
+import { breakpoints } from "common/src/common/style";
+import { H4, Strong } from "common/src/common/typography";
+import type { ReservationType } from "common/types/gql-types";
+import { getReservationUnitPrice } from "@/modules/reservationUnit";
 import {
   capitalize,
   formatDurationMinutes,
   getMainImage,
   getTranslation,
-} from "../../modules/util";
-import { reservationUnitPath } from "../../modules/const";
+} from "@/modules/util";
+import { reservationUnitPath } from "@/modules/const";
 
 type Type = "pending" | "confirmed" | "complete";
 
 type Props = {
   reservation: ReservationType | PendingReservation;
-  reservationUnit:
-    | ReservationUnitType
-    | ReservationUnitByPkType
-    | null
-    | undefined;
+  reservationUnit: ReservationUnitNode | null;
   type: Type;
   shouldDisplayReservationUnitPrice?: boolean;
 };

--- a/apps/ui/hooks/useReservationUnitList.ts
+++ b/apps/ui/hooks/useReservationUnitList.ts
@@ -1,32 +1,29 @@
 import { useSessionStorage } from "react-use";
-import {
-  ReservationUnitByPkType,
-  ReservationUnitType,
-} from "common/types/gql-types";
+import type { ReservationUnitNode } from "common";
 
-export type ReservationUnitUnion = ReservationUnitType | ReservationUnitByPkType
+// export type ReservationUnitUnion = ReservationUnitType | ReservationUnitByPkType
 export type ReservationUnitList = {
-  reservationUnits: ReservationUnitUnion[];
-  selectReservationUnit: (ru: ReservationUnitUnion) => void;
-  containsReservationUnit: (ru: ReservationUnitUnion) => boolean;
-  removeReservationUnit: (ru: ReservationUnitUnion) => void;
+  reservationUnits: ReservationUnitNode[];
+  selectReservationUnit: (ru: ReservationUnitNode) => void;
+  containsReservationUnit: (ru: ReservationUnitNode) => boolean;
+  removeReservationUnit: (ru: ReservationUnitNode) => void;
   clearSelections: () => void;
 };
 
 const useReservationUnitsList = (): ReservationUnitList => {
-  const [reservationUnits, setReservationUnits] = useSessionStorage<ReservationUnitUnion[]>(
+  const [reservationUnits, setReservationUnits] = useSessionStorage<ReservationUnitNode[]>(
     "reservationUnitList",
     []
   );
 
-  const selectReservationUnit = (reservationUnit: ReservationUnitUnion) => {
+  const selectReservationUnit = (reservationUnit: ReservationUnitNode) => {
     setReservationUnits([
       ...(reservationUnits),
       reservationUnit,
     ]);
   };
 
-  const removeReservationUnit = (reservationUnit: ReservationUnitUnion) => {
+  const removeReservationUnit = (reservationUnit: ReservationUnitNode) => {
     if (!reservationUnits) {
       return;
     }
@@ -40,7 +37,7 @@ const useReservationUnitsList = (): ReservationUnitList => {
   };
 
   const containsReservationUnit = (
-    reservationUnit: ReservationUnitUnion
+    reservationUnit: ReservationUnitNode
   ): boolean =>
     reservationUnits
       ? reservationUnits.some((ru) => ru.pk === reservationUnit.pk)

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -1,24 +1,22 @@
-import { formatters as getFormatters, getReservationVolume } from "common";
+import { type ReservationUnitNode, formatters as getFormatters, getReservationVolume } from "common";
 import { flatten, trim, uniq } from "lodash";
 import { addDays } from "date-fns";
 import { i18n } from "next-i18next";
 import { toApiDate, toUIDate } from "common/src/common/util";
 import { RoundPeriod, isSlotWithinReservationTime } from "common/src/calendar/util";
 import {
-  EquipmentType,
+  type EquipmentType,
   ReservationsReservationStateChoices,
-  ReservationUnitByPkType,
-  ReservationUnitPricingType,
+  type ReservationUnitPricingType,
   ReservationUnitsReservationUnitPricingPricingTypeChoices,
   ReservationUnitsReservationUnitPricingStatusChoices,
   ReservationUnitState,
-  ReservationUnitType,
-  UnitType,
+  type UnitType,
 } from "common/types/gql-types";
 import { capitalize, getTranslation } from "./util";
 
 export const isReservationUnitPublished = (
-  reservationUnit?: ReservationUnitType | ReservationUnitByPkType
+  reservationUnit?: ReservationUnitNode
 ): boolean => {
   if (!reservationUnit) {
     return false;
@@ -90,7 +88,7 @@ export const getEquipmentList = (equipment: EquipmentType[]): string[] => {
 };
 
 export const getReservationUnitName = (
-  reservationUnit?: ReservationUnitType | ReservationUnitByPkType,
+  reservationUnit?: ReservationUnitNode,
   language: string = i18n?.language ?? "fi"
 ): string | undefined => {
   if (!reservationUnit) {
@@ -143,13 +141,13 @@ export const getReservationUnitInstructionsKey = (
 };
 
 export const getDurationRange = (
-  reservationUnit: ReservationUnitType | ReservationUnitByPkType
+  reservationUnit: ReservationUnitNode
 ): string => {
   return `${reservationUnit.minReservationDuration} - ${reservationUnit.maxReservationDuration}`;
 };
 
 export const getActivePricing = (
-  reservationUnit: ReservationUnitType | ReservationUnitByPkType
+  reservationUnit: ReservationUnitNode
 ): ReservationUnitPricingType | undefined => {
   const { pricings } = reservationUnit;
 
@@ -161,7 +159,7 @@ export const getActivePricing = (
 };
 
 export const getFuturePricing = (
-  reservationUnit: ReservationUnitByPkType,
+  reservationUnit: ReservationUnitNode,
   applicationRounds: RoundPeriod[] = [],
   reservationDate?: Date
 ): ReservationUnitPricingType | undefined => {
@@ -259,7 +257,7 @@ export const getPrice = (props: GetPriceType): string => {
 };
 
 export type GetReservationUnitPriceProps = {
-  reservationUnit?: ReservationUnitType | ReservationUnitByPkType;
+  reservationUnit?: ReservationUnitNode;
   pricingDate?: Date;
   minutes?: number;
   trailingZeros?: boolean;
@@ -270,19 +268,17 @@ export const getReservationUnitPrice = (
   props: GetReservationUnitPriceProps
 ): string | undefined => {
   const {
-    reservationUnit,
+    reservationUnit: ru,
     pricingDate,
     minutes,
     trailingZeros = false,
     asInt = false,
   } = props;
 
-  if (!reservationUnit) {
+  if (!ru) {
     return undefined;
   }
 
-  // NOTE cast is mandatory because the Union doesn't overlap even though it has identical fields
-  const ru = reservationUnit as ReservationUnitByPkType
   const pricing: ReservationUnitPricingType | undefined = pricingDate
     ? getFuturePricing(ru, [], pricingDate) || getActivePricing(ru)
     : getActivePricing(ru);

--- a/apps/ui/modules/util.ts
+++ b/apps/ui/modules/util.ts
@@ -9,13 +9,11 @@ import {
   isValidDate,
   getTranslation,
 } from "common/src/common/util";
-import type { OptionType, ReducedApplicationStatus } from "common/types/common";
+import type { OptionType, ReducedApplicationStatus, ReservationUnitNode } from "common/types/common";
 import {
   type ReservationUnitImageType,
-  type ReservationUnitType,
   ApplicationStatusChoice,
-  type ReservationUnitByPkType,
-  AgeGroupType,
+  type AgeGroupType,
 } from "common/types/gql-types";
 import {
   searchPrefix,
@@ -207,7 +205,7 @@ const imagePriority = ["main", "map", "ground_plan", "other"].map((n) =>
 );
 
 export const getMainImage = (
-  ru?: ReservationUnitType | ReservationUnitByPkType
+  ru?: ReservationUnitNode
 ): ReservationUnitImageType | null => {
   if (!ru || !ru.images || ru.images.length === 0) {
     return null;
@@ -236,7 +234,7 @@ export const orderImages = (
   return result;
 };
 
-export const getAddressAlt = (ru: ReservationUnitType): string | null => {
+export const getAddressAlt = (ru: ReservationUnitNode): string | null => {
   const { location } = ru.unit || {};
 
   if (!location) {

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -28,7 +28,6 @@ import {
   ReservationPurposeType,
   ReservationsReservationReserveeTypeChoices,
   ReservationType,
-  ReservationUnitByPkType,
   ReservationUnitType,
   ReservationUpdateMutationInput,
   ReservationUpdateMutationPayload,
@@ -251,7 +250,7 @@ const ReservationUnitReservationWithReservationProp = ({
 
   const steps: ReservationStep[] = useMemo(() => {
     const price = getReservationUnitPrice({
-      reservationUnit: reservationUnit as unknown as ReservationUnitByPkType,
+      reservationUnit,
       pricingDate: reservation?.begin
         ? new Date(reservation?.begin)
         : undefined,

--- a/apps/ui/pages/reservation/confirmation/[id].tsx
+++ b/apps/ui/pages/reservation/confirmation/[id].tsx
@@ -102,7 +102,7 @@ const ReservationSuccess = ({ reservationPk }: Props) => {
     );
   }
 
-  const reservationUnit = reservation?.reservationUnits?.[0] ?? undefined;
+  const reservationUnit = reservation?.reservationUnits?.[0] ?? null;
 
   return (
     <StyledContainer size="s">

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -268,7 +268,7 @@ const Reservation = ({ termsOfUse, id }: Props): JSX.Element | null => {
     orderUuid: reservation?.orderUuid ?? "",
   });
 
-  const reservationUnit = reservation?.reservationUnits?.[0];
+  const reservationUnit = reservation?.reservationUnits?.[0] ?? null;
   const instructionsKey =
     reservation?.state != null
       ? getReservationUnitInstructionsKey(reservation.state)

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -20,7 +20,6 @@ import {
   type ReservationType,
   type ReservationUnitByPkType,
   type ReservationUnitsReservationUnitReservationStartIntervalChoices,
-  type ReservationUnitType,
   ReservationState,
 } from "../../types/gql-types";
 import {
@@ -29,6 +28,7 @@ import {
   type ApplicationEvent,
   type OptionType,
   type PendingReservation,
+  type ReservationUnitNode,
 } from "../../types/common";
 import {
   convertHMSToSeconds,
@@ -609,7 +609,7 @@ export const isReservationUnitReservable = (
 };
 
 export const isReservationStartInFuture = (
-  reservationUnit: ReservationUnitType | ReservationUnitByPkType,
+  reservationUnit: ReservationUnitNode,
   now = new Date()
 ): boolean => {
   const bufferDays = reservationUnit.reservationsMaxDaysBefore || 0;
@@ -622,7 +622,7 @@ export const isReservationStartInFuture = (
 };
 
 export const getNormalizedReservationBeginTime = (
-  reservationUnit: ReservationUnitType | ReservationUnitByPkType
+  reservationUnit: ReservationUnitNode
 ): string => {
   const bufferDays = reservationUnit.reservationsMaxDaysBefore || 0;
   const negativeBuffer = Math.abs(bufferDays) * -1;
@@ -695,7 +695,7 @@ export const getNewReservation = ({
   end,
   reservationUnit,
 }: {
-  reservationUnit: ReservationUnitByPkType;
+  reservationUnit: ReservationUnitNode;
   start: Date;
   end: Date;
 }): PendingReservation => {

--- a/packages/common/types/common.ts
+++ b/packages/common/types/common.ts
@@ -1,3 +1,8 @@
+import type { ReservationUnitByPkType, ReservationUnitType } from "./gql-types";
+
+// backend / generation problem: there is separate types for list and singular queries
+// these types have 100% overlap but are not compatible
+export type ReservationUnitNode = ReservationUnitByPkType | ReservationUnitType;
 export type CalendarBufferEvent = {
   state: "BUFFER";
 };


### PR DESCRIPTION
- fix: always show all units and reservation-units even if they have no applications
- fix: truncate long reservation-unit names
- fix: tabs overflowing from grid
- refactor: use a common ReservationUnit union type to remove some casts

Refs: TILA-2951