### PR TITLE
Fix search form date picker errors

### DIFF
--- a/apps/ui/components/application/ApplicationEvent.tsx
+++ b/apps/ui/components/application/ApplicationEvent.tsx
@@ -290,7 +290,7 @@ const ApplicationEventInner = ({
       </CheckboxWrapper>
       <PeriodContainer>
         <DateInput
-          disableConfirmation
+          // disableConfirmation: is not accessible
           language={getLocalizationLang(i18n.language)}
           {...register(`applicationEvents.${index}.begin`)}
           onChange={(v) => {
@@ -315,7 +315,7 @@ const ApplicationEventInner = ({
         />
         <DateInput
           {...register(`applicationEvents.${index}.end`)}
-          disableConfirmation
+          // disableConfirmation: is not accessible
           language={getLocalizationLang(i18n.language)}
           onChange={(v) => {
             clearErrors([

--- a/apps/ui/components/form/DateRangePicker.tsx
+++ b/apps/ui/components/form/DateRangePicker.tsx
@@ -137,7 +137,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
         id="start-date"
         value={internalStartDateString}
         onChange={handleStartDateChange}
-        disableConfirmation
+        // disableConfirmation: is not accessible
         helperText={
           showHelperText && !errors.startDateIsInvalid ? helperText : undefined
         }
@@ -159,7 +159,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
         id="end-date"
         value={internalEndDateString}
         onChange={handleEndDateChange}
-        disableConfirmation
+        // disableConfirmation: is not accessible
         helperText={
           showHelperText &&
           !endDateIsBeforeStartDate &&

--- a/apps/ui/components/form/DateSelectorMenu.tsx
+++ b/apps/ui/components/form/DateSelectorMenu.tsx
@@ -202,6 +202,7 @@ const DateSelectorMenu = ({
             onChangeEndDate={onChangeEndDate}
             onChangeStartDate={onChangeStartDate}
             startDate={startDate}
+            required={{ begin: true, end: true }}
           />
         </CustomDateWrapper>
       )}

--- a/apps/ui/components/form/__tests__/__snapshots__/DateSelectorMenu.test.tsx.snap
+++ b/apps/ui/components/form/__tests__/__snapshots__/DateSelectorMenu.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`matches snapshot 1`] = `
 <div
-  class="DateSelectorMenu__Wrapper-sc-24330e5-0 eKQfcc"
+  class="DateSelectorMenu__Wrapper-sc-dc184997-0 gzGpuX"
   data-testid="date-selector-menu"
 >
   <div
-    class="DateSelectorMenu__CheckboxWrapper-sc-24330e5-1 fYiAJH"
+    class="DateSelectorMenu__CheckboxWrapper-sc-dc184997-1 bUDepk"
   >
     <div
       class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz Checkbox__StyledCheckbox-sc-727f0e26-0 fOFnxE"
@@ -86,7 +86,7 @@ exports[`matches snapshot 1`] = `
     </div>
   </div>
   <button
-    class="DateSelectorMenu__Btn-sc-24330e5-2 hteKBV selectDates"
+    class="DateSelectorMenu__Btn-sc-dc184997-2 kDdYFu selectDates"
     type="button"
   >
     <svg
@@ -110,7 +110,7 @@ exports[`matches snapshot 1`] = `
       </g>
     </svg>
     <div
-      class="DateSelectorMenu__BtnText-sc-24330e5-3 eNfXDo"
+      class="DateSelectorMenu__BtnText-sc-dc184997-3 lppGtT"
     >
       dateSelector:menu.buttonCustom
     </div>
@@ -136,7 +136,7 @@ exports[`matches snapshot 1`] = `
     </svg>
   </button>
   <button
-    class="DateSelectorMenu__Btn-sc-24330e5-2 hzxElA back"
+    class="DateSelectorMenu__Btn-sc-dc184997-2 OgTLj back"
     type="button"
   >
     <svg
@@ -160,17 +160,17 @@ exports[`matches snapshot 1`] = `
       </g>
     </svg>
     <div
-      class="DateSelectorMenu__BtnText-sc-24330e5-3 eNfXDo"
+      class="DateSelectorMenu__BtnText-sc-dc184997-3 lppGtT"
     >
       dateSelector:menu.buttonBack
     </div>
   </button>
   <button
-    class="DateSelectorMenu__Btn-sc-24330e5-2 hteKBV close"
+    class="DateSelectorMenu__Btn-sc-dc184997-2 kDdYFu close"
     type="button"
   >
     <div
-      class="DateSelectorMenu__BtnText-sc-24330e5-3 eNfXDo"
+      class="DateSelectorMenu__BtnText-sc-dc184997-3 lppGtT"
     >
       dateSelector:menu.buttonClose
     </div>

--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -8,7 +8,7 @@ import { sortBy } from "lodash";
 import { OptionType } from "common/types/common";
 import { breakpoints } from "common/src/common/style";
 import { Query, QueryUnitsArgs } from "common/types/gql-types";
-import { addYears } from "date-fns";
+import { addYears, startOfDay } from "date-fns";
 import { ShowAllContainer } from "common/src/components";
 import { TextInput, TimeRangePicker } from "common/src/components/form";
 import { toUIDate } from "common/src/common/util";
@@ -453,15 +453,14 @@ const SearchForm = ({
                 begin: t("searchForm:dateFilter"),
                 end: " ",
               }}
-              required={{ begin: false, end: false }}
               placeholder={{
                 begin: t("common:beginLabel"),
                 end: t("common:endLabel"),
               }}
               limits={{
-                startMinDate: new Date(),
+                startMinDate: startOfDay(new Date()),
                 startMaxDate: addYears(new Date(), 2),
-                endMinDate: new Date(),
+                endMinDate: startOfDay(new Date()),
                 endMaxDate: addYears(new Date(), 2),
               }}
             />

--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -256,17 +256,23 @@ const SearchForm = ({
 }: Props): JSX.Element | null => {
   const formValueKeys = Object.keys(formValues);
   const { t } = useTranslation();
-  const { options: unitOptions, isLoading: unitsLoading } = useMappedOptions(
+  const { options: unitOptions } = useMappedOptions(
     SEARCH_FORM_PARAMS_UNIT,
     "units",
     { publishedReservationUnits: true }
   );
-  const { options: purposeOptions, isLoading: purposesLoading } =
-    useMappedOptions(SEARCH_FORM_PARAMS_PURPOSE, "purposes");
-  const { options: unitTypeOptions, isLoading: typesLoading } =
-    useMappedOptions(RESERVATION_UNIT_TYPES, "reservationUnitTypes");
-  const { options: equipmentsOptions, isLoading: equipmentsLoading } =
-    useMappedOptions(SEARCH_FORM_PARAMS_EQUIPMENT, "equipments");
+  const { options: purposeOptions } = useMappedOptions(
+    SEARCH_FORM_PARAMS_PURPOSE,
+    "purposes"
+  );
+  const { options: unitTypeOptions } = useMappedOptions(
+    RESERVATION_UNIT_TYPES,
+    "reservationUnitTypes"
+  );
+  const { options: equipmentsOptions } = useMappedOptions(
+    SEARCH_FORM_PARAMS_EQUIPMENT,
+    "equipments"
+  );
   const durationMinuteOptions = () => {
     const durations: OptionType[] = [];
     let minute = 15; // no zero duration option, as all available reservations have a positive/non-zero duration
@@ -388,9 +394,6 @@ const SearchForm = ({
     }, {});
     onSearch(searchCriteria);
   };
-
-  const areOptionsLoaded =
-    !unitsLoading && !purposesLoading && !typesLoading && !equipmentsLoading;
 
   return (
     <>
@@ -592,14 +595,12 @@ const SearchForm = ({
       </TopContainer>
 
       <BottomContainer>
-        {areOptionsLoaded && formValueKeys.length > 0 && (
-          <FilterTagList
-            formValueKeys={formValueKeys}
-            formValues={formValues}
-            removeValue={removeValue}
-            getFormSubValueLabel={getFormSubValueLabel}
-          />
-        )}
+        <FilterTagList
+          formValueKeys={formValueKeys}
+          formValues={formValues}
+          removeValue={removeValue}
+          getFormSubValueLabel={getFormSubValueLabel}
+        />
         <SubmitButton
           id="searchButton"
           onClick={handleSubmit(search) as SubmitHandler<FieldValues>}

--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -460,12 +460,8 @@ const SearchForm = ({
               }}
               limits={{
                 startMinDate: new Date(),
-                startMaxDate: getValues("endDate")
-                  ? fromUIDate(String(getValues("endDate"))) ?? undefined
-                  : undefined,
-                endMinDate: getValues("startDate")
-                  ? fromUIDate(String(getValues("startDate"))) ?? undefined
-                  : undefined,
+                startMaxDate: addYears(new Date(), 2),
+                endMinDate: new Date(),
                 endMaxDate: addYears(new Date(), 2),
               }}
             />

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -30,6 +30,7 @@ import ListWithPagination from "@/components/common/ListWithPagination";
 import ReservationUnitCard from "@/components/single-search/ReservationUnitCard";
 import BreadcrumbWrapper from "@/components/common/BreadcrumbWrapper";
 import { toApiDate } from "common/src/common/util";
+import { startOfDay } from "date-fns";
 
 const pagingLimit = 36;
 
@@ -85,6 +86,7 @@ const processVariables = (values: Record<string, string>, language: string) => {
 
   const startDate = fromUIDate(values.startDate);
   const endDate = fromUIDate(values.endDate);
+  const today = startOfDay(new Date());
 
   const replaceIfExists = (condition: string | boolean, returnObject: object) =>
     condition && returnObject;
@@ -124,10 +126,12 @@ const processVariables = (values: Record<string, string>, language: string) => {
       equipments: values.equipments?.split(",").map(Number),
     }),
     ...replaceIfExists(values.startDate, {
-      reservableDateStart: startDate ? toApiDate(startDate) : null,
+      reservableDateStart:
+        startDate && startDate >= today ? toApiDate(startDate) : null,
     }),
     ...replaceIfExists(values.endDate, {
-      reservableDateEnd: endDate ? toApiDate(endDate) : null,
+      reservableDateEnd:
+        endDate && endDate >= today ? toApiDate(endDate) : null,
     }),
     ...replaceIfExists(values.timeBegin, {
       reservableTimeStart: values.timeBegin,

--- a/apps/ui/public/locales/en/dateSelector.json
+++ b/apps/ui/public/locales/en/dateSelector.json
@@ -7,8 +7,12 @@
   "infoDate": "dd.mm.yyyy",
   "labelEndDate": "End date",
   "labelStartDate": "Start date",
-  "errorEndDateBeforeStartDate": "End date must be after start date",
-  "errorDateFormat": "The date must be in the format dd.mm.yyyy",
+  "errors": {
+    "endDateBeforeStartDate": "End date must be after start date",
+    "dateInvalid": "The date must be in the format dd.mm.yyyy",
+    "dateIsTooSmall": "The date must be after {{minDate}}",
+    "dateIsTooBig": "The date must be before {{maxDate}}"
+  },
   "menu": {
     "buttonBack": "Back",
     "buttonClose": "Close",

--- a/apps/ui/public/locales/fi/dateSelector.json
+++ b/apps/ui/public/locales/fi/dateSelector.json
@@ -7,8 +7,12 @@
   "infoDate": "pp.kk.vvvv",
   "labelEndDate": "Loppumispäivä",
   "labelStartDate": "Alkamispäivä",
-  "errorEndDateBeforeStartDate": "Alkamispäivän on oltava ennen loppumispäivää",
-  "errorDateFormat": "Päivämäärän on oltava muotoa pp.kk.vvvv",
+  "errors": {
+    "endDateBeforeStartDate": "Alkamispäivän on oltava ennen loppumispäivää",
+    "dateInvalid": "Päivämäärän on oltava muotoa pp.kk.vvvv",
+    "dateIsTooSmall": "Päivämäärän on oltava jälkeen {{minDate}}",
+    "dateIsTooBig": "Päivämäärän on oltava ennen {{maxDate}}"
+  },
   "menu": {
     "buttonBack": "Takaisin",
     "buttonClose": "Sulje",

--- a/apps/ui/public/locales/sv/dateSelector.json
+++ b/apps/ui/public/locales/sv/dateSelector.json
@@ -7,8 +7,12 @@
   "infoDate": "dd.mm.åååå",
   "labelEndDate": "Slutdatum",
   "labelStartDate": "Startdatum",
-  "errorEndDateBeforeStartDate": "Startdatumet måste vara före slutdatumet",
-  "errorDateFormat": "Datumet måste vara i formatet dd.mm.åååå",
+  "errors": {
+    "endDateBeforeStartDate": "Startdatumet måste vara före slutdatumet",
+    "dateInvalid": "Datumet måste vara i formatet dd.mm.åååå",
+    "dateIsTooSmall": "Datumet måste vara efter {{minDate}}",
+    "dateIsTooBig": "Datumet måste vara före {{maxDate}}"
+  },
   "menu": {
     "buttonBack": "Tillbaka",
     "buttonClose": "Stäng",


### PR DESCRIPTION
- fix: search button jumping because tags were removed from dom
- fix: don't send invalid dates to backend (we don't show the user the error, so it only shows empty search results)
- fix: show user an invalid date error if date is not in interval [today, today + 2 years]
- fix: remove all invalid dates when doing a search and reset the picker to empty
- fix: accessible DatePickers in ui
- fix: more comprehensive errors in DateRangePicker

Refs: TILA-3047, TILA-3048