### PR TITLE
fix: day of week one day ahead

### DIFF
--- a/apps/admin-ui/src/component/my-units/DayNavigation.tsx
+++ b/apps/admin-ui/src/component/my-units/DayNavigation.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Button, IconAngleLeft, IconAngleRight, DateInput } from "hds-react";
 import { fromUIDate, toUIDate } from "common/src/common/util";
 import { breakpoints } from "common";
+import { toMondayFirstUnsafe } from "common/src/helpers";
 
 type Props = {
   date: string;
@@ -64,7 +65,7 @@ const DayNavigation = ({ date, onDateChange }: Props): JSX.Element => {
       >
         {" "}
       </Button>
-      <WeekDay>{`${t(`dayShort.${d.getDay()}`)} `}</WeekDay>
+      <WeekDay>{`${t(`dayShort.${toMondayFirstUnsafe(d.getDay())}`)} `}</WeekDay>
       <SimpleDatePicker
         disableConfirmation
         id="date-input"


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: Sunday first -> Monday first when printing day of week.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- My units Date Picker should show the correct day of week not tomorrow.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
