### PR TITLE
refactor: add reusable query filter components

### DIFF
--- a/apps/admin-ui/src/component/QueryParamFilters/ComboboxFilter.tsx
+++ b/apps/admin-ui/src/component/QueryParamFilters/ComboboxFilter.tsx
@@ -1,0 +1,61 @@
+import { Combobox } from "hds-react";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
+
+interface OptionValue {
+  toString: () => string;
+}
+
+export function ComboboxFilter<T extends OptionValue>({
+  name,
+  options,
+}: {
+  name: string;
+  options: Array<{ label: string; value: T }>;
+}) {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filter = searchParams.getAll(name);
+  const setMultivalueSearchParam = (param: string, value: string[] | null) => {
+    const vals = new URLSearchParams(searchParams);
+    if (value == null || value.length === 0) {
+      vals.delete(param);
+    } else {
+      vals.set(param, value[0]);
+      value.forEach((v) => {
+        if (!vals.has(param, v)) {
+          vals.append(param, v);
+        }
+      });
+    }
+    setSearchParams(vals, { replace: true });
+  };
+  const onChange = (value: T[] | null) => {
+    const val = value?.map((v) => v.toString()) ?? null;
+    setMultivalueSearchParam(name, val);
+  };
+
+  const value = options.filter(
+    (v) => filter.find((x) => v.value.toString() === x) !== undefined
+  );
+
+  const label = t(`filters.label.${name}`);
+  const placeholder = t(`filters.placeholder.${name}`);
+  return (
+    <Combobox<typeof options>
+      label={label}
+      clearable
+      multiselect
+      /* @ts-expect-error - multiselect issues */
+      options={options}
+      disabled={options.length === 0}
+      value={value}
+      onChange={(val?: typeof options) =>
+        onChange(val?.map((x) => x.value) ?? null)
+      }
+      placeholder={placeholder}
+      clearButtonAriaLabel={t("common.clearAllSelections")}
+      selectedItemRemoveButtonAriaLabel={t("common.removeValue")}
+    />
+  );
+}

--- a/apps/admin-ui/src/component/QueryParamFilters/MultiSelectFilter.tsx
+++ b/apps/admin-ui/src/component/QueryParamFilters/MultiSelectFilter.tsx
@@ -1,0 +1,54 @@
+import { Select } from "hds-react";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
+
+// TODO is the T param good enough for type safety?
+// arrays of unions can be broken (ex. pushing a number to string[])
+// Discriminated Union can't be broken, but are unwieldy to use in this case
+// We want any type compatible with string | number be accepted
+// but never accept a combination of any of those types ex. [{label: "foo", value: 1}, {label: "bar", value: "baz"}]
+export function MultiSelectFilter<T extends string | number>({
+  name,
+  options,
+}: {
+  name: string;
+  options: { label: string; value: T }[];
+}): JSX.Element {
+  const { t } = useTranslation();
+  const [params, setParams] = useSearchParams();
+
+  const filter = params.getAll(name);
+
+  // TODO copy paste from allocation/index.tsx
+  const setFilter = (value: string[] | null) => {
+    const vals = new URLSearchParams(params);
+    if (value == null || value.length === 0) {
+      vals.delete(name);
+    } else {
+      vals.set(name, value[0]);
+      value.forEach((v) => {
+        if (!vals.has(name, v)) {
+          vals.append(name, v);
+        }
+      });
+    }
+    setParams(vals, { replace: true });
+  };
+
+  const label = t(`filters.label.${name}`);
+  const placeholder = t(`filters.placeholder.${name}`);
+  return (
+    <Select
+      label={label}
+      multiselect
+      placeholder={placeholder}
+      // @ts-expect-error -- multiselect problems
+      options={options}
+      disabled={options.length === 0}
+      value={options.filter((v) => filter.includes(v.value.toString())) ?? null}
+      onChange={(val?: typeof options) =>
+        setFilter(val?.map((x) => x.value.toString()) ?? null)
+      }
+    />
+  );
+}

--- a/apps/admin-ui/src/component/QueryParamFilters/SearchFilter.tsx
+++ b/apps/admin-ui/src/component/QueryParamFilters/SearchFilter.tsx
@@ -1,0 +1,36 @@
+import { SearchInput } from "hds-react";
+import { debounce } from "lodash";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
+
+// TODO should we check that name cant be empty?
+export function SearchFilter({ name }: { name: string }) {
+  const { t } = useTranslation();
+  const [searchParams, setParams] = useSearchParams();
+
+  const filter = searchParams.get(name);
+  const setFilter = (value: string) => {
+    const vals = new URLSearchParams(searchParams);
+    if (value === "") {
+      vals.delete(name);
+    } else {
+      vals.set(name, value);
+    }
+    setParams(vals, { replace: true });
+  };
+
+  // TODO general purpose filter labels and placeholders
+  const label = t(`filters.label.${name}`);
+  const placeholder = t(`filters.placeholder.${name}`);
+  return (
+    <SearchInput
+      label={label}
+      onChange={debounce((str) => setFilter(str), 100, {
+        leading: true,
+      })}
+      onSubmit={() => {}}
+      value={filter ?? ""}
+      placeholder={placeholder}
+    />
+  );
+}

--- a/apps/admin-ui/src/component/QueryParamFilters/index.tsx
+++ b/apps/admin-ui/src/component/QueryParamFilters/index.tsx
@@ -1,0 +1,3 @@
+export { ComboboxFilter } from "./ComboboxFilter";
+export { SearchFilter } from "./SearchFilter";
+export { MultiSelectFilter } from "./MultiSelectFilter";

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -1739,6 +1739,7 @@ const translations: ITranslations = {
   // common terms used in filters (reused in multiple places)
   // TODO key prefix is questionable (it's not only filters)
   filters: {
+    // TODO move to label
     homeCity: ["Kotipaikka"],
     purpose: ["Käyttötarkoitus"],
     ageGroup: ["Ikäryhmä"],
@@ -1750,6 +1751,13 @@ const translations: ITranslations = {
       status: ["Valitse käsittelyn vaihe"],
       eventStatus: ["Valitse käsittelyn vaihe"],
       weekday: ["Valitse viikonpäivä"],
+      priority: ["Valitse aikatoive"],
+      order: ["Valitse toivejärjestys"],
+      search: ["Hae nimellä tai ID:llä"],
+      applicantType: ["Valitse asiakastyyppi"],
+      ageGroup: ["Valitse ikäryhmä"],
+      purpose: ["Valitse käyttötarkoitus"],
+      homeCity: ["Valitse kotikunta"],
     },
     label: {
       unit: ["Toimipiste"],
@@ -1758,7 +1766,18 @@ const translations: ITranslations = {
       status: ["Käsittelyn vaihe"],
       eventStatus: ["Käsittelyn vaihe"],
       weekday: ["Viikonpäivä"],
+      selectUnits: ["Valitse toimipisteet"],
+      priority: ["Aikatoive"],
+      search: ["Hae hakemusta"],
+      ageGroup: ["Ikäryhmä"],
+      purpose: ["Käyttötarkoitus"],
+      homeCity: ["Kotikunta"],
+      applicantType: ["Asiakastyyppi"],
+      order: ["Varausyksiköiden toivejärjestys"],
     },
+    // weird values that don't fit under placeholder or label (custom options in this case)
+    reservationUnitApplication: ["Tilatoive"],
+    reservationUnitApplicationOthers: ["Muut tilatoiveet"],
   },
   RequestedReservation: {
     heading: ["Varauksen tarkastelu"],
@@ -1926,29 +1945,6 @@ const translations: ITranslations = {
     countResultsPostfix: ["tuloksesta näytetty"],
     countAllResults: ["Kaikki {{ count }}  tulosta näytetty"],
     clearFiltersButton: ["Tyhjennä suodattimet"],
-    filters: {
-      placeholder: {
-        time: ["Valitse aikatoive"],
-        order: ["Valitse toivejärjestys"],
-        search: ["Hae nimellä tai ID:llä"],
-        applicantType: ["Valitse asiakastyyppi"],
-        ageGroup: ["Valitse ikäryhmä"],
-        purpose: ["Valitse käyttötarkoitus"],
-        homeCity: ["Valitse kotikunta"],
-      },
-      label: {
-        unit: ["Toimipiste"],
-        selectUnits: ["Valitse toimipisteet"],
-        schedules: ["Aikatoive"],
-        search: ["Hae hakemusta"],
-        homeCity: ["Kotikunta"],
-        selectSchedules: ["Valitse aikatoive"],
-        applicantType: ["Asiakastyyppi"],
-        reservationUnitOrder: ["Varausyksiköiden toivejärjestys"],
-      },
-      reservationUnitApplication: ["Tilatoive"],
-      reservationUnitApplicationOthers: ["Muut tilatoiveet"],
-    },
     errors: {
       accepting: {
         alreadyDeclined: ['Varaukselle "{{name}}" on jo tehty hylkäys.'],

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/AllocatedEventDataLoader.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/AllocatedEventDataLoader.tsx
@@ -38,7 +38,7 @@ export function AllocatedEventDataLoader({
   const [searchParams] = useSearchParams();
   const unitFilter = searchParams.getAll("unit");
   const applicantFilter = searchParams.getAll("applicant");
-  const nameFilter = searchParams.get("name");
+  const nameFilter = searchParams.get("search");
   const appEventStatusFilter = searchParams.getAll("eventStatus");
   const weekDayFilter = searchParams.getAll("weekday");
   const reservationUnitFilter = searchParams.getAll("reservationUnit");

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/ApplicationDataLoader.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/ApplicationDataLoader.tsx
@@ -28,7 +28,7 @@ export function ApplicationDataLoader({
   const unitFilter = searchParams.getAll("unit");
   const statusFilter = searchParams.getAll("status");
   const applicantFilter = searchParams.getAll("applicant");
-  const nameFilter = searchParams.get("name");
+  const nameFilter = searchParams.get("search");
 
   const { fetchMore, previousData, loading, data } = useQuery<
     Query,

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/ApplicationEventDataLoader.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/ApplicationEventDataLoader.tsx
@@ -35,7 +35,7 @@ export function ApplicationEventDataLoader({
   const [searchParams] = useSearchParams();
   const unitFilter = searchParams.getAll("unit");
   const applicantFilter = searchParams.getAll("applicant");
-  const nameFilter = searchParams.get("name");
+  const nameFilter = searchParams.get("search");
   const eventStatusFilter = searchParams.getAll("eventStatus");
 
   const { fetchMore, previousData, loading, data } = useQuery<


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Use directly the url params based on name key.
- Use common translations and paths based on the name.

Requires react-router-dom so can't yet reuse in client application.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- For now only used on allocation and application-round/:id pages so check that the filters work and translations are correct.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3169
