### PR TITLE
fix: cache table queries when filtering n sorting

### DIFF
--- a/apps/admin-ui/src/component/Unit/Units.tsx
+++ b/apps/admin-ui/src/component/Unit/Units.tsx
@@ -17,7 +17,7 @@ const Units = (): JSX.Element => {
 
   const { t } = useTranslation();
 
-  const onSortChanged = (sortField: string) => {
+  const handleSortChanged = (sortField: string) => {
     setSort({
       field: sortField,
       sort: sort?.field === sortField ? !sort?.sort : true,
@@ -45,10 +45,9 @@ const Units = (): JSX.Element => {
         <Filters onSearch={debouncedSearch} />
         <HR />
         <UnitsDataLoader
-          key={JSON.stringify({ ...search, ...sort })}
           filters={search}
           sort={sort}
-          sortChanged={onSortChanged}
+          onSortChanged={handleSortChanged}
         />
       </Container>
     </>

--- a/apps/admin-ui/src/component/my-units/MyUnits.tsx
+++ b/apps/admin-ui/src/component/my-units/MyUnits.tsx
@@ -17,7 +17,7 @@ const MyUnits = () => {
 
   const { t } = useTranslation();
 
-  const onSortChanged = (sortField: string) => {
+  const handleSortChanged = (sortField: string) => {
     setSort({
       field: sortField,
       sort: sort?.field === sortField ? !sort?.sort : true,
@@ -37,7 +37,7 @@ const MyUnits = () => {
         <UnitsDataLoader
           filters={search}
           sort={sort}
-          sortChanged={onSortChanged}
+          onSortChanged={handleSortChanged}
           isMyUnits
         />
       </Container>

--- a/apps/admin-ui/src/component/reservations/ReservationsDataLoader.tsx
+++ b/apps/admin-ui/src/component/reservations/ReservationsDataLoader.tsx
@@ -131,7 +131,7 @@ const ReservationsDataLoader = ({
     sort
   );
 
-  if (loading) {
+  if (loading && !data) {
     return <Loader />;
   }
 


### PR DESCRIPTION
If we already have data (i.e. the query is in apollo cache) don't show loaders so the user experience is snappier when sorting or moving between pages.