### PR TITLE
fix: page 3 translations

### DIFF
--- a/apps/ui/pages/application/[id]/page3.tsx
+++ b/apps/ui/pages/application/[id]/page3.tsx
@@ -243,7 +243,7 @@ const Page3Wrapped = (props: Props): JSX.Element | null => {
       {/* TODO general mutation error (not query) */}
       {error != null && <ErrorToast error={`${t("common:error.dataError")}`} />}
       <ApplicationPageWrapper
-        translationKeyPrefix="application:preview"
+        translationKeyPrefix="application:Page3"
         application={application}
         isDirty={isDirty}
       >

--- a/apps/ui/public/locales/en/application.json
+++ b/apps/ui/public/locales/en/application.json
@@ -111,9 +111,9 @@
     "as": {
       "prefix": "I create the application...",
       "type": {
-        "organisation": "on behalf of an organisation, group or community",
-        "company": "on behalf of the company",
-        "individual": "as a private person"
+        "ASSOCIATION": "on behalf of an organisation, group or community",
+        "COMPANY": "on behalf of the company",
+        "INDIVIDUAL": "as a private person"
       }
     },
     "contactPerson": {

--- a/apps/ui/public/locales/sv/application.json
+++ b/apps/ui/public/locales/sv/application.json
@@ -111,9 +111,9 @@
     "as": {
       "prefix": "Skapa ansökan",
       "type": {
-        "organisation": "för en organisation, grupp eller samfund",
-        "company": "för ett företag",
-        "individual": "som privatkund"
+        "ASSOCIATION": "för en organisation, grupp eller samfund",
+        "COMPANY": "för ett företag",
+        "INDIVIDUAL": "som privatkund"
       }
     },
     "contactPerson": {


### PR DESCRIPTION
Page 3 was displaying page 4 heading and subheading and non-finnish translations didn't show due to erroneous translation key. Fixed.