### PR TITLE
fix: double test ids on reservation page

### DIFF
--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -28,8 +28,8 @@ import {
 } from "@/modules/reservationUnit";
 import { JustForDesktop, JustForMobile } from "@/modules/style/layout";
 import IconWithText from "@/components/common/IconWithText";
-import ReservationOrderStatus from "./ReservationOrderStatus";
-import ReservationStatus from "./ReservationStatus";
+import { ReservationOrderStatus } from "./ReservationOrderStatus";
+import { ReservationStatus } from "./ReservationStatus";
 import { ButtonLikeLink } from "../common/ButtonLikeLink";
 
 type CardType = "upcoming" | "past" | "cancelled";

--- a/apps/ui/components/reservation/ReservationOrderStatus.tsx
+++ b/apps/ui/components/reservation/ReservationOrderStatus.tsx
@@ -10,7 +10,6 @@ export type Props = {
 
 const Wrapper = styled.div<{ $color: string }>`
   display: inline-block;
-  margin-bottom: var(--spacing-m);
   padding: var(--spacing-3-xs) var(--spacing-2-xs);
   background-color: ${({ $color }) => $color};
   line-height: var(--lineheight-l);
@@ -18,10 +17,10 @@ const Wrapper = styled.div<{ $color: string }>`
   ${truncatedText};
 `;
 
-const ReservationOrderStatus = ({
+export function ReservationOrderStatus({
   orderStatus,
   ...rest
-}: Props): JSX.Element => {
+}: Props): JSX.Element {
   const { t } = useTranslation();
 
   const color = useMemo(() => {
@@ -50,6 +49,4 @@ const ReservationOrderStatus = ({
       {statusText}
     </Wrapper>
   );
-};
-
-export default ReservationOrderStatus;
+}

--- a/apps/ui/components/reservation/ReservationStatus.tsx
+++ b/apps/ui/components/reservation/ReservationStatus.tsx
@@ -9,9 +9,9 @@ export type Props = {
   state: ReservationsReservationStateChoices;
 };
 
+// TODO why ? why not use HDS tags?
 const Wrapper = styled.div<{ $color: string }>`
   display: inline-block;
-  margin-bottom: var(--spacing-m);
   padding: var(--spacing-3-xs) var(--spacing-2-xs);
   background-color: ${({ $color }) => $color};
   line-height: var(--lineheight-l);
@@ -19,7 +19,7 @@ const Wrapper = styled.div<{ $color: string }>`
   ${truncatedText};
 `;
 
-const ReservationStatus = ({ state, ...rest }: Props): JSX.Element => {
+export function ReservationStatus({ state, ...rest }: Props): JSX.Element {
   const { t } = useTranslation();
 
   const color = useMemo(() => {
@@ -47,6 +47,4 @@ const ReservationStatus = ({ state, ...rest }: Props): JSX.Element => {
       {statusText}
     </Wrapper>
   );
-};
-
-export default ReservationStatus;
+}

--- a/apps/ui/components/reservation/__tests__/ReservationOrderStatus.test.tsx
+++ b/apps/ui/components/reservation/__tests__/ReservationOrderStatus.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { get as mockGet } from "lodash";
 import { render, screen } from "../../../test/testUtils";
-import ReservationOrderStatus, { Props } from "../ReservationOrderStatus";
+import { ReservationOrderStatus, type Props } from "../ReservationOrderStatus";
 import mockTranslations from "../../../public/locales/fi/reservations.json";
 
 // TODO use a proper mocking solution in setup

--- a/apps/ui/components/reservation/__tests__/ReservationStatus.test.tsx
+++ b/apps/ui/components/reservation/__tests__/ReservationStatus.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { get as mockGet } from "lodash";
 import { ReservationsReservationStateChoices } from "common/types/gql-types";
 import { render, screen } from "../../../test/testUtils";
-import ReservationStatus, { Props } from "../ReservationStatus";
+import { ReservationStatus, type Props } from "../ReservationStatus";
 import mockTranslations from "../../../public/locales/fi/reservations.json";
 
 // TODO use a proper mocking solution in setup


### PR DESCRIPTION
Replace only mobile / desktop dom elements with a responsive grid.

Fixes testid="reservation__reservation-info-card__duration"