### PR TITLE
comments out buffer options from reservation unit editing for now

### DIFF
--- a/apps/admin-ui/src/spa/ReservationUnit/edit/form.ts
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/form.ts
@@ -998,8 +998,8 @@ export function transformReservationUnit(
         ? constructApiDate(publishEndsDate, publishEndsTime)
         : null,
     reservationBlockWholeDay: reservationBlockWholeDay === "blocks-whole-day",
-    bufferTimeAfter,
-    bufferTimeBefore,
+    bufferTimeAfter: hasBufferTimeAfter ? bufferTimeAfter : 0,
+    bufferTimeBefore: hasBufferTimeBefore ? bufferTimeBefore : 0,
     isDraft,
     isArchived,
     termsOfUseEn: termsOfUseEn !== "" ? termsOfUseEn : null,

--- a/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
@@ -153,6 +153,7 @@ const SubAccordion = styled(Accordion)`
   }
 `;
 
+/*
 const BufferWrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -165,6 +166,7 @@ const BufferWrapper = styled.div`
     }
   }
 `;
+*/
 
 const Preview = styled.a<{ $disabled: boolean }>`
   display: flex;
@@ -1078,6 +1080,7 @@ function ReservationUnitSettings({
             />
           )}
         />
+        {/*
         <FieldGroup
           heading={t("ReservationUnitEditor.bufferSettings")}
           tooltip={t("ReservationUnitEditor.tooltip.bufferSettings")}
@@ -1179,7 +1182,8 @@ function ReservationUnitSettings({
               </BufferWrapper>
             )}
           </Grid>
-        </FieldGroup>
+      </FieldGroup>
+      */}
         <FieldGroup
           heading={t("ReservationUnitEditor.cancellationSettings")}
           tooltip={t("ReservationUnitEditor.tooltip.cancellationSettings")}


### PR DESCRIPTION
## 🛠️ Changelog

- Hides the buffer options from the reservation unit create/edit form

## 🧪 Test plan

- Create/edit a reservation unit and notice that the section isn't shown

## 🎫 Tickets

- TILA-3029