### PR TITLE
fix: unify the labeling of reservation control fields

### DIFF
--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -315,13 +315,15 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
     const options = getDurationOptions(
       minReservationDuration ?? 0,
       maxReservationDuration ?? 0,
-      reservationStartInterval
+      reservationStartInterval,
+      t
     );
     return [{ value: "0:00", label: "" }, ...options];
   }, [
     minReservationDuration,
     maxReservationDuration,
     reservationStartInterval,
+    t,
   ]);
 
   const [date, setDate] = useState<Date | null>(new Date());

--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -207,9 +207,10 @@ const ResetButton = styled(Button).attrs({
 
   && {
     border: var(--border-width) solid var(--color-black-50) !important;
-      &:hover, &:focus-within {
-          border-color: var(--color-black) !important;
-      }
+    &:hover,
+    &:focus-within {
+      border-color: var(--color-black) !important;
+    }
   }
 
   span {

--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -200,13 +200,17 @@ const Price = styled.div`
 `;
 
 const ResetButton = styled(Button).attrs({
-  variant: "supplementary",
+  variant: "secondary",
   iconLeft: <IconCross aria-hidden />,
 })<{ $isLast: boolean }>`
   --color: var(--color-black);
 
   white-space: nowrap;
   order: 1;
+
+  span {
+    ${fontRegular};
+  }
 
   svg {
     min-width: 24px;
@@ -220,7 +224,7 @@ const ResetButton = styled(Button).attrs({
   @media (min-width: ${breakpoints.xl}) {
     grid-column: unset;
 
-    svg {
+    [class*="Button-module__icon"] {
       display: none;
     }
   }

--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -174,7 +174,7 @@ const Content = styled.div<{ $isAnimated: boolean }>`
   }
 
   @media (min-width: ${breakpoints.xl}) {
-    grid-template-columns: 154px 120px 100px minmax(100px, 1fr) 100px auto;
+    grid-template-columns: 154px 105px 140px minmax(100px, 1fr) 110px auto;
   }
 `;
 
@@ -188,15 +188,13 @@ const PriceWrapper = styled.div`
   }
 `;
 
-const Label = styled.div`
-  margin-bottom: var(--spacing-2-xs);
-`;
-
 const Price = styled.div`
+  display: flex;
+  align-items: center;
+  height: 58px;
   ${fontRegular};
   font-size: var(--fontsize-body-l);
-  line-height: var(--lineheight-s);
-  padding-bottom: var(--spacing-3-xs);
+  line-height: var(--lineheight-l);
 `;
 
 const ResetButton = styled(Button).attrs({
@@ -204,12 +202,19 @@ const ResetButton = styled(Button).attrs({
   iconLeft: <IconCross aria-hidden />,
 })<{ $isLast: boolean }>`
   --color: var(--color-black);
-
   white-space: nowrap;
   order: 1;
 
+  && {
+    border: var(--border-width) solid var(--color-black-50) !important;
+      &:hover, &:focus-within {
+          border-color: var(--color-black) !important;
+      }
+  }
+
   span {
     ${fontRegular};
+    padding-left: 0;
   }
 
   svg {
@@ -748,8 +753,10 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
             <PriceWrapper>
               {isReservable && (
                 <>
-                  <Label>{t("reservationUnit:price")}:</Label>
-                  <Price data-testid="reservation__price--value">{price}</Price>
+                  <label htmlFor="price">{t("reservationUnit:price")}</label>
+                  <Price id="price" data-testid="reservation__price--value">
+                    {price}
+                  </Price>
                 </>
               )}
             </PriceWrapper>

--- a/apps/ui/components/reservation-unit/QuickReservation.tsx
+++ b/apps/ui/components/reservation-unit/QuickReservation.tsx
@@ -581,7 +581,7 @@ const QuickReservation = ({
       <Selects>
         <DateInput
           id="quick-reservation-date"
-          label={t("reservationCalendar:quickReservation.date")}
+          label={t("reservationCalendar:startDate")}
           initialMonth={new Date()}
           language={getLocalizationLang(i18n.language)}
           onChange={(_val, valueAsDate) => {
@@ -609,7 +609,7 @@ const QuickReservation = ({
         <StyledTimeInput
           key={`timeInput-${time}`}
           id="quick-reservation-time"
-          label={t("reservationCalendar:quickReservation.time")}
+          label={t("reservationCalendar:startTime")}
           hoursLabel={t("common:hours")}
           minutesLabel={t("common:minutes")}
           defaultValue={time}
@@ -628,7 +628,7 @@ const QuickReservation = ({
         <StyledSelect
           key={`durationSelect-${duration?.value}`}
           id="quick-reservation-duration"
-          label={t("reservationCalendar:quickReservation.duration")}
+          label={t("reservationCalendar:duration")}
           options={durationOptions}
           onChange={(val: OptionType) => setDuration(val)}
           defaultValue={duration}

--- a/apps/ui/components/reservation-unit/QuickReservation.tsx
+++ b/apps/ui/components/reservation-unit/QuickReservation.tsx
@@ -402,7 +402,8 @@ const QuickReservation = ({
     return getDurationOptions(
       minReservationDuration ?? undefined,
       maxReservationDuration ?? undefined,
-      reservationStartInterval
+      reservationStartInterval,
+      t
     );
   }, [
     minReservationDuration,
@@ -431,7 +432,7 @@ const QuickReservation = ({
     formatDate(nextHour.toISOString(), "HH:mm")
   );
   const [duration, setDuration] = useState<OptionType | undefined>(
-    durationOptions.find((n) => n.value === "1:00") || durationOptions[0]
+    durationOptions.find((n) => n.value === "60 min") ?? durationOptions[0]
   );
   const [slot, setSlot] = useState<string | null>(null);
   const [isReserving, setIsReserving] = useState(false);
@@ -591,7 +592,6 @@ const QuickReservation = ({
               const times = getAvailableTimesForDay({
                 day: valueAsDate,
                 duration: duration?.value?.toString() ?? "00:00",
-                time,
                 isSlotReservable,
                 reservationUnit: reservationUnit ?? undefined,
                 fromStartOfDay: true,

--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../reservation";
 import mockTranslations from "../../public/locales/fi/prices.json";
 import { toApiDate } from "common/src/common/util";
+import { TFunction } from "i18next";
 
 jest.mock("next-i18next", () => ({
   i18n: {
@@ -39,64 +40,66 @@ jest.mock("next-i18next", () => ({
 
 describe("getDurationOptions", () => {
   test("empty inputs", () => {
+    const mockT = ((x: string) => x) as TFunction;
     const interval90 =
       ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_90Mins;
     const interval60 =
       ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_60Mins;
-    expect(getDurationOptions(0, 5400, interval90)).toEqual([]);
-    expect(getDurationOptions(5400, 0, interval60)).toEqual([]);
-    expect(getDurationOptions(0, 0, interval90)).toEqual([]);
+    expect(getDurationOptions(0, 5400, interval90, mockT)).toEqual([]);
+    expect(getDurationOptions(5400, 0, interval60, mockT)).toEqual([]);
+    expect(getDurationOptions(0, 0, interval90, mockT)).toEqual([]);
   });
-
   test("with 15 min intervals", () => {
+    const mockT = ((x: string) => x) as TFunction;
     const interval15 =
       ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins;
-    expect(getDurationOptions(1800, 5400, interval15)).toEqual([
+    expect(getDurationOptions(1800, 5400, interval15, mockT)).toEqual([
       {
-        label: "0:30",
+        label: " common:abbreviations.minute",
         value: "0:30",
       },
       {
-        label: "0:45",
+        label: " common:abbreviations.minute",
         value: "0:45",
       },
       {
-        label: "1:00",
+        label: " common:abbreviations.minute",
         value: "1:00",
       },
       {
-        label: "1:15",
+        label: " common:abbreviations.minute",
         value: "1:15",
       },
       {
-        label: "1:30",
+        label: " common:abbreviations.minute",
         value: "1:30",
       },
     ]);
   });
 
   test("with 90 min intervals", () => {
+    const mockT = ((x: string) => x) as TFunction;
     const interval90 =
       ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_90Mins;
-    expect(getDurationOptions(1800, 30600, interval90)).toEqual([
+    expect(getDurationOptions(1800, 30600, interval90, mockT)).toEqual([
       {
-        label: "1:30",
+        label: " common:abbreviations.minute",
         value: "1:30",
       },
       {
-        label: "3:00",
+        label: "common:abbreviations.hour ",
         value: "3:00",
       },
       {
-        label: "4:30",
+        label: "common:abbreviations.hour common:abbreviations.minute",
         value: "4:30",
       },
       {
-        label: "6:00",
+        label: "common:abbreviations.hour ",
         value: "6:00",
       },
       {
-        label: "7:30",
+        label: "common:abbreviations.hour common:abbreviations.minute",
         value: "7:30",
       },
     ]);

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -23,14 +23,15 @@ import {
 import { getReservationApplicationFields } from "common/src/reservation-form/util";
 import { filterNonNullable } from "common/src/helpers";
 import { getTranslation } from "./util";
+import { TFunction } from "i18next";
 
 export const getDurationOptions = (
   minReservationDuration: number | undefined,
   maxReservationDuration: number | undefined,
-  reservationStartInterval: ReservationUnitsReservationUnitReservationStartIntervalChoices
+  reservationStartInterval: ReservationUnitsReservationUnitReservationStartIntervalChoices,
+  t: TFunction
 ): OptionType[] => {
   const intervalSeconds = getIntervalMinutes(reservationStartInterval) * 60;
-
   if (!minReservationDuration || !maxReservationDuration || !intervalSeconds)
     return [];
 
@@ -44,10 +45,21 @@ export const getDurationOptions = (
     i += intervalSeconds
   ) {
     const hms = secondsToHms(i);
-    const minute = String(hms.m).padEnd(2, "0");
+    const hourString =
+      hms.h !== 0 && hms.h >= 2
+        ? t("common:abbreviations.hour", { count: hms.h })
+        : "";
+    const minuteString = () => {
+      if (hms.h < 2)
+        return t("common:abbreviations.minute", { count: hms.h * 60 + hms.m });
+      if (hms.m !== 0)
+        return t("common:abbreviations.minute", { count: hms.m });
+      return "";
+    };
+    const optionString = `${hourString} ${minuteString()}`;
     timeOptions.push({
-      label: `${hms.h}:${minute}`,
-      value: `${hms.h}:${minute}`,
+      label: optionString,
+      value: `${hms.h}:${String(hms.m).padEnd(2, "0")}`,
     });
   }
 

--- a/apps/ui/public/locales/en/application.json
+++ b/apps/ui/public/locales/en/application.json
@@ -72,7 +72,7 @@
     "resetTimes": "Clear calendar",
     "summary": "Summary",
     "prioritySelectLabel": "Type of booking request",
-    "reservationUnitSelectLabel": "Seasonal booking times",
+    "reservationUnitSelectLabel": "Available seasonal booking times for",
     "priorityLabels": {
       "300": "Select preferred time slots",
       "200": "Select other time slots"

--- a/apps/ui/public/locales/en/reservationCalendar.json
+++ b/apps/ui/public/locales/en/reservationCalendar.json
@@ -87,9 +87,6 @@
   "reservationQuotaFull_other": "You cannot make new bookings.",
   "quickReservation": {
     "heading": "See the available times and make a booking",
-    "date": "Date",
-    "time": "Time (from)",
-    "duration": "Duration (h:mm)",
     "subheading": "Available times",
     "noTimes": "No available times",
     "gotoCalendar": "See all available times",

--- a/apps/ui/public/locales/fi/application.json
+++ b/apps/ui/public/locales/fi/application.json
@@ -73,7 +73,7 @@
     "resetTimes": "Tyhjennä kalenteri",
     "summary": "Yhteenveto",
     "prioritySelectLabel": "Aikatoiveen tyyppi",
-    "reservationUnitSelectLabel": "Kausivarauksen ajankohdat",
+    "reservationUnitSelectLabel": "Näytä kausivarattavat ajankohdat tilalle",
     "priorityLabels": {
       "300": "Valitse ensisijaiset aikatoiveet",
       "200": "Valitse muut aikatoiveet"

--- a/apps/ui/public/locales/fi/reservationCalendar.json
+++ b/apps/ui/public/locales/fi/reservationCalendar.json
@@ -85,9 +85,6 @@
   "reservationQuotaFull_other": "Et voi tehdä uusia varauksia.",
   "quickReservation": {
     "heading": "Katso vapaat ajat ja varaa",
-    "date": "Päivä",
-    "time": "Aika (alkaen)",
-    "duration": "Kesto (t:mm)",
     "subheading": "Seuraavat vapaat ajat",
     "noTimes": "Ei vapaita aikoja",
     "gotoCalendar": "Katso kaikki vapaat ajat",

--- a/apps/ui/public/locales/sv/application.json
+++ b/apps/ui/public/locales/sv/application.json
@@ -72,7 +72,7 @@
     "resetTimes": "Töm kalendern",
     "summary": "Sammanfattning",
     "prioritySelectLabel": "Typ av tidsönskemål",
-    "reservationUnitSelectLabel": "Säsongbokningstider",
+    "reservationUnitSelectLabel": "Visa säsongbokningstider för lokalen",
     "priorityLabels": {
       "300": "Välj prioriterade tidsönskemål",
       "200": "Välj alternativa tidsönskemål"

--- a/apps/ui/public/locales/sv/reservationCalendar.json
+++ b/apps/ui/public/locales/sv/reservationCalendar.json
@@ -87,9 +87,6 @@
   "reservationQuotaFull_other": "Du kan inte göra nya bokningar.",
   "quickReservation": {
     "heading": "Se lediga tider och boka",
-    "date": "Dag",
-    "time": "Tid (från)",
-    "duration": "Längd (t:mm)",
     "subheading": "Lediga tider",
     "noTimes": "Inga lediga tider",
     "gotoCalendar": "Se alla lediga tider",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Quick reservation used its own set of duplicated translation keys for the field label texts. Changes the referred keys to be the same ones used by the calendar.
- The reset button in the calendar reservation view was styled wrong. Changes it to `secondary` instead of `supplementary` got the basic styling right. Manually fixed the rest.
- Restyles ReservationCalendarControls to make everything fit
- Removes start time input from QuickReservation element, as it was confusing and we list all the available times for the given date anyway right below the input. The user can navigate via the quick reservation time chunks.
- Updates translations for seasonal application unit selection label on Page2

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to any reservation unit page and select a time, then open the reservation controls accordion:
  - The labels should match between the quick reservation and the calendar reservation controls
  - The calendar reservation controls reset button looks and behaves as it should (== grayscale)
  - The duration options are in "2t 30min"-format, starting from 2h. Any values below that should be displayed in minutes only ("90 min").

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3018
