### PR TITLE
Fix UI extra buffers

### DIFF
--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -205,11 +205,14 @@ const EditStep0 = ({
         : undefined;
     const diff = maybeDiff ?? 0;
     const duration = diff >= 90 ? `(${formatDurationMinutes(diff)})` : "";
-    const shownReservation = { ...initialReservation, state: "INITIAL" } || {
-      begin: reservation.begin,
-      end: reservation.end,
-      state: "OWN",
-    };
+    const shownReservation =
+      initialReservation != null
+        ? { ...initialReservation, state: "INITIAL" }
+        : {
+            begin: reservation.begin,
+            end: reservation.end,
+            state: "OWN",
+          };
     const reservations =
       (initialReservation?.begin
         ? reservationUnit?.reservations?.filter((n) => n?.pk !== reservation.pk)

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -257,14 +257,24 @@ const EditStep0 = ({
   }, [reservation.pk, reservationUnit]);
 
   const eventBuffers = useMemo(() => {
+    const bufferTimeBefore =
+      reservationUnit?.bufferTimeBefore != null &&
+      reservationUnit.bufferTimeBefore !== 0
+        ? reservationUnit?.bufferTimeBefore.toString()
+        : undefined;
+    const bufferTimeAfter =
+      reservationUnit?.bufferTimeAfter != null &&
+      reservationUnit.bufferTimeAfter !== 0
+        ? reservationUnit?.bufferTimeAfter.toString()
+        : undefined;
+
     return getEventBuffers([
       ...(calendarEvents.flatMap((e) => e.event) as ReservationType[]),
-
       {
         begin: initialReservation?.begin || reservation.begin,
         end: initialReservation?.end || reservation.end,
-        bufferTimeBefore: reservationUnit?.bufferTimeBefore?.toString(),
-        bufferTimeAfter: reservationUnit?.bufferTimeAfter?.toString(),
+        bufferTimeBefore,
+        bufferTimeAfter,
       },
     ]);
   }, [

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -260,24 +260,43 @@ const EditStep0 = ({
   }, [reservation.pk, reservationUnit]);
 
   const eventBuffers = useMemo(() => {
+    // TODO refactor
+    // backend sends 0 => front shows 30 min buffer, so has to be undefined
+    // if reservation buffers !== reservationUnit buffers, we want the to show the reservation buffers till user edits the reservation
+    const reservationBufferTimeBefore =
+      reservation?.bufferTimeBefore != null &&
+      reservation.bufferTimeBefore !== 0
+        ? reservation?.bufferTimeBefore.toString()
+        : undefined;
+    const reservationBufferTimeAfter =
+      reservation?.bufferTimeAfter != null && reservation.bufferTimeAfter !== 0
+        ? reservation?.bufferTimeAfter.toString()
+        : undefined;
+
     const bufferTimeBefore =
       reservationUnit?.bufferTimeBefore != null &&
       reservationUnit.bufferTimeBefore !== 0
         ? reservationUnit?.bufferTimeBefore.toString()
-        : undefined;
+        : reservationBufferTimeBefore;
     const bufferTimeAfter =
       reservationUnit?.bufferTimeAfter != null &&
       reservationUnit.bufferTimeAfter !== 0
         ? reservationUnit?.bufferTimeAfter.toString()
-        : undefined;
+        : reservationBufferTimeAfter;
 
     return getEventBuffers([
       ...(calendarEvents.flatMap((e) => e.event) as ReservationType[]),
       {
         begin: initialReservation?.begin || reservation.begin,
         end: initialReservation?.end || reservation.end,
-        bufferTimeBefore,
-        bufferTimeAfter,
+        bufferTimeBefore:
+          initialReservation != null
+            ? bufferTimeBefore
+            : reservationBufferTimeBefore,
+        bufferTimeAfter:
+          initialReservation != null
+            ? bufferTimeAfter
+            : reservationBufferTimeAfter,
       },
     ]);
   }, [
@@ -285,6 +304,8 @@ const EditStep0 = ({
     initialReservation,
     reservation.begin,
     reservation.end,
+    reservation?.bufferTimeAfter,
+    reservation?.bufferTimeBefore,
     reservationUnit?.bufferTimeAfter,
     reservationUnit?.bufferTimeBefore,
   ]);

--- a/apps/ui/modules/queries/reservation.ts
+++ b/apps/ui/modules/queries/reservation.ts
@@ -205,6 +205,8 @@ export const GET_RESERVATION = gql`
       reserveeType
       reserveeId
       reserveeOrganisationName
+      bufferTimeBefore
+      bufferTimeAfter
       begin
       end
       calendarUrl

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -763,6 +763,16 @@ const ReservationUnit = ({
   }, [reservationUnit, t, initialReservation]);
 
   const eventBuffers = useMemo(() => {
+    const bufferTimeBefore =
+      reservationUnit?.bufferTimeBefore != null &&
+      reservationUnit.bufferTimeBefore !== 0
+        ? reservationUnit?.bufferTimeBefore.toString()
+        : undefined;
+    const bufferTimeAfter =
+      reservationUnit?.bufferTimeAfter != null &&
+      reservationUnit.bufferTimeAfter !== 0
+        ? reservationUnit?.bufferTimeAfter.toString()
+        : undefined;
     return getEventBuffers([
       ...calendarEvents
         .flatMap((e) => e.event)
@@ -771,8 +781,8 @@ const ReservationUnit = ({
         begin: initialReservation?.begin,
         end: initialReservation?.end,
         state: "INITIAL",
-        bufferTimeBefore: reservationUnit?.bufferTimeBefore?.toString(),
-        bufferTimeAfter: reservationUnit?.bufferTimeAfter?.toString(),
+        bufferTimeBefore,
+        bufferTimeAfter,
       } as PendingReservation,
     ]);
   }, [calendarEvents, initialReservation, reservationUnit]);


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: extra buffers shown on all new reservations because api value changed from `null` -> `0`.
- Fix: ghost reservation on edit page.
- Fix: show reservation buffers when editing till user changes the time.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Reservation to Unit without buffer time should not show buffers in calendar either when making a new reservation or changing an existing one.
- Edit page should not show a ghost 30 min reservation for today when landing on the page.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
