### PR TITLE
Fix quick reservation time intervals

### DIFF
--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -492,6 +492,7 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
   const { start: dayStartTime, end: dayEndTime }: { start?: Date; end?: Date } =
     timeIntervalForDay ?? {};
 
+  // FIXME there is an issue with pk 110 (no startTime available), others work
   const startingTimesOptions: OptionType[] = useMemo(() => {
     const durations = durationOptions
       .filter((n) => n.label !== "")

--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -405,8 +405,8 @@ describe("getReservationCancellationReason", () => {
     expect(
       getReservationCancellationReason({
         ...reservation,
-        begin: addHours(startOfToday(), 12).toISOString(),
-        end: addHours(startOfToday(), 13).toISOString(),
+        begin: addHours(new Date(), 12).toISOString(),
+        end: addHours(new Date(), 13).toISOString(),
         reservationUnits: [resUnit],
       })
     ).toBe("BUFFER");
@@ -744,17 +744,12 @@ describe("getCheckoutUrl", () => {
       getCheckoutUrl({ ...order, checkoutUrl: undefined })
     ).not.toBeDefined();
 
+    // we are expecting console.errors => suppress
+    jest.spyOn(console, "error").mockImplementation(jest.fn());
     expect(
       getCheckoutUrl({
         ...order,
         checkoutUrl: "checkout.url?user=1111-2222-3333-4444",
-      })
-    ).not.toBeDefined();
-
-    expect(
-      getCheckoutUrl({
-        ...order,
-        checkoutUrl: "https://checkout.url/path",
       })
     ).not.toBeDefined();
   });

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -218,8 +218,7 @@ export const isReservationReservable = ({
     return false;
   }
 
-  const reservationsArr =
-    reservations?.filter((r): r is NonNullable<typeof r> => r != null) ?? [];
+  const reservationsArr = filterNonNullable(reservations);
   if (
     doBuffersCollide(
       {

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -311,6 +311,17 @@ export const createMockOpeningTimes = (pk: number) => {
       },
     ];
   }
+  if (pk % 3 === 0) {
+    return Array.from(Array(100)).map((_, index) => {
+      const start = toApiDate(addDays(new Date(), index));
+      const end = toApiDate(addDays(new Date(), index));
+      return {
+        startDatetime: `${start}T00:00:00+02:00`,
+        endDatetime: `${end}T23:59:00+02:00`,
+      };
+    });
+  }
+
   return Array.from(Array(100)).map((_, index) => {
     const start = toApiDate(addDays(new Date(), index));
     const end = toApiDate(addDays(new Date(), index));

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -303,14 +303,18 @@ export const getReservationUnitPrice = (
 // if pk is odd, return 100 days from 12:00 to 20:00
 // assuming that the backend will add TZ info to the dates
 export const createMockOpeningTimes = (pk: number) => {
-  if (pk % 2 === 0) {
+  // A weird case where the end time < start time (different days)
+  if (pk % 5 === 0) {
+    const start = toApiDate(addDays(new Date(), -4));
+    const end = toApiDate(addDays(new Date(), 4));
     return [
       {
-        startDatetime: "2023-01-01T04:00:00+02:00",
-        endDatetime: "2027-12-31T20:00:00+02:00",
+        startDatetime: `${start}T23:00:00+02:00`,
+        endDatetime: `${end}T01:00:00+02:00`,
       },
     ];
   }
+
   if (pk % 3 === 0) {
     return Array.from(Array(100)).map((_, index) => {
       const start = toApiDate(addDays(new Date(), index));
@@ -322,6 +326,14 @@ export const createMockOpeningTimes = (pk: number) => {
     });
   }
 
+  if (pk % 2 === 0) {
+    return [
+      {
+        startDatetime: "2023-01-01T04:00:00+02:00",
+        endDatetime: "2027-12-31T20:00:00+02:00",
+      },
+    ];
+  }
   return Array.from(Array(100)).map((_, index) => {
     const start = toApiDate(addDays(new Date(), index));
     const end = toApiDate(addDays(new Date(), index));

--- a/packages/common/src/calendar/__tests__/calendar.test.ts
+++ b/packages/common/src/calendar/__tests__/calendar.test.ts
@@ -4,7 +4,6 @@ import {
   doBuffersCollide,
   doesBufferCollide,
   doReservationsCollide,
-  getAvailableTimes,
   getBufferedEventTimes,
   getDayIntervals,
   getEventBuffers,
@@ -16,7 +15,6 @@ import {
   isReservationStartInFuture,
   isReservationUnitReservable,
   isSlotWithinReservationTime,
-  isSlotWithinTimeframe,
   isStartTimeWithinInterval,
 } from "../util";
 import {
@@ -76,14 +74,6 @@ test("isReservationLongEnough", () => {
       5400
     )
   ).toBe(true);
-});
-
-test("isSlotWithinTimeframe", () => {
-  expect(isSlotWithinTimeframe(new Date(2021, 9, 9))).toBe(false);
-  expect(isSlotWithinTimeframe(new Date())).toBe(false);
-  expect(isSlotWithinTimeframe(new Date(), undefined, undefined, -1)).toBe(
-    true
-  );
 });
 
 describe("areSlotsReservable", () => {
@@ -1001,70 +991,9 @@ describe("getNormalizedReservationBeginTime", () => {
   });
 });
 
-describe("getAvailableTimes", () => {
-  test("get correct times", () => {
-    const reservableTimeSpans: ReservableTimeSpanType = [
-      {
-        startDatetime: "2022-11-14T04:00:00+02:00",
-        endDatetime: "2022-11-14T20:00:00+02:00",
-      },
-    ];
-
-    expect(
-      getAvailableTimes(
-        {
-          reservableTimeSpans,
-          reservationStartInterval: "INTERVAL_90_MINS",
-        } as ReservationUnitByPkType,
-        new Date("2022-11-14T00:00:00+02:00")
-      )
-    ).toEqual([
-      "04:00",
-      "05:30",
-      "07:00",
-      "08:30",
-      "10:00",
-      "11:30",
-      "13:00",
-      "14:30",
-      "16:00",
-      "17:30",
-      "19:00",
-    ]);
-  });
-
-  test("get correct times", () => {
-    const reservableTimeSpans: ReservableTimeSpanType = [
-      {
-        startDatetime: "2022-11-14T04:00:00+02:00",
-        endDatetime: "2022-11-14T06:00:00+02:00",
-      },
-    ];
-
-    expect(
-      getAvailableTimes(
-        {
-          reservableTimeSpans,
-          reservationStartInterval: "INTERVAL_15_MINS",
-        } as ReservationUnitByPkType,
-        new Date("2022-11-14T00:00:00+02:00")
-      )
-    ).toEqual([
-      "04:00",
-      "04:15",
-      "04:30",
-      "04:45",
-      "05:00",
-      "05:15",
-      "05:30",
-      "05:45",
-    ]);
-  });
-});
-
 describe("getOpenDays", () => {
   test("correct output", () => {
-    const reservableTimeSpans: ReservableTimeSpanType = [
+    const reservableTimeSpans = [
       {
         startDatetime: "2022-09-14T04:00:00+00:00",
         endDatetime: "2022-09-14T06:00:00+00:00",
@@ -1081,7 +1010,7 @@ describe("getOpenDays", () => {
         startDatetime: "2022-08-10T04:00:00+00:00",
         endDatetime: "2022-08-10T06:00:00+00:00",
       },
-    ];
+    ] as ReservableTimeSpanType[];
 
     expect(
       getOpenDays({ reservableTimeSpans } as ReservationUnitByPkType)

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -9,7 +9,6 @@ import {
   getISODay,
   isAfter,
   isBefore,
-  isSameDay,
   isWithinInterval,
   roundToNearestMinutes,
   startOfDay,
@@ -39,7 +38,6 @@ import {
   startOfWeek,
   toUIDate,
 } from "../common/util";
-import { filterNonNullable } from "../helpers";
 
 export const longDate = (date: Date, t: TFunction): string =>
   t("common:dateLong", {
@@ -630,39 +628,6 @@ export const parseTimeframeLength = (begin: string, end: string): string => {
   const endDate = new Date(end);
   const diff = differenceInSeconds(endDate, beginDate);
   return formatSecondDuration(diff);
-};
-
-// Returns an timeslot array (in HH:mm format) with the time-slots that are
-// available for reservation on the given date
-export const getAvailableTimes = (
-  reservationUnit: ReservationUnitByPkType,
-  date: Date
-): string[] => {
-  const allTimes: string[] = [];
-  const { reservableTimeSpans, reservationStartInterval } = reservationUnit;
-  filterNonNullable(reservableTimeSpans)
-    ?.filter(({ startDatetime }) => {
-      if (!startDatetime) return false;
-      const startDate = new Date(startDatetime);
-      return isSameDay(new Date(date), startDate);
-    })
-    ?.forEach((rts) => {
-      if (!rts?.startDatetime || !rts?.endDatetime) return;
-      const intervals = getDayIntervals(
-        format(new Date(rts.startDatetime), "HH:mm"),
-        format(new Date(rts.endDatetime), "HH:mm"),
-        reservationStartInterval
-      );
-
-      const times: string[] = intervals.map((val) => {
-        const [startHours, startMinutes] = val.split(":");
-
-        return `${startHours}:${startMinutes}`;
-      });
-      allTimes.push(...times);
-    });
-
-  return allTimes;
 };
 
 export const getOpenDays = (

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -120,7 +120,7 @@ export const areReservableTimesAvailable = (
     const endDate = new Date(endDatetime);
 
     if (validateEnding) {
-      return startDate <= slotDate && endDate >= slotDate;
+      return startDate <= slotDate && endDate > slotDate;
     }
     return startDate <= slotDate;
   });
@@ -139,26 +139,19 @@ export const isSlotWithinReservationTime = (
 
 export const isSlotWithinTimeframe = (
   start: Date,
-  reservationsMinDaysBefore: number,
-  reservationsMaxDaysBefore: number,
+  minDaysBefore: number,
+  maxDaysBefore: number,
   reservationBegins?: Date,
   reservationEnds?: Date
 ) => {
   const isLegalTimeframe =
     isAfter(start, new Date()) &&
     isSlotWithinReservationTime(start, reservationBegins, reservationEnds);
-  const latest = addDays(new Date(), reservationsMaxDaysBefore);
+  const maxDay = addDays(new Date(), maxDaysBefore);
   // if max days === 0 => latest = today
-  const isBeforeMaxDaysBefore =
-    reservationsMaxDaysBefore === 0 || !isAfter(start, latest);
-  const earliestReservationStart = addDays(
-    new Date(),
-    reservationsMinDaysBefore
-  );
-  const isAfterMinDaysBefore = !isBefore(
-    start,
-    startOfDay(earliestReservationStart)
-  );
+  const isBeforeMaxDaysBefore = maxDaysBefore === 0 || !isAfter(start, maxDay);
+  const minDay = addDays(new Date(), minDaysBefore);
+  const isAfterMinDaysBefore = !isBefore(start, startOfDay(minDay));
   return isLegalTimeframe && isAfterMinDaysBefore && isBeforeMaxDaysBefore;
 };
 

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -349,20 +349,18 @@ export const isStartTimeWithinInterval = (
   if (!interval) return true;
 
   // TODO this is awfully similar to the one in QuickReservation
-  const timeframeArr = reservableTimeSpans.filter(
-    (n) => {
-      if (!n.startDatetime || !n.endDatetime) return false;
+  const timeframeArr = reservableTimeSpans.filter((n) => {
+    if (!n.startDatetime || !n.endDatetime) return false;
 
-      const begin = isSameDay(new Date(n.startDatetime), start)
-        ? new Date(n.startDatetime)
-        : set(start, { hours: 0, minutes: 0 });
-      const end = isSameDay(new Date(n.endDatetime), start)
-        ? new Date(n.endDatetime)
-        : set(start, { hours: 23, minutes: 59 });
+    const begin = isSameDay(new Date(n.startDatetime), start)
+      ? new Date(n.startDatetime)
+      : set(start, { hours: 0, minutes: 0 });
+    const end = isSameDay(new Date(n.endDatetime), start)
+      ? new Date(n.endDatetime)
+      : set(start, { hours: 23, minutes: 59 });
 
-      return isWithinInterval(start, { start: begin, end });
-    }
-  );
+    return isWithinInterval(start, { start: begin, end });
+  });
   type TimeFrame = { start: Date; end: Date };
   const timeframe = timeframeArr
     .map((n) =>


### PR DESCRIPTION
Multi day intervals causing issues for both quick  reservation and the control bar.

- fix: Calendar allowing selecting an extra 30 mins
- fix: 24h time spans working
- fix: QuickReservation next time not working occasionally