### PR TITLE
Add checking for SEASON reservationKind to isReservationUnitReservable

### DIFF
--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -132,7 +132,7 @@ const NonReservableNotification = ({
     reservationUnit.reservationKind ===
     ReservationUnitsReservationUnitReservationKindChoices.Season
   ) {
-    returnText = t("reservationUnit:notifications.season");
+    returnText = t("reservationUnit:notifications.onlyRecurring");
   } else if (isReservationStartInFuture(reservationUnit))
     returnText = futureOpeningText;
   return (

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -18,18 +18,19 @@ import {
 import { TFunction } from "next-i18next";
 import {
   type ReservableTimeSpanType,
+  ReservationState,
   type ReservationType,
   type ReservationUnitByPkType,
+  ReservationUnitsReservationUnitReservationKindChoices,
   type ReservationUnitsReservationUnitReservationStartIntervalChoices,
-  ReservationState,
 } from "../../types/gql-types";
 import {
-  type CalendarEventBuffer,
-  type SlotProps,
   type ApplicationEvent,
+  type CalendarEventBuffer,
   type OptionType,
   type PendingReservation,
   type ReservationUnitNode,
+  type SlotProps,
 } from "../../types/common";
 import {
   convertHMSToSeconds,
@@ -593,8 +594,12 @@ export const isReservationUnitReservable = (
   if (!reservationUnit) {
     return [false, "reservationUnit is null"];
   }
-  const { reservationState, minReservationDuration, maxReservationDuration } =
-    reservationUnit;
+  const {
+    reservationState,
+    minReservationDuration,
+    maxReservationDuration,
+    reservationKind,
+  } = reservationUnit;
 
   switch (reservationState) {
     case ReservationState.Reservable:
@@ -617,6 +622,15 @@ export const isReservationUnitReservable = (
       }
       if (!minReservationDuration || !maxReservationDuration) {
         return [false, "reservationUnit has no min/max reservation duration"];
+      }
+      if (
+        reservationKind ===
+        ReservationUnitsReservationUnitReservationKindChoices.Season
+      ) {
+        return [
+          false,
+          "reservationUnit is only available for seasonal booking",
+        ];
       }
       return [true];
     }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Hide QuickReservation and the reservation calendar by adding a `reservationKind === SEASON` check to the isReservationUnitReservable helper function.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check out a reservationUnit page, which has reservationKind set to SEASON. The QuickReservation and Calendar elements shouldn't be displayed.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3012, TILA-3075
