### PR TITLE
fix: show blocked reservations as closed time slots

### DIFF
--- a/apps/ui/components/common/calendarUtils.ts
+++ b/apps/ui/components/common/calendarUtils.ts
@@ -1,0 +1,66 @@
+import { CalendarEvent } from "common/src/calendar/Calendar";
+import { ReservationType } from "common/types/gql-types";
+import React from "react";
+
+type ReservationStateWithInitial = string;
+
+const eventStyleGetter = (
+  { event }: CalendarEvent<ReservationType>,
+  ownReservations: number[],
+  draggable = true
+): { style: React.CSSProperties; className?: string } => {
+  const style = {
+    borderRadius: "0px",
+    opacity: "0.8",
+    color: "var(--color-white)",
+    display: "block",
+    borderColor: "transparent",
+  } as Record<string, string>;
+  let className = "";
+
+  const eventPk = event != null && "pk" in event ? event.pk : Number(event?.id);
+  const isOwn =
+    eventPk != null &&
+    !Number.isNaN(eventPk) &&
+    ownReservations?.includes(eventPk) &&
+    (event?.state as ReservationStateWithInitial) !== "BUFFER";
+
+  const state = isOwn ? "OWN" : (event?.state as ReservationStateWithInitial);
+
+  switch (state) {
+    case "INITIAL":
+      style.backgroundColor = "var(--tilavaraus-event-initial-color)";
+      style.color = "var(--color-black)";
+      style.border = "2px dashed var(--tilavaraus-event-initial-border)";
+      className = draggable ? "rbc-event-movable" : "";
+      break;
+    case "OWN":
+      style.backgroundColor = "var(--tilavaraus-event-initial-color)";
+      style.color = "var(--color-black)";
+      style.border = "2px solid var(--tilavaraus-event-initial-border)";
+      break;
+    case "BUFFER":
+      style.backgroundColor = "var(--color-black-5)";
+      className = "rbc-event-buffer";
+      break;
+    default:
+      style.backgroundColor = "var(--tilavaraus-event-reservation-color)";
+      style.border = "2px solid var(--tilavaraus-event-reservation-border)";
+      style.color = "var(--color-black)";
+  }
+
+  if (event?.isBlocked) {
+    style.color = "transparent";
+    style.backgroundColor = "var(--color-black-5)";
+    style.border = "1px solid var(--color-black-30)";
+    style.borderLeft = "2px solid var(--color-black-30)";
+    className = "rbc-timeslot-inactive";
+  }
+
+  return {
+    style,
+    className,
+  };
+};
+
+export { eventStyleGetter };

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -22,13 +22,7 @@ import {
 import classNames from "classnames";
 import { IconArrowRight, IconCross } from "hds-react";
 import { useRouter } from "next/router";
-import React, {
-  CSSProperties,
-  Children,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
+import React, { Children, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "next-i18next";
 import { useMedia } from "react-use";
 import styled from "styled-components";
@@ -44,6 +38,7 @@ import { BlackButton, MediumButton } from "@/styles/util";
 import Legend from "../calendar/Legend";
 import ReservationCalendarControls from "../calendar/ReservationCalendarControls";
 import { CalendarWrapper } from "../reservation-unit/ReservationUnitStyles";
+import { eventStyleGetter } from "@/components/common/calendarUtils";
 
 type Props = {
   reservation: ReservationType;
@@ -58,8 +53,6 @@ type Props = {
   nextStep: () => void;
   apiBaseUrl: string;
 };
-
-type ReservationStateWithInitial = string;
 
 type WeekOptions = "day" | "week" | "month";
 
@@ -89,60 +82,6 @@ const Actions = styled.div`
     flex-direction: row;
   }
 `;
-
-const eventStyleGetter = (
-  { event }: CalendarEvent<ReservationType>,
-  ownReservations: number[]
-): { style: React.CSSProperties; className?: string } => {
-  const draggable = true;
-  const style: CSSProperties = {
-    borderRadius: "0px",
-    opacity: "0.8",
-    color: "var(--color-white)",
-    display: "block",
-    borderColor: "transparent",
-  };
-  let className = "";
-
-  const eventPk: number | undefined =
-    event != null && "pk" in event
-      ? event?.pk ?? undefined
-      : Number(event?.id) ?? undefined;
-  const eventState = event?.state as ReservationStateWithInitial;
-  const isOwn =
-    eventPk != null &&
-    ownReservations.includes(eventPk) &&
-    eventState !== "BUFFER";
-
-  const state = isOwn ? "OWN" : eventState;
-
-  switch (state) {
-    case "INITIAL":
-      style.backgroundColor = "var(--tilavaraus-event-initial-color)";
-      style.color = "var(--color-black)";
-      style.border = "2px dashed var(--tilavaraus-event-initial-border)";
-      className = draggable ? "rbc-event-movable" : "";
-      break;
-    case "OWN":
-      style.backgroundColor = "var(--tilavaraus-event-initial-color)";
-      style.color = "var(--color-black)";
-      style.border = "2px solid var(--tilavaraus-event-initial-border)";
-      break;
-    case "BUFFER":
-      style.backgroundColor = "var(--color-black-5)";
-      className = "rbc-event-buffer";
-      break;
-    default:
-      style.backgroundColor = "var(--tilavaraus-event-reservation-color)";
-      style.border = "2px solid var(--tilavaraus-event-reservation-border)";
-      style.color = "var(--color-black)";
-  }
-
-  return {
-    style,
-    className,
-  };
-};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO type calendar props
 const EventWrapperComponent = (props: any): JSX.Element => {

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -360,6 +360,14 @@ const eventStyleGetter = (
       style.color = "var(--color-black)";
   }
 
+  if (event?.isBlocked) {
+    style.color = "transparent";
+    style.backgroundColor = "var(--color-black-5)";
+    style.border = "1px solid var(--color-black-30)";
+    style.borderLeft = "2px solid var(--color-black-30)";
+    className = "rbc-timeslot-inactive";
+  }
+
   return {
     style,
     className,

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -119,6 +119,7 @@ import { genericTermsVariant } from "@/modules/const";
 import { APPLICATION_ROUNDS_PERIODS } from "@/modules/queries/applicationRound";
 import { CenterSpinner } from "@/components/common/common";
 import { getCommonServerSideProps } from "@/modules/serverUtils";
+import { eventStyleGetter } from "@/components/common/calendarUtils";
 
 // TODO infered types don't cast them
 // type Props = Awaited<ReturnType<typeof getServerSideProps>>['props']
@@ -135,8 +136,6 @@ type Props = {
 };
 
 type WeekOptions = "day" | "week" | "month";
-
-type ReservationStateWithInitial = string;
 
 const allowedReservationStates: ReservationsReservationStateChoices[] = [
   ReservationsReservationStateChoices.Created,
@@ -314,65 +313,6 @@ const Columns = styled(TwoColumnLayout)`
     order: 1;
   }
 `;
-
-const eventStyleGetter = (
-  { event }: CalendarEvent<ReservationType>,
-  ownReservations: number[],
-  draggable = true
-): { style: React.CSSProperties; className?: string } => {
-  const style = {
-    borderRadius: "0px",
-    opacity: "0.8",
-    color: "var(--color-white)",
-    display: "block",
-    borderColor: "transparent",
-  } as Record<string, string>;
-  let className = "";
-
-  const eventPk = event != null && "pk" in event ? event.pk : Number(event?.id);
-  const isOwn =
-    eventPk != null &&
-    !Number.isNaN(eventPk) &&
-    ownReservations?.includes(eventPk) &&
-    (event?.state as ReservationStateWithInitial) !== "BUFFER";
-
-  const state = isOwn ? "OWN" : (event?.state as ReservationStateWithInitial);
-
-  switch (state) {
-    case "INITIAL":
-      style.backgroundColor = "var(--tilavaraus-event-initial-color)";
-      style.color = "var(--color-black)";
-      style.border = "2px dashed var(--tilavaraus-event-initial-border)";
-      className = draggable ? "rbc-event-movable" : "";
-      break;
-    case "OWN":
-      style.backgroundColor = "var(--tilavaraus-event-initial-color)";
-      style.color = "var(--color-black)";
-      style.border = "2px solid var(--tilavaraus-event-initial-border)";
-      break;
-    case "BUFFER":
-      style.backgroundColor = "var(--color-black-5)";
-      className = "rbc-event-buffer";
-      break;
-    default:
-      style.backgroundColor = "var(--tilavaraus-event-reservation-color)";
-      style.border = "2px solid var(--tilavaraus-event-reservation-border)";
-      style.color = "var(--color-black)";
-  }
-
-  if (event?.isBlocked) {
-    style.color = "transparent";
-    style.backgroundColor = "var(--color-black-5)";
-    style.border = "1px solid var(--color-black-30)";
-    style.borderLeft = "2px solid var(--color-black-30)";
-    className = "rbc-timeslot-inactive";
-  }
-
-  return {
-    style,
-    className,
-  };
-};
 
 const EventWrapper = styled.div``;
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Blocked reservations should show as the reservation unit being closed, so adds a check for `isBlocked` and applies same styling as for when the reservation unit is closed.
- Assumes that we also want to hide the time (and/or other possible text) so sets `color` to `transparent`.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Create an event/a reservation on the admin side which should be seen as blocked on the client side
- Check the reservation unit's page: the reservation should show as closed
- Same thing for EditStep0 (== edit reservation, first step)

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3016
