### PR TITLE
Fix clear calendar button coloring

### DIFF
--- a/apps/ui/components/application/TimeSelector.tsx
+++ b/apps/ui/components/application/TimeSelector.tsx
@@ -335,6 +335,12 @@ const ResetButton = styled(Button)`
     white-space: nowrap;
     align-items: center;
   }
+  &:hover {
+    --background-color-hover-focus: var(--color-black-15);
+    --background-color-hover: var(--color-black-5);
+    --color-hover: var(--color-black-90);
+    --color-hover-focus: var(--color-hover);
+  }
 
   ${fontRegular};
 `;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes the "Reset calendar"-button `:hover` and `:hover-focus` colors. It inherited some blue styling as a supplementary HDS-button.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to page 2 in the recurring reservation process, select any time slot in the calendar to enable the button. Hover/focus styles are in black.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3029
