### PR TITLE
fix: sort cancelled reservations newest first

### DIFF
--- a/apps/ui/pages/reservations/index.tsx
+++ b/apps/ui/pages/reservations/index.tsx
@@ -102,7 +102,7 @@ const Reservations = (): JSX.Element | null => {
               ReservationsReservationStateChoices.WaitingForPayment,
               ReservationsReservationStateChoices.Denied,
             ],
-      orderBy: tab !== "past" ? "begin" : "-begin",
+      orderBy: tab === "upcoming" ? "begin" : "-begin",
       user: currentUser?.pk?.toString(),
       // valid values: "normal", "behalf", "staff", "blocked"
       reservationType: [


### PR DESCRIPTION
- fixes an issue with test automation (more than 100 cancelled).
- cleaner for users since you probably don't care about what you cancelled three years ago.