### PR TITLE
fix: regular user can't see waiting for payment

### DIFF
--- a/apps/ui/components/reservations/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/reservations/UnpaidReservationNotification.tsx
@@ -3,10 +3,7 @@ import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { breakpoints } from "common/src/common/style";
-import {
-  ReservationsReservationStateChoices,
-  ReservationsReservationTypeChoices,
-} from "common/types/gql-types";
+import { ReservationsReservationStateChoices } from "common/types/gql-types";
 import NotificationWrapper from "common/src/components/NotificationWrapper";
 import { useCurrentUser } from "@/hooks/user";
 import { BlackButton, Toast } from "@/styles/util";
@@ -48,11 +45,7 @@ const ReservationNotification = () => {
     orderBy: "-pk",
   });
 
-  const reservation = reservations?.find(
-    (r) =>
-      r.state === ReservationsReservationStateChoices.WaitingForPayment &&
-      r.type === ReservationsReservationTypeChoices.Normal
-  );
+  const reservation = reservations?.[0];
 
   const { order } = useOrder({
     orderUuid: reservation?.orderUuid ?? undefined,

--- a/apps/ui/hooks/reservation.tsx
+++ b/apps/ui/hooks/reservation.tsx
@@ -13,7 +13,6 @@ import {
   ReservationType,
   ReservationsReservationStateChoices,
   UserType,
-  ReservationsReservationTypeChoices,
 } from "common/types/gql-types";
 import {
   DELETE_RESERVATION,
@@ -145,14 +144,12 @@ type UseReservationsProps = {
   currentUser?: UserType;
   states?: ReservationsReservationStateChoices[];
   orderBy?: string;
-  type?: ReservationsReservationTypeChoices;
 };
 
 export const useReservations = ({
   currentUser,
   states,
   orderBy,
-  type,
 }: UseReservationsProps): {
   reservations: ReservationType[];
   error?: ApolloError;
@@ -165,7 +162,6 @@ export const useReservations = ({
       variables: {
         ...(states != null && states?.length > 0 && { state: states }),
         ...(orderBy && { orderBy }),
-        ...(type && { reservationType: [type.toLowerCase()] }),
         user: currentUser?.pk?.toString(),
       },
       fetchPolicy: "no-cache",

--- a/apps/ui/modules/queries/reservation.ts
+++ b/apps/ui/modules/queries/reservation.ts
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+import { ReservationsReservationTypeChoices } from "common/types/gql-types";
 
 export const CREATE_RESERVATION = gql`
   mutation createReservation($input: ReservationCreateMutationInput!) {
@@ -107,6 +108,10 @@ export const CONFIRM_RESERVATION = gql`
   }
 `;
 
+// NOTE hard coded NORMAL type so only ment to be used in client ui.
+// reservationType valid values: "normal", "behalf", "staff", "blocked"
+// even though the ReservationsReservationTypeChoices says they are uppercase
+// NOTE bang user ID so this doesn't get abused (don't use it without a user)
 export const LIST_RESERVATIONS = gql`
   query listReservations(
     $before: String
@@ -116,10 +121,9 @@ export const LIST_RESERVATIONS = gql`
     $begin: DateTime
     $end: DateTime
     $state: [String]
-    $user: ID
+    $user: ID!
     $reservationUnit: [ID]
     $orderBy: String
-    $reservationType: [String]
   ) {
     reservations(
       before: $before
@@ -132,7 +136,7 @@ export const LIST_RESERVATIONS = gql`
       user: $user
       reservationUnit: $reservationUnit
       orderBy: $orderBy
-      reservationType: $reservationType
+      reservationType: "${ReservationsReservationTypeChoices.Normal.toLowerCase()}"
     ) {
       edges {
         node {
@@ -146,7 +150,6 @@ export const LIST_RESERVATIONS = gql`
           bufferTimeAfter
           orderUuid
           isBlocked
-          type
           reservationUnits {
             pk
             nameFi

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -506,8 +506,6 @@ const ReservationUnit = ({
         user: currentUser?.pk?.toString(),
         reservationUnit: [reservationUnit?.pk?.toString() ?? ""],
         state: allowedReservationStates,
-        // valid values: "normal", "behalf", "staff", "blocked"
-        reservationType: ["normal"],
       },
     }
   );

--- a/apps/ui/pages/reservations/index.tsx
+++ b/apps/ui/pages/reservations/index.tsx
@@ -12,7 +12,6 @@ import {
   type Query,
   type QueryReservationsArgs,
   ReservationsReservationStateChoices,
-  ReservationsReservationTypeChoices,
 } from "common/types/gql-types";
 import { Container } from "common";
 import { filterNonNullable } from "common/src/helpers";
@@ -104,10 +103,6 @@ const Reservations = (): JSX.Element | null => {
             ],
       orderBy: tab === "upcoming" ? "begin" : "-begin",
       user: currentUser?.pk?.toString(),
-      // valid values: "normal", "behalf", "staff", "blocked"
-      reservationType: [
-        ReservationsReservationTypeChoices.Normal.toLowerCase(),
-      ],
       begin: tab === "upcoming" ? today.toISOString() : undefined,
       end: tab === "past" ? today.toISOString() : undefined,
     },


### PR DESCRIPTION
list reservations query
- make user id mandatory
- is only ment to be used for client reservations