### PR TITLE
Changes durationOptions value to "H:mm" format

### DIFF
--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -22,7 +22,11 @@ import {
 } from "hds-react";
 import { maxBy, trim, trimStart } from "lodash";
 import { CalendarEvent } from "common/src/calendar/Calendar";
-import { secondsToHms, toUIDate } from "common/src/common/util";
+import {
+  convertHMSToSeconds,
+  secondsToHms,
+  toUIDate,
+} from "common/src/common/util";
 import { useLocalStorage } from "react-use";
 import { Transition } from "react-transition-group";
 import {
@@ -493,16 +497,18 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
       .filter((n) => n.label !== "")
       .map((n) => n.value);
 
+    const durationValue = durations[0]?.toString();
+
     if (
       date == null ||
       dayStartTime == null ||
       dayEndTime == null ||
-      durations == null
+      durationValue == null
     ) {
       return [];
     }
 
-    const durationInMinutes = (durations[0] as number) * 60;
+    const [endHours, endMinutes] = durationValue.split(":").map(Number);
 
     return getDayIntervals(
       format(new Date(dayStartTime), "HH:mm"),
@@ -515,7 +521,7 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
 
         const d = new Date(date);
         d.setHours(hours, minutes);
-        const e = addMinutes(d, durationInMinutes);
+        const e = addMinutes(d, endHours * 60 + endMinutes);
         return isSlotReservable(d, e);
       })
       .map((n) => ({
@@ -578,7 +584,7 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
   })();
 
   const minutes =
-    (Number.isNaN(Number(duration?.value)) ? 0 : Number(duration?.value)) * 60;
+    (convertHMSToSeconds(`0${duration?.value ?? 0}:00`) ?? 0) / 60;
   const price =
     date != null
       ? getReservationUnitPrice({

--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -51,23 +51,23 @@ describe("getDurationOptions", () => {
     expect( getDurationOptions( 1800, 5400, interval15)).toEqual([
       {
         label: "0:30",
-        value: 0.5,
+        value: "0:30",
       },
       {
         label: "0:45",
-        value: 0.75,
+        value: "0:45",
       },
       {
         label: "1:00",
-        value: 1,
+        value: "1:00",
       },
       {
         label: "1:15",
-        value: 1.25,
+        value: "1:15",
       },
       {
         label: "1:30",
-        value: 1.5,
+        value: "1:30",
       },
     ]);
   });
@@ -77,23 +77,23 @@ describe("getDurationOptions", () => {
     expect( getDurationOptions( 1800, 30600, interval90)).toEqual([
       {
         label: "1:30",
-        value: 1.5,
+        value: "1:30",
       },
       {
         label: "3:00",
-        value: 3,
+        value: "3:00",
       },
       {
         label: "4:30",
-        value: 4.5,
+        value: "4:30",
       },
       {
         label: "6:00",
-        value: 6,
+        value: "6:00",
       },
       {
         label: "7:30",
-        value: 7.5,
+        value: "7:30",
       },
     ]);
   });

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -29,31 +29,27 @@ export const getDurationOptions = (
   maxReservationDuration: number | undefined,
   reservationStartInterval: ReservationUnitsReservationUnitReservationStartIntervalChoices
 ): OptionType[] => {
-  const durationStep = getIntervalMinutes(reservationStartInterval) * 60;
+  const intervalSeconds = getIntervalMinutes(reservationStartInterval) * 60;
 
-  if (!minReservationDuration || !maxReservationDuration || !durationStep)
+  if (!minReservationDuration || !maxReservationDuration || !intervalSeconds)
     return [];
 
-  const durationSteps = [];
+  const timeOptions = [];
   for (
     let i =
-      minReservationDuration > durationStep
+      minReservationDuration > intervalSeconds
         ? minReservationDuration
-        : durationStep;
+        : intervalSeconds;
     i <= maxReservationDuration;
-    i += durationStep
+    i += intervalSeconds
   ) {
-    durationSteps.push(i);
-  }
-
-  const timeOptions = durationSteps.map((n) => {
-    const hms = secondsToHms(n);
+    const hms = secondsToHms(i);
     const minute = String(hms.m).padEnd(2, "0");
-    return {
+    timeOptions.push({
       label: `${hms.h}:${minute}`,
-      value: n/3600,
-    };
-  });
+      value: `${hms.h}:${minute}`,
+    });
+  }
 
   return timeOptions;
 };

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -111,8 +111,8 @@ export const areReservableTimesAvailable = (
   slotDate: Date,
   validateEnding = false
 ): boolean => {
-  return !!reservableTimes?.some((oh) => {
-    const { startDatetime, endDatetime } = oh;
+  return !!reservableTimes?.some((rt) => {
+    const { startDatetime, endDatetime } = rt;
 
     if (!startDatetime || !endDatetime) return false;
 
@@ -448,7 +448,7 @@ export const getSlotPropGetter =
       const nEndDate = new Date(n.endDatetime);
       return nStartDate >= start && nEndDate <= end;
     });
-    switch (
+    if (
       areSlotsReservable(
         [date],
         hours,
@@ -460,13 +460,12 @@ export const getSlotPropGetter =
       ) &&
       (customValidation ? customValidation(date) : true)
     ) {
-      case true:
-        return {};
-      default:
-        return {
-          className: "rbc-timeslot-inactive",
-        };
+      return {};
     }
+
+    return {
+      className: "rbc-timeslot-inactive",
+    };
   };
 
 // TimeSlots change the Calendar view. How many intervals are shown i.e. every half an hour, every hour


### PR DESCRIPTION
Makes duration use a H:mm-format string as the value again, instead of a number. Seems to fix booking a time via the calendar, and the quick reservation (w/ price) works, too. However, doesn't yet fix the problems with the calendar showing incorrect reservable times. :/