### PR TITLE
Fix: show-only-available checkbox now works on initial page load

### DIFF
--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -388,6 +388,7 @@ const SearchForm = ({
     }, {});
     onSearch(searchCriteria);
   };
+
   const areOptionsLoaded =
     !unitsLoading && !purposesLoading && !typesLoading && !equipmentsLoading;
 

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -146,8 +146,8 @@ const processVariables = (values: Record<string, string>, language: string) => {
     ...replaceIfExists(values.duration, {
       reservableMinimumDurationMinutes: parseInt(values.duration, 10),
     }),
-    ...replaceIfExists(values.showOnlyReservable === "true", {
-      showOnlyReservable: !!values.showOnlyReservable,
+    ...replaceIfExists(values.showOnlyReservable !== "false", {
+      showOnlyReservable: true,
     }),
     first: pagingLimit,
     orderBy: values.order === "desc" ? `-${sortCriteria}` : sortCriteria,


### PR DESCRIPTION
The "show only available times" checkbox was checked by default, but the filter wasn't in effect on the initial page load.