### PR TITLE
Fix data range picker crashing

### DIFF
--- a/apps/admin-ui/src/component/my-units/DayNavigation.tsx
+++ b/apps/admin-ui/src/component/my-units/DayNavigation.tsx
@@ -60,7 +60,9 @@ const DayNavigation = ({ date, onDateChange }: Props): JSX.Element => {
         initialMonth={d}
         language="fi"
         required
-        onChange={(value) => onDateChange({ date: fromUIDate(value) })}
+        onChange={(value) =>
+          onDateChange({ date: fromUIDate(value) ?? new Date() })
+        }
         value={toUIDate(d)}
       />
       <Button

--- a/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
+++ b/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
@@ -196,8 +196,8 @@ const MyUnitRecurringReservationForm = ({ reservationUnits }: Props) => {
   const checkedReservations = useFilteredReservationList({
     items: newReservations.reservations,
     reservationUnitPk: reservationUnit?.pk ?? undefined,
-    begin: fromUIDate(getValues("startingDate")),
-    end: fromUIDate(getValues("endingDate")),
+    begin: fromUIDate(getValues("startingDate")) ?? new Date(),
+    end: fromUIDate(getValues("endingDate")) ?? new Date(),
     reservationType: reservationType as ReservationsReservationTypeChoices,
   });
 

--- a/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/generateReservations.ts
+++ b/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/generateReservations.ts
@@ -1,5 +1,5 @@
 import { toMondayFirst } from "common/src/helpers";
-import { fromUIDate } from "common/src/common/util";
+import { fromUIDateUnsafe } from "common/src/common/util";
 import { ReservationUnitsReservationUnitReservationStartIntervalChoices } from "common/types/gql-types";
 import { timeSelectionSchema } from "app/schemas";
 
@@ -65,10 +65,13 @@ const generateReservations = (
   try {
     const min = (a: number, b: number) => (a < b ? a : b);
     const max = (a: number, b: number) => (a > b ? a : b);
-    const sDay = max(utcDate(new Date()), utcDate(fromUIDate(startingDate)));
+    const sDay = max(
+      utcDate(new Date()),
+      utcDate(fromUIDateUnsafe(startingDate))
+    );
 
     // end date with time 23:59:59
-    const eDay = utcDate(fromUIDate(endingDate)) + (MS_IN_DAY - 1);
+    const eDay = utcDate(fromUIDateUnsafe(endingDate)) + (MS_IN_DAY - 1);
     const firstWeek = eachDayOfInterval(sDay, min(sDay + MS_IN_DAY * 7, eDay));
 
     return {

--- a/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/hooks.ts
+++ b/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/hooks.ts
@@ -20,7 +20,11 @@ import {
 } from "common/types/gql-types";
 import type { UseFormReturn } from "react-hook-form";
 import type { RecurringReservationForm } from "app/schemas";
-import { toApiDate, fromUIDate, toApiDateUnsafe } from "common/src/common/util";
+import {
+  toApiDate,
+  toApiDateUnsafe,
+  fromUIDateUnsafe,
+} from "common/src/common/util";
 import { addDays } from "date-fns";
 import {
   CollisionInterval,
@@ -354,9 +358,9 @@ export const useCreateRecurringReservation = () => {
 
     const input: RecurringReservationCreateMutationInput = {
       reservationUnitPk: unitPk,
-      beginDate: toApiDateUnsafe(fromUIDate(data.startingDate)),
+      beginDate: toApiDateUnsafe(fromUIDateUnsafe(data.startingDate)),
       beginTime: data.startTime,
-      endDate: toApiDateUnsafe(fromUIDate(data.endingDate)),
+      endDate: toApiDateUnsafe(fromUIDateUnsafe(data.endingDate)),
       endTime: data.endTime,
       weekdays: data.repeatOnDays,
       recurrenceInDays: data.repeatPattern.value === "weekly" ? 7 : 14,

--- a/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
+++ b/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
@@ -12,7 +12,7 @@ import {
 } from "common/types/gql-types";
 import styled from "styled-components";
 import { camelCase, get } from "lodash";
-import { format } from "date-fns";
+import { format, isValid as isDateValid } from "date-fns";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -108,16 +108,17 @@ const useCheckFormCollisions = ({
       ? reservationUnit.bufferTimeAfter
       : 0;
 
+  const d = fromUIDate(formDate);
   const { hasCollisions } = useCheckCollisions({
     reservationPk: undefined,
     reservationUnitPk: reservationUnit?.pk ?? 0,
     start:
-      formDate && formStartTime
-        ? setTimeOnDate(fromUIDate(formDate), formStartTime)
+      d && isDateValid(d) && formStartTime
+        ? setTimeOnDate(d, formStartTime)
         : undefined,
     end:
-      formDate && formEndTime
-        ? setTimeOnDate(fromUIDate(formDate), formEndTime)
+      d && isDateValid(d) && formEndTime
+        ? setTimeOnDate(d, formEndTime)
         : undefined,
     buffers: {
       before: bufferBeforeSeconds,

--- a/apps/admin-ui/src/component/recurring-reservations/review/AllocatedEventsTable.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/review/AllocatedEventsTable.tsx
@@ -95,11 +95,13 @@ const appEventMapper = (
         )
       : 0;
 
+  const begin = appEvent.begin ? fromApiDate(appEvent.begin) : undefined;
+  const end = appEvent.end ? fromApiDate(appEvent.end) : undefined;
   const totalHours =
-    appEvent.begin && appEvent.end
+    begin && end
       ? appEventHours(
-          fromApiDate(appEvent.begin).toISOString(),
-          fromApiDate(appEvent.end).toISOString(),
+          begin.toISOString(),
+          end.toISOString(),
           appEvent.biweekly,
           appEvent.eventsPerWeek ?? 0,
           appEvent.minDuration ?? 0

--- a/apps/admin-ui/src/component/recurring-reservations/review/ApplicationEventsTable.tsx
+++ b/apps/admin-ui/src/component/recurring-reservations/review/ApplicationEventsTable.tsx
@@ -95,11 +95,13 @@ const appEventMapper = (
         )
       : 0;
 
+  const begin = appEvent.begin ? fromApiDate(appEvent.begin) : undefined;
+  const end = appEvent.end ? fromApiDate(appEvent.end) : undefined;
   const totalHours =
-    appEvent.begin && appEvent.end
+    begin && end
       ? appEventHours(
-          fromApiDate(appEvent.begin).toISOString(),
-          fromApiDate(appEvent.end).toISOString(),
+          begin.toISOString(),
+          end.toISOString(),
           appEvent.biweekly,
           appEvent.eventsPerWeek ?? 0,
           appEvent.minDuration ?? 0

--- a/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
+++ b/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
@@ -223,8 +223,14 @@ const DialogContent = ({ reservation, onAccept, onClose }: Props) => {
   const formEndTime = watch("endTime");
   const formStartTime = watch("startTime");
 
-  const newStartTime = setTimeOnDate(fromUIDate(formDate), formStartTime);
-  const newEndTime = setTimeOnDate(fromUIDate(formDate), formEndTime);
+  const newStartTime = setTimeOnDate(
+    fromUIDate(formDate) ?? new Date(),
+    formStartTime
+  );
+  const newEndTime = setTimeOnDate(
+    fromUIDate(formDate) ?? new Date(),
+    formEndTime
+  );
   const { hasCollisions, isLoading } = useCheckCollisions({
     reservationPk: reservation.pk ?? 0,
     reservationUnitPk: reservationUnit?.pk ?? 0,
@@ -256,8 +262,14 @@ const DialogContent = ({ reservation, onAccept, onClose }: Props) => {
 
   const onSubmit = (values: FormValueType) => {
     if (values.date && values.startTime && values.endTime) {
-      const start = setTimeOnDate(fromUIDate(values.date), values.startTime);
-      const end = setTimeOnDate(fromUIDate(values.date), values.endTime);
+      const start = setTimeOnDate(
+        fromUIDate(values.date) ?? new Date(),
+        values.startTime
+      );
+      const end = setTimeOnDate(
+        fromUIDate(values.date) ?? new Date(),
+        values.endTime
+      );
       changeTime(start, end, {
         before: values.bufferTimeBefore ? bufferBefore : 0,
         after: values.bufferTimeAfter ? bufferAfter : 0,

--- a/apps/admin-ui/src/component/reservations/requested/util.ts
+++ b/apps/admin-ui/src/component/reservations/requested/util.ts
@@ -110,14 +110,15 @@ export const getReservatinUnitPricing = (
 
   reservationUnit.pricings.sort((a, b) =>
     a?.begins && b?.begins
-      ? fromApiDate(a.begins).getTime() - fromApiDate(b.begins).getTime()
+      ? (fromApiDate(a.begins)?.getTime() ?? 0) -
+        (fromApiDate(b.begins)?.getTime() ?? 0)
       : 1
   );
 
   return (
     (reservationUnit.pricings || []) as ReservationUnitPricingType[]
   ).reduce((prev, current) => {
-    if (fromApiDate(current?.begins) < reservationDate) {
+    if ((fromApiDate(current?.begins) ?? 0) < reservationDate) {
       return current;
     }
     return prev;

--- a/apps/admin-ui/src/schemas/recurringReservation.ts
+++ b/apps/admin-ui/src/schemas/recurringReservation.ts
@@ -60,10 +60,10 @@ export const RecurringReservationFormSchema = z
     }
   );
 
-const convertToDate = (date?: string): Date | undefined =>
-  date ? fromUIDate(date) : undefined;
+const convertToDate = (date?: string): Date | null =>
+  date ? fromUIDate(date) : null;
 
-const dateIsBefore = (date?: Date, other?: Date) =>
+const dateIsBefore = (date: Date | null, other: Date | null) =>
   date && other && date.getTime() < other.getTime();
 
 export const timeSelectionSchema = (

--- a/apps/admin-ui/src/schemas/schemaCommon.ts
+++ b/apps/admin-ui/src/schemas/schemaCommon.ts
@@ -13,7 +13,7 @@ export const OptionSchema = z.object({
 });
 
 export const checkDateNotInPast = (
-  date: Date | undefined,
+  date: Date | null,
   ctx: z.RefinementCtx,
   path: string
 ): void => {
@@ -27,7 +27,7 @@ export const checkDateNotInPast = (
 };
 
 export const checkDateWithinThreeYears = (
-  date: Date | undefined,
+  date: Date | null,
   ctx: z.RefinementCtx,
   path: string
 ): void => {
@@ -45,7 +45,7 @@ export const checkDateWithinThreeYears = (
 
 // TODO doesn't check for valid days or months i.e. 2024-02-31 and 2024-13-41 are valid
 export const checkValidDate = (
-  date: Date | undefined,
+  date: Date | null,
   ctx: z.RefinementCtx,
   path: string
 ): void => {
@@ -66,7 +66,7 @@ export const checkValidDate = (
 };
 
 export const checkValidFutureDate = (
-  date: Date | undefined,
+  date: Date | null,
   ctx: z.RefinementCtx,
   path: string
 ): void => {

--- a/apps/admin-ui/src/spa/ReservationUnit/edit/form.ts
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/form.ts
@@ -67,14 +67,15 @@ const refinePricing = (
         code: z.ZodIssueCode.custom,
       });
     }
-    if (Number.isNaN(fromUIDate(data.begins).getTime())) {
+    const date = fromUIDate(data.begins);
+    if (date == null || Number.isNaN(date.getTime())) {
       ctx.addIssue({
         message: "Invalid date",
         path: [`${path}.begins`],
         code: z.ZodIssueCode.custom,
       });
     }
-    if (fromUIDate(data.begins) < new Date()) {
+    if (date != null && date < new Date()) {
       ctx.addIssue({
         message: "Begin needs to be in the future",
         path: [`${path}.begins`],
@@ -767,6 +768,9 @@ const constructApiDate = (date: string, time: string) => {
     return null;
   }
   const d = fromUIDate(date);
+  if (!d) {
+    return null;
+  }
   const d2 = setTimeOnDate(d, time);
   return d2.toISOString();
 };
@@ -858,7 +862,7 @@ export function transformReservationUnit(
     pricings: filterNonNullable(pricings)
       .filter(shouldSavePricing)
       .map((p) => ({
-        begins: toApiDate(fromUIDate(p.begins)) ?? "",
+        begins: toApiDate(fromUIDate(p.begins) ?? new Date()) ?? "",
         highestPrice: Number(p.highestPrice),
         highestPriceNet: Number(p.highestPriceNet),
         lowestPrice: Number(p.lowestPrice),

--- a/apps/ui/components/application/ApplicationEventSummary.tsx
+++ b/apps/ui/components/application/ApplicationEventSummary.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { Trans, useTranslation, TFunction } from "next-i18next";
 import styled from "styled-components";
 import { H5 } from "common/src/common/typography";
-import { fromUIDate } from "../../modules/util";
+import { fromUIDate } from "common/src/common/util";
 import IconWithText from "../common/IconWithText";
 import { ApplicationEventFormValue } from "./Form";
 
@@ -46,9 +46,12 @@ const numHours = (
   if (!startDate || !endDate) {
     return 0;
   }
-  const numWeeks =
-    differenceInWeeks(fromUIDate(endDate), fromUIDate(startDate)) /
-    (biweekly ? 2 : 1);
+  const sd = fromUIDate(startDate);
+  const ed = fromUIDate(endDate);
+  if (!sd || !ed) {
+    return 0;
+  }
+  const numWeeks = differenceInWeeks(ed, sd) / (biweekly ? 2 : 1);
 
   const hours = (numWeeks * eventsPerWeek * minDurationMinutes) / 60;
   return hours;

--- a/apps/ui/components/application/Form.tsx
+++ b/apps/ui/components/application/Form.tsx
@@ -37,6 +37,18 @@ export type ApplicationEventScheduleFormType = z.infer<
   typeof ApplicationEventScheduleFormTypeSchema
 >;
 
+function lessThanMaybeDate(a?: string | null, b?: string | null): boolean {
+  if (a == null || b == null) {
+    return false;
+  }
+  const aDate = fromUIDate(a);
+  const bDate = fromUIDate(b);
+  if (aDate == null || bDate == null) {
+    return false;
+  }
+  return aDate < bDate;
+}
+
 const ApplicationEventFormValueSchema = z
   .object({
     pk: z.number().optional(),
@@ -68,7 +80,7 @@ const ApplicationEventFormValueSchema = z
     path: ["maxDuration"],
     message: "Maximum duration must be greater than minimum duration",
   })
-  .refine((s) => s.begin && s.end && fromUIDate(s.begin) < fromUIDate(s.end), {
+  .refine((s) => lessThanMaybeDate(s.begin, s.end), {
     path: ["end"],
     message: "End date must be after begin date",
   });
@@ -234,10 +246,16 @@ export type ApplicationFormValues = z.infer<typeof ApplicationFormSchema>;
 
 /// form -> API transformers, enforce return types so API changes cause type errors
 
-const transformDateString = (date?: string | null): string | undefined =>
-  date != null && toApiDate(fromUIDate(date)) != null
-    ? toApiDate(fromUIDate(date))
-    : undefined;
+function transformDateString(date?: string | null): string | null {
+  if (date == null) {
+    return null;
+  }
+  const d = fromUIDate(date);
+  if (d != null) {
+    return toApiDate(d);
+  }
+  return null;
+}
 
 type ApplicationEventScheduleFormValues = Omit<
   NonNullable<

--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -458,10 +458,10 @@ const SearchForm = ({
               limits={{
                 startMinDate: new Date(),
                 startMaxDate: getValues("endDate")
-                  ? fromUIDate(String(getValues("endDate")))
+                  ? fromUIDate(String(getValues("endDate"))) ?? undefined
                   : undefined,
                 endMinDate: getValues("startDate")
-                  ? fromUIDate(String(getValues("startDate")))
+                  ? fromUIDate(String(getValues("startDate"))) ?? undefined
                   : undefined,
                 endMaxDate: addYears(new Date(), 2),
               }}

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -71,7 +71,6 @@ import {
   formatDurationMinutes,
   getTranslation,
   isTouchDevice,
-  parseDate,
   printErrorMessages,
 } from "@/modules/util";
 import {
@@ -742,8 +741,8 @@ const ReservationUnit = ({
                 ? `${t("reservationCalendar:prefixForCancelled")}: `
                 : suffix
             }`,
-            start: n.begin != null ? parseDate(n.begin) : new Date(),
-            end: n.end != null ? parseDate(n.end) : new Date(),
+            start: n.begin != null ? new Date(n.begin) : new Date(),
+            end: n.end != null ? new Date(n.end) : new Date(),
             allDay: false,
             // TODO refactor and remove modifying the state
             event: n as ReservationType,

--- a/apps/ui/public/locales/en/dateSelector.json
+++ b/apps/ui/public/locales/en/dateSelector.json
@@ -7,7 +7,7 @@
   "infoDate": "dd.mm.yyyy",
   "labelEndDate": "End date",
   "labelStartDate": "Start date",
-  "errorEndDateBeforeStartDate": "The start date must be before the end date",
+  "errorEndDateBeforeStartDate": "End date must be after begin date",
   "errorDateFormat": "The date must be in the format dd.mm.yyyy",
   "menu": {
     "buttonBack": "Back",

--- a/apps/ui/public/locales/en/searchForm.json
+++ b/apps/ui/public/locales/en/searchForm.json
@@ -17,6 +17,7 @@
   "dateFilter": "Date",
   "timeFilter": "Time",
   "durationFilter": "Duration",
+  "beginTimeIsBeforeEndTime": "The start time must be before the end time",
   "resetForm": "Clear",
   "filters": {
     "applicationRound": "{{label}}",

--- a/apps/ui/public/locales/sv/searchForm.json
+++ b/apps/ui/public/locales/sv/searchForm.json
@@ -29,8 +29,8 @@
     "maxPersons_other": "Upp till {{value}} personer",
     "startDate": "Från {{value}}",
     "endDate": "Till {{value}}",
-    "timeBegin": "Tidigast kl.{{value}}",
-    "timeEnd": "Senast kl.{{value}}",
+    "timeBegin": "Tidigast kl. {{value}}",
+    "timeEnd": "Senast kl. {{value}}",
     "duration": "Minst {{unit}}"
   },
   "all": "Alla",

--- a/packages/common/src/common/util.ts
+++ b/packages/common/src/common/util.ts
@@ -86,37 +86,55 @@ export const formatSecondDuration = (
 
 // Returns a string in specified format (default: "yyyy-MM-dd") from a Date object,
 // pass a format string as a second parameter to change the format
-export const toApiDate = (
-  date: Date,
-  formatStr = "yyyy-MM-dd"
-): string | undefined => {
+// TODO rename to API
+export function toApiDate(date: Date, formatStr = "yyyy-MM-dd"): string | null {
   if (!date || Number.isNaN(date.getTime())) {
-    return undefined;
+    return null;
   }
   try {
     return format(date, formatStr);
   } catch (e) {
-    return undefined;
+    return null;
   }
-};
+}
 
 // May crash on invalid dates
+// TODO rename to API
 export const toApiDateUnsafe = (date: Date, formatStr = "yyyy-MM-dd") =>
   format(date, formatStr);
 
-// Returns a Date object from a string in format "yyyy-MM-dd"
-export const fromApiDate = (date: string): Date =>
-  parse(date, "yyyy-MM-dd", new Date());
+// Returns a Date from a string in format "yyyy-MM-dd"
+// TODO rename to API
+export function fromApiDate(date: string): Date | null {
+  try {
+    return parse(date, "yyyy-MM-dd", new Date());
+  } catch (e) {
+    return null;
+  }
+}
+
+export function fromUIDateUnsafe(date: string): Date {
+  return parse(date, "d.M.yyyy", new Date());
+}
 
 // Returns a Date object from a string in format "d.M.yyyy"
-export const fromUIDate = (date: string): Date =>
-  parse(date, "d.M.yyyy", new Date());
+export function fromUIDate(date: string): Date | null {
+  try {
+    return parse(date, "d.M.yyyy", new Date());
+  } catch (e) {
+    return null;
+  }
+}
 
+// Returns true if the date is not NaN and after year 1000
+// this is used to check date after string conversion
+// another option: combine it to the date conversion functions (return null on invalid dates) => better with TS
 export const isValidDate = (date: Date): boolean =>
   isValid(date) && isAfter(date, new Date("1000-01-01"));
 
 // Returns a string in "d.M.yyyy" format from a Date object
-export const toUIDate = (date: Date, formatStr = "d.M.yyyy"): string => {
+// TODO returning undefined would be preferably (specificity) but breaks the users of this function
+export const toUIDate = (date: Date | null, formatStr = "d.M.yyyy"): string => {
   if (!date || !isValidDate(date)) {
     return "";
   }

--- a/packages/common/src/components/form/TimeRangePicker.tsx
+++ b/packages/common/src/components/form/TimeRangePicker.tsx
@@ -8,7 +8,6 @@ import {
   useController,
   UseControllerProps,
 } from "react-hook-form";
-import { type OptionType } from "../../../types/common";
 import { truncatedText } from "../../../styles/styledComponentUtils";
 import { removeRefParam } from "../../reservation-form/util";
 
@@ -29,6 +28,10 @@ interface PopulateTimesProps {
   intervalMinutes?: number;
 }
 
+type OptionType = {
+  label: string;
+  value: number;
+};
 const StyledSelect = styled(Select<OptionType>)`
   button {
     display: grid;
@@ -83,8 +86,8 @@ const TimeRangePicker = <T extends FieldValues>({
   const getSelectedOption = (
     optionValue: string | null,
     optionList: OptionType[]
-  ): OptionType | undefined => {
-    return optionList.find((o) => o.label === optionValue);
+  ): OptionType | null => {
+    return optionList.find((o) => o.label === optionValue) ?? null;
   };
   const populateTimes = (
     populateTimesProps?: PopulateTimesProps


### PR DESCRIPTION
fix: date picker crashing when the start date is invalid
fix: search page translations
fix: make date utils safe (no throwing)
fix: don't pass undefined to Select input
refactor: remove duplicated date utils

Refs: TILA-2853