### PR TITLE
fix: empty links on my reservation page

### DIFF
--- a/apps/ui/modules/queries/reservation.ts
+++ b/apps/ui/modules/queries/reservation.ts
@@ -255,6 +255,8 @@ export const GET_RESERVATION = gql`
           textSv
         }
         unit {
+          pk
+          tprekId
           nameFi
           nameEn
           nameSv


### PR DESCRIPTION
Two links on reservation page were empty because the field was missing.