### PR TITLE
Fix unit permissions getting elevated

### DIFF
--- a/apps/admin-ui/src/common/queries.ts
+++ b/apps/admin-ui/src/common/queries.ts
@@ -173,9 +173,14 @@ export const DELETE_RESOURCE = gql`
   }
 `;
 
+// TODO backend should add: onlyWithHandlingPermission parameter for this query (replaces the onlyWithPermission)
 export const HANDLING_COUNT_QUERY = gql`
-  query dataQueries {
-    reservations(state: "REQUIRES_HANDLING") {
+  query dataQueries($begin: DateTime!) {
+    reservations(
+      state: "REQUIRES_HANDLING"
+      begin: $begin
+      onlyWithPermission: true
+    ) {
       edges {
         node {
           pk

--- a/apps/admin-ui/src/hooks/useHandling.ts
+++ b/apps/admin-ui/src/hooks/useHandling.ts
@@ -1,15 +1,23 @@
+import { useMemo } from "react";
+import { startOfDay } from "date-fns";
 import { useQuery } from "@apollo/client";
-import { useSession } from "app/hooks/auth";
-
-import { Query } from "common/types/gql-types";
+import { useSession } from "@/hooks/auth";
+import { Query, QueryReservationsArgs } from "common/types/gql-types";
 import { HANDLING_COUNT_QUERY } from "../common/queries";
 
 const useHandling = () => {
   const { isAuthenticated } = useSession();
 
-  const { data, refetch } = useQuery<Query>(HANDLING_COUNT_QUERY, {
-    skip: !isAuthenticated,
-  });
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const { data, refetch } = useQuery<Query, QueryReservationsArgs>(
+    HANDLING_COUNT_QUERY,
+    {
+      skip: !isAuthenticated,
+      variables: {
+        begin: today.toISOString(),
+      },
+    }
+  );
 
   const handlingCount: number = data?.reservations?.edges?.length ?? 0;
   const unitCount: number = data?.units?.totalCount ?? 0;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: reduce the number of waiting to be handled shown on the dot (partial).
- Fix: unit permission showing elevated permissions if user had more permissions in another unit.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Waiting to be handled dot should not show any past reservations anymore.
- Waiting to be handled should not show results for units where the user has no access at all.
- Giving a user unit "view" and "all" permissions to separate units should now hide approval / deny buttons correctly (where user only has "view" access).
- Giving a user unit "reserve" and "all" permissions to separate units should block the user from seeing a reservation (where user only has "reserve" permissions).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3131
