### PR TITLE
Adds reservation unit selection to recurring application page2

### DIFF
--- a/apps/ui/components/application/Page2.tsx
+++ b/apps/ui/components/application/Page2.tsx
@@ -75,7 +75,7 @@ const applicationEventSchedulesToCells = (
           end: t && +t.end.split(":")[0] === 0 ? 24 : t && +t.end.split(":")[0],
         };
       }) ?? [];
-    // state is 50 if the cell is outside of the opening hours, 100 if it's inside
+    // state is 50 if the cell is outside the opening hours, 100 if it's inside
     for (let i = firstSlotStart; i <= lastSlotStart; i += 1) {
       const isAvailable = dayOpeningHours.some(
         (t) => t.begin != null && t.end != null && t?.begin <= i && t?.end > i
@@ -214,15 +214,23 @@ const getApplicationEventsWhichMinDurationsIsNotFulfilled = (
 
 const Page2 = ({ application, onNext }: Props): JSX.Element => {
   const { t } = useTranslation();
-
+  const [selectedReservationUnit, setSelectedReservationUnit] =
+    useState<number>(0);
   const [successMsg, setSuccessMsg] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
   const [minDurationMsg, setMinDurationMsg] = useState(true);
   const router = useRouter();
   const openingHours = filterNonNullable(
-    application?.applicationEvents?.[0]?.eventReservationUnits?.[0]
-      ?.reservationUnit.applicationRoundTimeSlots
+    application?.applicationEvents?.[0]?.eventReservationUnits?.[
+      selectedReservationUnit
+    ]?.reservationUnit.applicationRoundTimeSlots
   );
+  const reservationUnitOptions = filterNonNullable(
+    application?.applicationEvents?.[0]?.eventReservationUnits?.map(
+      (n, idx) => ({ value: idx, label: n?.reservationUnit.nameFi ?? "" })
+    )
+  );
+
   const { getValues, setValue, watch, handleSubmit } =
     useFormContext<ApplicationFormValues>();
 
@@ -392,6 +400,9 @@ const Page2 = ({ application, onNext }: Props): JSX.Element => {
               copyCells={applicationEvents.length > 1 ? copyCells : null}
               resetCells={() => resetCells(index)}
               summaryData={[summaryDataPrimary, summaryDataSecondary]}
+              reservationUnitOptions={reservationUnitOptions}
+              selectedReservationUnit={selectedReservationUnit}
+              setSelectedReservationUnit={setSelectedReservationUnit}
             />
           </Accordion>
         );

--- a/apps/ui/components/application/Page2.tsx
+++ b/apps/ui/components/application/Page2.tsx
@@ -38,10 +38,6 @@ type DailyOpeningHours =
     }[]
   | null;
 
-const SubHeading = styled.p`
-  margin-top: var(--spacing-2-xs);
-`;
-
 const StyledNotification = styled(Notification)`
   margin-top: var(--spacing-m);
 `;
@@ -214,21 +210,24 @@ const getApplicationEventsWhichMinDurationsIsNotFulfilled = (
 
 const Page2 = ({ application, onNext }: Props): JSX.Element => {
   const { t } = useTranslation();
-  const [selectedReservationUnit, setSelectedReservationUnit] =
-    useState<number>(0);
+  const [reservationUnitPk, setReservationUnitPk] = useState<number>(
+    application?.applicationEvents?.[0]?.eventReservationUnits?.[0]
+      ?.reservationUnit.pk ?? 0
+  );
   const [successMsg, setSuccessMsg] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
   const [minDurationMsg, setMinDurationMsg] = useState(true);
   const router = useRouter();
   const openingHours = filterNonNullable(
-    application?.applicationEvents?.[0]?.eventReservationUnits?.[
-      selectedReservationUnit
-    ]?.reservationUnit.applicationRoundTimeSlots
+    application?.applicationEvents?.[0]?.eventReservationUnits?.find(
+      (n) => n.reservationUnit.pk === reservationUnitPk
+    )?.reservationUnit.applicationRoundTimeSlots
   );
   const reservationUnitOptions = filterNonNullable(
-    application?.applicationEvents?.[0]?.eventReservationUnits?.map(
-      (n, idx) => ({ value: idx, label: n?.reservationUnit.nameFi ?? "" })
-    )
+    application?.applicationEvents?.[0]?.eventReservationUnits?.map((n) => ({
+      value: n?.reservationUnit.pk ?? 0,
+      label: n?.reservationUnit.nameFi ?? "",
+    }))
   );
 
   const { getValues, setValue, watch, handleSubmit } =
@@ -385,7 +384,6 @@ const Page2 = ({ application, onNext }: Props): JSX.Element => {
             heading={event.name || undefined}
             theme="thin"
           >
-            <SubHeading>{t("application:Page2.subHeading")}</SubHeading>
             <StyledNotification
               label={t("application:Page2.info")}
               size="small"
@@ -401,8 +399,8 @@ const Page2 = ({ application, onNext }: Props): JSX.Element => {
               resetCells={() => resetCells(index)}
               summaryData={[summaryDataPrimary, summaryDataSecondary]}
               reservationUnitOptions={reservationUnitOptions}
-              selectedReservationUnit={selectedReservationUnit}
-              setSelectedReservationUnit={setSelectedReservationUnit}
+              reservationUnitPk={reservationUnitPk}
+              setReservationUnitPk={setReservationUnitPk}
             />
           </Accordion>
         );

--- a/apps/ui/components/application/TimeSelector.tsx
+++ b/apps/ui/components/application/TimeSelector.tsx
@@ -463,6 +463,7 @@ const TimeSelector = ({
           variant="supplementary"
           onClick={() => resetCells()}
           iconLeft={<IconCross />}
+          disabled={!cells.some((day) => day.some((cell) => cell.state > 100))}
         >
           {t("application:Page2.resetTimes")}
         </ResetButton>

--- a/apps/ui/components/application/TimeSelector.tsx
+++ b/apps/ui/components/application/TimeSelector.tsx
@@ -36,6 +36,9 @@ type Props = {
     ApplicationEventScheduleFormType[],
     ApplicationEventScheduleFormType[],
   ];
+  reservationUnitOptions: OptionType[];
+  selectedReservationUnit: number;
+  setSelectedReservationUnit: (id: number) => void;
 };
 
 const CalendarHead = styled.div`
@@ -199,10 +202,23 @@ const Day = ({
 
 const OptionWrapper = styled.div`
   margin-top: var(--spacing-m);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+
+  @media (min-width: ${breakpoints.l}) {
+    flex-direction: row;
+  }
 `;
 
-const PrioritySelect = styled(Select<OptionType>)`
-  max-width: 380px;
+const StyledSelect = styled(Select<OptionType>)`
+  flex-grow: 1;
+  min-width: 300px;
+  &:last-child {
+    flex-grow: 0;
+    min-width: 300px;
+  }
 `;
 
 const CalendarContainer = styled.div`
@@ -276,7 +292,18 @@ const LegendBox = styled.div<{ type: string }>`
 
     background-color: var(--tilavaraus-calendar-selected-secondary);
   `}
-
+  ${(props) =>
+    props.type === "within-opening-hours" &&
+    ` 
+    background-color: var(--color-white);
+    border: 1px solid var(--color-black-50);
+   `}
+  ${(props) =>
+    props.type === "outside-opening-hours" &&
+    ` 
+    background-color: var(--color-black-10);
+    border: 1px solid var(--color-black-50);
+   `}
   margin-right: 1em;
   width: 37px;
   height: 37px;
@@ -323,6 +350,9 @@ const TimeSelector = ({
   resetCells,
   index,
   summaryData,
+  reservationUnitOptions,
+  selectedReservationUnit,
+  setSelectedReservationUnit,
 }: Props): JSX.Element | null => {
   const { t } = useTranslation();
   const [priority, setPriority] =
@@ -340,6 +370,14 @@ const TimeSelector = ({
     {
       type: "selected-2",
       label: t("application:Page2.legend.selected-2"),
+    },
+    {
+      type: "within-opening-hours",
+      label: t("application:Page2.legend.within-opening-hours"),
+    },
+    {
+      type: "outside-opening-hours",
+      label: t("application:Page2.legend.outside-opening-hours"),
     },
   ];
   const priorityOptions: OptionType[] = [300, 200].map((n) => ({
@@ -370,7 +408,16 @@ const TimeSelector = ({
   return (
     <>
       <OptionWrapper>
-        <PrioritySelect
+        <StyledSelect
+          id={`time-selector__select--reservation-unit-${index}`}
+          aria-labelledby={t("appplication:Page2.")}
+          options={reservationUnitOptions}
+          defaultValue={reservationUnitOptions[selectedReservationUnit]}
+          onChange={(val: OptionType) =>
+            setSelectedReservationUnit(val.value as number)
+          }
+        />
+        <StyledSelect
           id={`time-selector__select--priority-${index}`}
           label=""
           options={priorityOptions}

--- a/apps/ui/public/locales/en/application.json
+++ b/apps/ui/public/locales/en/application.json
@@ -66,12 +66,13 @@
   },
   "Page2": {
     "heading": "2. Select booking dates",
-    "subHeading": "List all suitable times. Check opening hours in the spaces' description.",
     "info": "Please select both preferred times and also select other times that suit you. Providing more space and time options will improve your chances of getting spaces and times you like.",
     "text": "Indicate your preferred dates for the seasonal booking",
     "copyTimes": "Copy times for all booking requests",
     "resetTimes": "Clear calendar",
     "summary": "Summary",
+    "prioritySelectLabel": "Type of booking request",
+    "reservationUnitSelectLabel": "Seasonal booking times",
     "priorityLabels": {
       "300": "Select preferred time slots",
       "200": "Select other time slots"

--- a/apps/ui/public/locales/en/application.json
+++ b/apps/ui/public/locales/en/application.json
@@ -79,7 +79,9 @@
     "legend": {
       "unavailable": "Not available",
       "selected-1": "Preferred time slots",
-      "selected-2": "Other request"
+      "selected-2": "Other request",
+      "within-opening-hours": "Reservable",
+      "outside-opening-hours": "Not for seasonal bookings"
     },
     "primarySchedules": "Preferred time slots",
     "secondarySchedules": "Other time slots",

--- a/apps/ui/public/locales/fi/application.json
+++ b/apps/ui/public/locales/fi/application.json
@@ -79,7 +79,9 @@
     "legend": {
       "unavailable": "Ei varattavissa",
       "selected-1": "Ensisijainen toive",
-      "selected-2": "Muu toive"
+      "selected-2": "Muu toive",
+      "within-opening-hours": "Varattavissa",
+      "outside-opening-hours": "Ei merkitty kausivarattavaksi"
     },
     "primarySchedules": "Ensisijaiset aikatoiveet",
     "secondarySchedules": "Muut aikatoiveet",

--- a/apps/ui/public/locales/fi/application.json
+++ b/apps/ui/public/locales/fi/application.json
@@ -72,6 +72,8 @@
     "copyTimes": "Kopioi ajat kaikille varaustoiveille",
     "resetTimes": "Tyhjennä kalenteri",
     "summary": "Yhteenveto",
+    "prioritySelectLabel": "Aikatoiveen tyyppi",
+    "reservationUnitSelectLabel": "Kausivarauksen ajankohdat",
     "priorityLabels": {
       "300": "Valitse ensisijaiset aikatoiveet",
       "200": "Valitse muut aikatoiveet"

--- a/apps/ui/public/locales/sv/application.json
+++ b/apps/ui/public/locales/sv/application.json
@@ -79,7 +79,9 @@
     "legend": {
       "unavailable": "Kan inte bokas",
       "selected-1": "Prioriterat önskemål",
-      "selected-2": "Alternativt önskemål"
+      "selected-2": "Alternativt önskemål",
+      "within-opening-hours": "Kan reserveras",
+      "outside-opening-hours": "Inte för säsongbokning"
     },
     "primarySchedules": "Prioriterade tidsönskemål",
     "secondarySchedules": "Alternativa tidsönskemål",

--- a/apps/ui/public/locales/sv/application.json
+++ b/apps/ui/public/locales/sv/application.json
@@ -66,12 +66,13 @@
   },
   "Page2": {
     "heading": "2. Välj bokningens tidpunkt",
-    "subHeading": "Ange alla lämpliga tider som passar dig. Kontrollera öppettiderna i lokalens beskrivning.",
     "info": "Välj både de tider som du i första hand önskar och också tider som alternativt passar för dig. Att ange flera önskemål om lokaler och tider förbättrar dina chanser att få de lokaler och tider du vill ha.",
     "text": "Ange de tidpunkter du önskar för säsongbokningen",
     "copyTimes": "Kopiera tiderna till alla önskemål",
     "resetTimes": "Töm kalendern",
     "summary": "Sammanfattning",
+    "prioritySelectLabel": "Typ av tidsönskemål",
+    "reservationUnitSelectLabel": "Säsongbokningstider",
     "priorityLabels": {
       "300": "Välj prioriterade tidsönskemål",
       "200": "Välj alternativa tidsönskemål"


### PR DESCRIPTION
Adds reservation unit selection to a season reservation application, so the user can check opening times of different reservation units. 
Made with a simple useState, as it's meant only for showing the time-slots meant for seasonal bookings and doesn't affect the form contents per se. Some prop drilling necessary, to display the reservation unit selector in the right place.

Also fixes some styling issues on page 2 (legend, reset button..).

Refs: TILA-3052