### PR TITLE
fix: search cards too much gap between text

### DIFF
--- a/apps/admin-ui/src/component/ButtonLikeLink.tsx
+++ b/apps/admin-ui/src/component/ButtonLikeLink.tsx
@@ -1,12 +1,6 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-
-type ButtonProps = {
-  readonly variant?: "primary" | "secondary";
-  readonly size?: "normal" | "large";
-  readonly fontSize?: "small" | "normal";
-  readonly disabled?: boolean;
-};
+import { ButtonCss, ButtonStyleProps } from "common/styles/buttonCss";
 
 /// @brief looks like a button but is a link
 /// @desc why? because nesting buttons and links is invalid html and HDS doesn't include this
@@ -15,54 +9,6 @@ type ButtonProps = {
 /// Differences to HDS: secondary is black themed since we don't use the standard light blue
 /// @param variant: 'primary' | 'secondary'
 /// @param size: 'normal' | 'large'
-export const ButtonLikeLink = styled(Link)<ButtonProps>`
-  --background-color-hover: ${({ variant }) =>
-    variant === "primary" ? "var(--color-bus-dark)" : "var(--color-black-5)"};
-  --color-hover: ${({ variant }) =>
-    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
-  --background-color-focus: ${({ variant }) =>
-    variant === "primary" ? "var(--color-bus)" : "transparent"};
-  --color-focus: ${({ variant }) =>
-    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
-  --focus-outline-color: var(--color-focus-outline);
-  --outline-gutter: 2px;
-  --outline-width: 3px;
-  --font-size: ${({ fontSize }) =>
-    fontSize === "small" ? "var(--fontsize-body-s)" : "var(--fontsize-body-m)"};
-
-  font-size: var(--font-size);
-
-  opacity: ${({ disabled }) => (disabled ? "0.5" : "1")};
-  text-decoration: none;
-  background-color: ${({ variant }) =>
-    variant === "primary" ? "var(--color-bus)" : "transparent"};
-  color: ${({ variant }) =>
-    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
-  padding: ${({ size }) => (size === "large" ? "4px 20px" : "0 20px")};
-  border: 2px solid
-    ${({ variant }) =>
-      variant === "primary" ? "var(--color-bus)" : "var(--color-black)"};
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 80px;
-  line-height: 1;
-  text-align: center;
-  height: 44px;
-  &:hover,
-  &:focus-visible {
-    transition-property: background-color, border-color, color;
-    transition-duration: 85ms;
-    transition-timing-function: ease-out;
-  }
-  &:hover {
-    background-color: var(--background-color-hover);
-    color: var(--color-hover);
-  }
-  &:focus-visible {
-    background-color: var(--background-color-focus, transparent);
-    color: var(--color-focus);
-    outline-offset: var(--outline-gutter);
-    outline: var(--outline-width) solid var(--focus-outline-color);
-  }
+export const ButtonLikeLink = styled(Link)<ButtonStyleProps>`
+  ${ButtonCss}
 `;

--- a/apps/ui/components/common/ButtonLikeLink.tsx
+++ b/apps/ui/components/common/ButtonLikeLink.tsx
@@ -3,7 +3,13 @@ import { ButtonCss, ButtonStyleProps } from "common/styles/buttonCss";
 import Link from "next/link";
 import { fontMedium } from "common";
 
+/* small overrides that might be moved to buttonCss.ts after testing
+ * gap: in case there is an icon
+ * max-height since the small button this replaces is 40px + 4px padding
+ */
 export const ButtonLikeLink = styled(Link)<ButtonStyleProps>`
   ${ButtonCss}
   ${fontMedium}
+  max-height: 40px;
+  gap: var(--spacing-s);
 `;

--- a/apps/ui/components/common/ButtonLikeLink.tsx
+++ b/apps/ui/components/common/ButtonLikeLink.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+import { ButtonCss, ButtonStyleProps } from "common/styles/buttonCss";
+import Link from "next/link";
+import { fontMedium } from "common";
+
+export const ButtonLikeLink = styled(Link)<ButtonStyleProps>`
+  ${ButtonCss}
+  ${fontMedium}
+`;

--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from "react";
 import { IconGlyphEuro, IconCross, IconArrowRight } from "hds-react";
 import { useTranslation } from "next-i18next";
 import { differenceInMinutes, parseISO } from "date-fns";
-import router from "next/router";
 import styled from "styled-components";
 import { getReservationPrice } from "common";
 import { trim } from "lodash";
@@ -16,21 +15,22 @@ import {
   getMainImage,
   getTranslation,
   reservationsUrl,
-} from "../../modules/util";
-import IconWithText from "../common/IconWithText";
-import { BlackButton } from "../../styles/util";
+} from "@/modules/util";
+import { pixel } from "@/styles/util";
 import {
   canUserCancelReservation,
   getNormalizedReservationOrderStatus,
-} from "../../modules/reservation";
+} from "@/modules/reservation";
 import {
   getReservationUnitName,
   getReservationUnitPrice,
   getUnitName,
-} from "../../modules/reservationUnit";
-import { JustForDesktop, JustForMobile } from "../../modules/style/layout";
+} from "@/modules/reservationUnit";
+import { JustForDesktop, JustForMobile } from "@/modules/style/layout";
+import IconWithText from "@/components/common/IconWithText";
 import ReservationOrderStatus from "./ReservationOrderStatus";
 import ReservationStatus from "./ReservationStatus";
+import { ButtonLikeLink } from "../common/ButtonLikeLink";
 
 type CardType = "upcoming" | "past" | "cancelled";
 
@@ -131,11 +131,6 @@ const ActionButtons = styled.div`
   display: flex;
   gap: var(--spacing-s);
 `;
-
-const ActionButton = styled(BlackButton).attrs({
-  size: "small",
-  variant: "secondary",
-})``;
 
 const Image = styled.img`
   width: 100%;
@@ -239,10 +234,8 @@ const ReservationCard = ({ reservation, type }: PropsT): JSX.Element => {
 
   const name = reservationUnit ? getTranslation(reservationUnit, "name") : "-";
   const img = getMainImage(reservationUnit);
-  const imgSrc =
-    img?.mediumUrl ||
-    img?.imageUrl ||
-    "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
+  const imgSrc = img?.mediumUrl || img?.imageUrl || pixel;
+
   return (
     <Container data-testid="reservation-card__container">
       <Image alt={name} src={imgSrc} />
@@ -281,23 +274,21 @@ const ReservationCard = ({ reservation, type }: PropsT): JSX.Element => {
           <Actions>
             <ActionButtons>
               {type === "upcoming" && canUserCancelReservation(reservation) && (
-                <ActionButton
-                  iconRight={<IconCross aria-hidden />}
-                  onClick={() =>
-                    router.push(`${reservationsUrl}${reservation.pk}/cancel`)
-                  }
+                <ButtonLikeLink
+                  href={`${reservationsUrl}${reservation.pk}/cancel`}
                   data-testid="reservation-card__button--cancel-reservation"
                 >
                   {t("reservations:cancelReservationAbbreviated")}
-                </ActionButton>
+                  <IconCross aria-hidden />
+                </ButtonLikeLink>
               )}
-              <ActionButton
-                iconRight={<IconArrowRight aria-hidden />}
-                onClick={() => router.push(link)}
+              <ButtonLikeLink
+                href={link}
                 data-testid="reservation-card__button--goto-reservation"
               >
                 {t("reservationList:seeMore")}
-              </ActionButton>
+                <IconArrowRight aria-hidden />
+              </ButtonLikeLink>
             </ActionButtons>
           </Actions>
         </Bottom>

--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -238,15 +238,14 @@ const ReservationCard = ({ reservation, type }: PropsT): JSX.Element => {
   );
 
   const name = reservationUnit ? getTranslation(reservationUnit, "name") : "-";
+  const img = getMainImage(reservationUnit);
+  const imgSrc =
+    img?.mediumUrl ||
+    img?.imageUrl ||
+    "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
   return (
     <Container data-testid="reservation-card__container">
-      <Image
-        alt={name}
-        src={
-          getMainImage(reservationUnit)?.mediumUrl ||
-          "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
-        }
-      />
+      <Image alt={name} src={imgSrc} />
       <MainContent>
         <Top>
           <Name>{title}</Name>

--- a/apps/ui/components/search/ReservationUnitCard.tsx
+++ b/apps/ui/components/search/ReservationUnitCard.tsx
@@ -1,14 +1,20 @@
-import { IconGroup, IconCheck, IconPlus, IconLinkExternal } from "hds-react";
+import {
+  IconGroup,
+  IconCheck,
+  IconPlus,
+  IconLinkExternal,
+  Button,
+} from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import NextImage from "next/image";
 import styled from "styled-components";
 import { breakpoints } from "common/src/common/style";
-import { H5, Strongish } from "common/src/common/typography";
+import { H5, fontMedium } from "common/src/common/typography";
 import { ReservationUnitType } from "common/types/gql-types";
-import { getAddressAlt, getMainImage, getTranslation } from "@/modules/util";
-import IconWithText from "../common/IconWithText";
-import { BlackButton, MediumButton, pixel, truncatedText } from "@/styles/util";
+import { getMainImage, getTranslation } from "@/modules/util";
+import IconWithText from "@/components/common/IconWithText";
+import { pixel, truncatedText } from "@/styles/util";
 import { reservationUnitPrefix } from "@/modules/const";
 import { getReservationUnitName, getUnitName } from "@/modules/reservationUnit";
 
@@ -54,15 +60,10 @@ const Description = styled.span`
   font-family: var(--font-regular);
   font-size: var(--fontsize-body-m);
   flex-grow: 1;
-  height: 40px;
-
-  @media (min-width: ${breakpoints.m}) {
-    height: unset;
-  }
 `;
 
-const Bottom = styled.span`
-  display: block;
+const Bottom = styled.div`
+  display: flex;
 
   > div {
     :last-child {
@@ -70,16 +71,17 @@ const Bottom = styled.span`
     }
   }
 
-  @media (min-width: ${breakpoints.l}) {
-    display: grid;
-    grid-template-columns: 1fr 2fr;
-    gap: var(--spacing-l);
+  flex-direction: column;
+  align-items: flex-start;
+
+  @media (min-width: ${breakpoints.s}) {
+    flex-direction: row;
+    align-items: center;
   }
 `;
 
 const Props = styled.div`
   display: block;
-  margin-bottom: var(--spacing-s);
 
   @media (min-width: ${breakpoints.m}) {
     display: flex;
@@ -92,6 +94,8 @@ const Actions = styled.div`
   flex-direction: column;
   padding: var(--spacing-s) 0 var(--spacing-s) 0;
   gap: var(--spacing-s);
+  flex-grow: 1;
+  width: 100%;
 
   > button {
     white-space: nowrap;
@@ -99,6 +103,7 @@ const Actions = styled.div`
 
   @media (min-width: ${breakpoints.m}) {
     flex-direction: row;
+    width: auto;
     padding: 0;
     justify-content: flex-end;
   }
@@ -134,6 +139,13 @@ const StyledIconWithText = styled(IconWithText)`
   }
 `;
 
+/* TODO something is overriding button font-family to be bold */
+const StyledButton = styled(Button).attrs({ size: "small" })`
+  && {
+    ${fontMedium}
+  }
+`;
+
 const ReservationUnitCard = ({
   reservationUnit,
   selectReservationUnit,
@@ -144,7 +156,6 @@ const ReservationUnitCard = ({
 
   const name = getReservationUnitName(reservationUnit);
 
-  const addressString = getAddressAlt(reservationUnit);
   const localeString = i18n.language === "fi" ? "" : `/${i18n.language}`;
   const link = `${localeString}${reservationUnitPrefix}/${reservationUnit.pk}`;
 
@@ -157,23 +168,15 @@ const ReservationUnitCard = ({
       ? getTranslation(reservationUnit.reservationUnitType, "name")
       : undefined;
 
+  const img = getMainImage(reservationUnit);
+  const imgSrc = img?.smallUrl || img?.imageUrl || pixel;
+
   return (
     <Container>
-      <Image
-        alt={name}
-        src={getMainImage(reservationUnit)?.smallUrl || pixel}
-      />
+      <Image alt={name} src={imgSrc} />
       <MainContent>
         <Name>{name}</Name>
-        <Description>
-          {unitName}
-          {addressString && (
-            <>
-              {", "}
-              <Strongish>{addressString}</Strongish>
-            </>
-          )}
-        </Description>
+        <Description>{unitName}</Description>
         <Bottom>
           <Props>
             {reservationUnitTypeName && (
@@ -208,31 +211,31 @@ const ReservationUnitCard = ({
           </Props>
           <Actions>
             {containsReservationUnit(reservationUnit) ? (
-              <MediumButton
+              <StyledButton
                 iconRight={<IconCheck />}
                 onClick={() => removeReservationUnit(reservationUnit)}
                 data-testid="reservation-unit-card__button--select"
               >
                 {t("common:removeReservationUnit")}
-              </MediumButton>
+              </StyledButton>
             ) : (
-              <BlackButton
+              <StyledButton
+                variant="secondary"
                 iconRight={<IconPlus />}
                 onClick={() => selectReservationUnit(reservationUnit)}
-                variant="secondary"
                 data-testid="reservation-unit-card__button--select"
               >
                 {t("common:selectReservationUnit")}
-              </BlackButton>
+              </StyledButton>
             )}
-            <BlackButton
+            <StyledButton
               variant="secondary"
               iconRight={<IconLinkExternal aria-hidden />}
               onClick={() => window.open(link, "_blank")}
               data-testid="reservation-unit-card__button--link"
             >
               {t("reservationUnitCard:seeMore")}
-            </BlackButton>
+            </StyledButton>
           </Actions>
         </Bottom>
       </MainContent>

--- a/apps/ui/components/single-search/ReservationUnitCard.tsx
+++ b/apps/ui/components/single-search/ReservationUnitCard.tsx
@@ -110,7 +110,6 @@ const Actions = styled.div`
   & > a {
     display: flex;
     flex-grow: 1;
-    max-height: 40px;
   }
 
   @media (min-width: ${breakpoints.s}) {

--- a/apps/ui/components/single-search/ReservationUnitCard.tsx
+++ b/apps/ui/components/single-search/ReservationUnitCard.tsx
@@ -38,7 +38,6 @@ const Container = styled.div`
 
 const MainContent = styled.div`
   display: grid;
-  gap: var(--spacing-s);
   margin: var(--spacing-s);
   position: relative;
 
@@ -62,9 +61,10 @@ const Description = styled.span`
   font-family: var(--font-regular);
   font-size: var(--fontsize-body-m);
   flex-grow: 1;
+  margin-bottom: var(--spacing-s);
 
-  @media (min-width: ${breakpoints.m}) {
-    height: unset;
+  @media (min-width: ${breakpoints.l}) {
+    margin-bottom: 0;
   }
 `;
 
@@ -85,11 +85,15 @@ const Bottom = styled.span`
 `;
 
 const Props = styled.div`
-  display: block;
+  display: flex;
+  gap: var(--spacing-s);
+  flex-direction: column;
+  align-items: start;
 
   @media (min-width: ${breakpoints.l}) {
-    display: flex;
+    flex-direction: row;
     gap: var(--spacing-l);
+    align-items: end;
   }
 `;
 
@@ -139,7 +143,7 @@ const StyledInlineLink = styled(StyledLink)`
 `;
 
 const StyledIconWithText = styled(IconWithText)`
-  margin-top: var(--spacing-xs);
+  margin: 0;
 
   span {
     margin-left: var(--spacing-2-xs);
@@ -149,11 +153,14 @@ const StyledIconWithText = styled(IconWithText)`
 `;
 
 const StyledTag = styled(Tag)<{ $status: "available" | "no-times" | "closed" }>`
+  margin-bottom: var(--spacing-s);
+
   @media (min-width: ${breakpoints.s}) {
     position: absolute;
     top: 0;
     right: 0;
     z-index: 1;
+    margin: 0;
   }
 
   && {

--- a/apps/ui/components/single-search/ReservationUnitCard.tsx
+++ b/apps/ui/components/single-search/ReservationUnitCard.tsx
@@ -1,8 +1,7 @@
-import { IconGlyphEuro, IconGroup, Tag } from "hds-react";
+import { IconArrowRight, IconGlyphEuro, IconGroup, Tag } from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import NextImage from "next/image";
 import styled from "styled-components";
 import { H5 } from "common/src/common/typography";
@@ -12,7 +11,7 @@ import { format, isToday, isTomorrow } from "date-fns";
 import { toUIDate } from "common/src/common/util";
 import { getMainImage, getTranslation } from "@/modules/util";
 import IconWithText from "../common/IconWithText";
-import { MediumButton, pixel, truncatedText } from "@/styles/util";
+import { pixel, truncatedText } from "@/styles/util";
 import {
   getActivePricing,
   getPrice,
@@ -20,6 +19,7 @@ import {
   getUnitName,
 } from "@/modules/reservationUnit";
 import { reservationUnitPrefix } from "@/modules/const";
+import { ButtonLikeLink } from "../common/ButtonLikeLink";
 
 interface PropsT {
   reservationUnit: ReservationUnitType;
@@ -90,6 +90,10 @@ const Props = styled.div`
   flex-direction: column;
   align-items: start;
 
+  @media (min-width: ${breakpoints.s}) {
+    gap: var(--spacing-3-xs);
+  }
+
   @media (min-width: ${breakpoints.l}) {
     flex-direction: row;
     gap: var(--spacing-l);
@@ -98,11 +102,19 @@ const Props = styled.div`
 `;
 
 const Actions = styled.div`
-  display: block;
-  padding: var(--spacing-s) var(--spacing-s) var(--spacing-s) 0;
+  display: flex;
+  padding: var(--spacing-m) var(--spacing-s) var(--spacing-s) 0;
+  width: 100%;
 
-  > button {
-    white-space: nowrap;
+  /* ButtonLikeLink doesn't scale to max-width on mobile */
+  & > a {
+    display: flex;
+    flex-grow: 1;
+    max-height: 40px;
+  }
+
+  @media (min-width: ${breakpoints.s}) {
+    padding-top: var(--spacing-s);
   }
 
   @media (min-width: ${breakpoints.m}) {
@@ -211,8 +223,6 @@ const StatusTag = (ru: {
 const ReservationUnitCard = ({ reservationUnit }: PropsT): JSX.Element => {
   const { t } = useTranslation();
 
-  const router = useRouter();
-
   const name = getReservationUnitName(reservationUnit);
 
   const link = `${reservationUnitPrefix}/${reservationUnit.pk}`;
@@ -291,10 +301,10 @@ const ReservationUnitCard = ({ reservationUnit }: PropsT): JSX.Element => {
             ) : null}
           </Props>
           <Actions>
-            <div style={{ flexGrow: 1 }} />
-            <MediumButton variant="secondary" onClick={() => router.push(link)}>
+            <ButtonLikeLink href={link}>
               {t("reservationUnitCard:seeMore")}
-            </MediumButton>
+              <IconArrowRight aria-hidden="true" />
+            </ButtonLikeLink>
           </Actions>
         </Bottom>
       </MainContent>

--- a/apps/ui/components/single-search/ReservationUnitCard.tsx
+++ b/apps/ui/components/single-search/ReservationUnitCard.tsx
@@ -227,13 +227,13 @@ const ReservationUnitCard = ({ reservationUnit }: PropsT): JSX.Element => {
       ? getTranslation(reservationUnit.reservationUnitType, "name")
       : undefined;
 
+  const img = getMainImage(reservationUnit);
+  const imgSrc = img?.smallUrl || img?.imageUrl || pixel;
+
   return (
     <Container>
       <StyledLink href={link}>
-        <Image
-          alt={name}
-          src={getMainImage(reservationUnit)?.smallUrl ?? pixel}
-        />
+        <Image alt={name} src={imgSrc} />
       </StyledLink>
       <MainContent>
         <Name>

--- a/apps/ui/modules/queries/reservationUnit.ts
+++ b/apps/ui/modules/queries/reservationUnit.ts
@@ -232,6 +232,7 @@ export const RESERVATION_UNITS = gql`
             imageType
             smallUrl
             mediumUrl
+            imageUrl
           }
           pricings {
             begins

--- a/apps/ui/public/locales/en/reservationUnitCard.json
+++ b/apps/ui/public/locales/en/reservationUnitCard.json
@@ -8,7 +8,7 @@
   },
   "address": "Address",
   "type": "Service type",
-  "seeMore": "Show more",
+  "seeMore": "Show",
   "available": "Available",
   "noTimes": "No available times",
   "closed": "Closed"

--- a/apps/ui/public/locales/en/reservations.json
+++ b/apps/ui/public/locales/en/reservations.json
@@ -20,6 +20,7 @@
   "saveNewTimeSuccess": "Time of the booking has been changed",
   "cancelReservation": "Cancel booking",
   "cancelReservationCancellation": "Undo the cancelling",
+  "cancelReservationAbbreviated": "Cancel",
   "cancelApplication": "Cancel application",
   "cancelReservationBody": "You are about to cancel your booking.",
   "redoReservation": "Make a new booking",

--- a/apps/ui/public/locales/fi/reservationUnitCard.json
+++ b/apps/ui/public/locales/fi/reservationUnitCard.json
@@ -9,7 +9,7 @@
   },
   "address": "Katuosoite",
   "type": "Palvelun tyyppi",
-  "seeMore": "Katso lisää",
+  "seeMore": "Näytä",
   "available": "Vapaa",
   "noTimes": "Ei vapaita aikoja",
   "closed": "Suljettu"

--- a/apps/ui/public/locales/sv/reservationUnitCard.json
+++ b/apps/ui/public/locales/sv/reservationUnitCard.json
@@ -8,7 +8,7 @@
   },
   "address": "Adress",
   "type": "",
-  "seeMore": "Visa mer",
+  "seeMore": "Visa",
   "available": "Ledigt",
   "noTimes": "Inga lediga tider",
   "closed": "Stängt"

--- a/packages/common/styles/buttonCss.ts
+++ b/packages/common/styles/buttonCss.ts
@@ -1,0 +1,60 @@
+import { css } from "styled-components";
+
+export type ButtonStyleProps = {
+  readonly variant?: "primary" | "secondary";
+  readonly size?: "normal" | "large";
+  readonly fontSize?: "small" | "normal";
+  readonly disabled?: boolean;
+};
+
+export const ButtonCss = css<ButtonStyleProps>`
+  --background-color-hover: ${({ variant }) =>
+    variant === "primary" ? "var(--color-bus-dark)" : "var(--color-black-5)"};
+  --color-hover: ${({ variant }) =>
+    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
+  --background-color-focus: ${({ variant }) =>
+    variant === "primary" ? "var(--color-bus)" : "transparent"};
+  --color-focus: ${({ variant }) =>
+    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
+  --focus-outline-color: var(--color-focus-outline);
+  --outline-gutter: 2px;
+  --outline-width: 3px;
+  --font-size: ${({ fontSize }) =>
+    fontSize === "small" ? "var(--fontsize-body-s)" : "var(--fontsize-body-m)"};
+
+  font-size: var(--font-size);
+
+  opacity: ${({ disabled }) => (disabled ? "0.5" : "1")};
+  text-decoration: none;
+  background-color: ${({ variant }) =>
+    variant === "primary" ? "var(--color-bus)" : "transparent"};
+  color: ${({ variant }) =>
+    variant === "primary" ? "var(--color-white)" : "var(--color-black)"};
+  padding: ${({ size }) => (size === "large" ? "4px 20px" : "0 20px")};
+  border: 2px solid
+    ${({ variant }) =>
+      variant === "primary" ? "var(--color-bus)" : "var(--color-black)"};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 80px;
+  line-height: 1;
+  text-align: center;
+  height: 44px;
+  &:hover,
+  &:focus-visible {
+    transition-property: background-color, border-color, color;
+    transition-duration: 85ms;
+    transition-timing-function: ease-out;
+  }
+  &:hover {
+    background-color: var(--background-color-hover);
+    color: var(--color-hover);
+  }
+  &:focus-visible {
+    background-color: var(--background-color-focus, transparent);
+    color: var(--color-focus);
+    outline-offset: var(--outline-gutter);
+    outline: var(--outline-width) solid var(--focus-outline-color);
+  }
+`;

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -6,6 +6,7 @@
   "exclude": ["node_modules/"],
   "include": [
     "src",
+    "styles",
     "index.ts",
     "types/**/*.d.ts",
     ".eslintrc.js",


### PR DESCRIPTION
Change the general styling of the cards.

fix: Remove the extra space that got added when moving the mobile tag.
fix: Replace buttons with ButtonLikeLinks where applicable.
fix: Button / Links should span the whole card on mobile
fix: translations
fix: images working when running locally (without image cdn)
