### PR TITLE
Refactor format duration combine utility functions

### DIFF
--- a/apps/admin-ui/src/common/util.test.ts
+++ b/apps/admin-ui/src/common/util.test.ts
@@ -1,7 +1,6 @@
 import {
   convertHMSToSeconds,
   formatTimeDistance,
-  formatDuration,
   secondsToHms,
   filterData,
   formatDecimal,
@@ -18,33 +17,6 @@ test("secondToHms", () => {
   expect(secondsToHms(-190)).toEqual({});
   expect(secondsToHms()).toEqual({});
   expect(secondsToHms(undefined)).toEqual({});
-});
-
-// can't test actual values since i18next mock doesn't pass them through
-test("parseDuration short", () => {
-  expect(formatDuration(3600)).toBe("common.hoursUnit");
-  expect(formatDuration(3600 * 10)).toContain("common.hoursUnit");
-  expect(formatDuration(7834)).toContain("common.hoursUnit");
-  expect(formatDuration(3600 - 10)).not.toContain("common.hoursUnit");
-  expect(formatDuration(3600 - 10)).toBe("common.minutesUnit");
-  // we have both hours and minutes
-  expect(formatDuration(3600 + 2 * 60)).toBe(
-    "common.hoursUnit common.minutesUnit"
-  );
-});
-
-test("parseDuration long", () => {
-  expect(formatDuration(3600, "long")).toBe("common.hoursUnitLong");
-  expect(formatDuration(3600 - 10, "long")).toBe("common.minutesUnitLong");
-  expect(formatDuration(3600 + 2 * 60, "long")).toBe(
-    "common.hoursUnitLong common.minutesUnitLong"
-  );
-});
-
-test("parseDuration invalid", () => {
-  expect(formatDuration(0)).toBe("");
-  expect(formatDuration(-30)).toBe("");
-  expect(formatDuration(undefined)).toBe("");
 });
 
 test("parseDurationString", () => {

--- a/apps/admin-ui/src/common/util.ts
+++ b/apps/admin-ui/src/common/util.ts
@@ -5,6 +5,8 @@ import { LocationType, Query } from "common/types/gql-types";
 import { DataFilterOption } from "./types";
 import { NUMBER_OF_DECIMALS } from "./const";
 
+export { formatDuration } from "common/src/common/util";
+
 export const DATE_FORMAT = "d.M.yyyy";
 export const DATE_FORMAT_SHORT = "d.M.";
 
@@ -88,30 +90,6 @@ export const parseDurationString = (time: string): HMS | undefined => {
     return undefined;
   }
   return { h, m };
-};
-
-export const formatDurationShort = (hms: HMS): string =>
-  `${hms.h ? i18next.t("common.hoursUnit", { count: hms.h }) : ""} ${
-    hms.m ? i18next.t("common.minutesUnit", { count: hms.m }) : ""
-  }`;
-
-export const formatDurationLong = (hms: HMS): string =>
-  `${hms.h ? i18next.t("common.hoursUnitLong", { count: hms.h }) : ""} ${
-    hms.m ? i18next.t("common.minutesUnitLong", { count: hms.m }) : ""
-  }`;
-
-export const formatDuration = (
-  duration: number | null | undefined,
-  unitFormat?: "long"
-): string => {
-  const hms = secondsToHms(duration);
-
-  switch (unitFormat) {
-    case "long":
-      return formatDurationLong(hms).trim();
-    default:
-      return formatDurationShort(hms).trim();
-  }
 };
 
 export const convertHMSToSeconds = (input: string): number | null => {

--- a/apps/admin-ui/src/component/applications/ApplicationDetails.tsx
+++ b/apps/admin-ui/src/component/applications/ApplicationDetails.tsx
@@ -17,13 +17,7 @@ import {
   type ApplicationNode,
   ApplicationsApplicationApplicantTypeChoices,
 } from "common/types/gql-types";
-import {
-  formatNumber,
-  formatDate,
-  parseAgeGroups,
-  formatDurationShort,
-  secondsToHms,
-} from "@/common/util";
+import { formatNumber, formatDate, parseAgeGroups } from "@/common/util";
 import { weekdays } from "@/common/const";
 import { useNotification } from "@/context/NotificationContext";
 import ScrollIntoView from "@/common/ScrollIntoView";
@@ -41,6 +35,7 @@ import StickyHeader from "../StickyHeader";
 import StatusBlock from "../StatusBlock";
 import { APPLICATION_ADMIN_QUERY } from "./queries";
 import { BirthDate } from "../BirthDate";
+import { formatDuration } from "common/src/common/util";
 
 const parseApplicationEventSchedules = (
   applicationEventSchedules: ApplicationEventScheduleNode[],
@@ -209,18 +204,17 @@ const KV = ({
   </div>
 );
 
-const formatDuration = (
-  duration: number | undefined,
+const formatApplicationDuration = (
+  durationSeconds: number | undefined,
   t: TFunction,
   type?: "min" | "max"
 ): string => {
-  if (!duration) {
+  if (!durationSeconds) {
     return "";
   }
+  const durMinutes = durationSeconds / 60;
   const translationKey = `common.${type}Amount`;
-  return `${type ? t(translationKey) : ""} ${formatDurationShort(
-    secondsToHms(duration)
-  )}`;
+  return `${type ? t(translationKey) : ""} ${formatDuration(durMinutes, t)}`;
 };
 
 const appEventDuration = (
@@ -230,10 +224,10 @@ const appEventDuration = (
 ): string => {
   let duration = "";
   if (isEqual(min, max)) {
-    duration += formatDuration(min, t);
+    duration += formatApplicationDuration(min, t);
   } else {
-    duration += formatDuration(min, t, "min");
-    duration += `, ${formatDuration(max, t, "max")}`;
+    duration += formatApplicationDuration(min, t, "min");
+    duration += `, ${formatApplicationDuration(max, t, "max")}`;
   }
   return trim(duration, ", ");
 };

--- a/apps/admin-ui/src/component/reservations/requested/util.test.ts
+++ b/apps/admin-ui/src/component/reservations/requested/util.test.ts
@@ -125,7 +125,7 @@ describe("createTag", () => {
     const mockT = ((x: string) => x) as TFunction;
     const tag = createTagString(res, mockT);
     expect(tag).toContain(
-      "dayShort.0, dayShort.1, dayShort.3 12:00-14:00, common.hoursUnit"
+      "dayShort.0, dayShort.1, dayShort.3 12:00-14:00, common:abbreviations.hour"
     );
     expect(tag).toContain("1.4.2023-1.7.2023");
     expect(tag).toContain("Foobar");
@@ -147,7 +147,7 @@ describe("createTag", () => {
     const tag = createTagString(res, mockT);
     expect(tag).not.toContain("dayShort.0, dayShort.1, dayShort.3");
     expect(tag).toContain("1.4.2023");
-    expect(tag).toContain("12:00-14:00, common.hoursUnit");
+    expect(tag).toContain("12:00-14:00, common:abbreviations.hour");
     expect(tag).toContain("dayShort.5");
     expect(tag).toContain("Foobar");
   });

--- a/apps/admin-ui/src/component/reservations/requested/util.ts
+++ b/apps/admin-ui/src/component/reservations/requested/util.ts
@@ -23,7 +23,7 @@ import {
   ReservationUnitsReservationUnitPricingPriceUnitChoices,
   ReservationsReservationTypeChoices,
 } from "common/types/gql-types";
-import { fromApiDate } from "common/src/common/util";
+import { formatDuration, fromApiDate } from "common/src/common/util";
 import { toMondayFirst } from "common/src/helpers";
 import { truncate } from "@/helpers";
 import { DATE_FORMAT, formatDate, formatTime } from "@/common/util";
@@ -63,20 +63,18 @@ export const reservationDuration = (start: Date, end: Date): string => {
   return `${differenceInHours(end, start)}`;
 };
 
-const reservationDurationString = (
+function reservationDurationString(
   start: string,
   end: string,
   t: TFunction
-): string => {
+): string {
   const startDate = new Date(start);
   const endDate = new Date(end);
 
-  const h = differenceInHours(endDate, startDate);
-  const m = differenceInMinutes(endDate, startDate) - h * 60;
-  return `${t("common.hoursUnit", { count: h })} ${
-    m !== 0 ? t("common.minutesUnit", { count: m }) : ""
-  }`;
-};
+  const durMinutes = differenceInMinutes(endDate, startDate);
+  const abbreviated = true;
+  return formatDuration(durMinutes, t, abbreviated);
+}
 
 export const reservationUnitName = (
   reservationUnit: Maybe<ReservationUnitType>
@@ -230,6 +228,7 @@ export const getName = (reservation: ReservationType, t: TFunction) => {
   );
 };
 
+// TODO rename: it's the time + duration
 // recurring format: {weekday(s)} {time}, {duration} | {startDate}-{endDate} | {unit}
 // single format   : {weekday} {date} {time}, {duration} | {unit}
 export const createTagString = (reservation: ReservationType, t: TFunction) => {

--- a/apps/admin-ui/src/i18n/index.ts
+++ b/apps/admin-ui/src/i18n/index.ts
@@ -26,6 +26,12 @@ i18n.addResourceBundle("fi", "common", {
   increase: "Lisää",
   decrease: "Vähennä",
   applicationName: "Tilavarauskäsittely",
+  abbreviations: {
+    hour: "{{count}} t",
+    minute: "{{count}} min",
+  },
+  hours: "Tunnit",
+  minutes: "Minuutit",
 });
 i18n.addResourceBundle("en", "common", {
   day: "Day",

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/AllocationCard.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/AllocationCard.tsx
@@ -26,6 +26,7 @@ import {
   parseApiTime,
   timeSlotKeyToScheduleTime,
   decodeTimeSlot,
+  createDurationString,
 } from "./modules/applicationRoundAllocation";
 import {
   APPROVE_APPLICATION_EVENT_SCHEDULE,
@@ -408,7 +409,7 @@ export function AllocationCard({
   const selectionDurationMins = selection.length * 30;
   const beginSeconds = applicationEvent.minDuration ?? 0;
   const endSeconds = applicationEvent.maxDuration ?? 0;
-  const selectionDurationString = formatDuration(selectionDurationMins * 60);
+  const selectionDurationString = formatDuration(selectionDurationMins, t);
   const isRequestedTimeMismatch = isOutsideOfRequestedTimes(
     matchingApplicationEventSchedule,
     selection
@@ -566,12 +567,8 @@ function TimeRequested({
   applicationEvent: ApplicationEventNode;
 }) {
   const { t } = useTranslation();
-  const { minDuration, maxDuration, eventsPerWeek } = applicationEvent;
-
-  const parsedDuration =
-    minDuration === maxDuration
-      ? formatDuration(minDuration)
-      : `${formatDuration(minDuration)} - ${formatDuration(maxDuration)}`;
+  const { eventsPerWeek } = applicationEvent;
+  const durationString = createDurationString(applicationEvent, t);
 
   const aes = filterNonNullable(applicationEvent?.applicationEventSchedules);
   const primaryTimes = getApplicationEventScheduleTimeString(aes, 300);
@@ -582,7 +579,7 @@ function TimeRequested({
       <DetailRow>
         <span>{t("Allocation.applicationsWeek")}:</span>
         <SemiBold>
-          {parsedDuration}, {eventsPerWeek}x
+          {durationString}, {eventsPerWeek}x
         </SemiBold>
       </DetailRow>
       <DetailRow>

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/ApplicationEventCard.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/ApplicationEventCard.tsx
@@ -8,11 +8,13 @@ import type {
 } from "common/types/gql-types";
 import { SemiBold, type ReservationUnitNode, fontMedium } from "common";
 import { PUBLIC_URL } from "@/common/const";
-import { formatDuration } from "@/common/util";
 import { getApplicantName } from "@/component/applications/util";
 import { ageGroup } from "@/component/reservations/requested/util";
 import { filterNonNullable } from "common/src/helpers";
-import { formatTime } from "./modules/applicationRoundAllocation";
+import {
+  createDurationString,
+  formatTime,
+} from "./modules/applicationRoundAllocation";
 
 export type AllocationApplicationEventCardType =
   | "unallocated"
@@ -152,12 +154,7 @@ export function ApplicationEventCard({
 
   const applicantName = getApplicantName(application);
   const isActive = applicationEvent === focusedApplicationEvent;
-  const parsedDuration =
-    applicationEvent.minDuration === applicationEvent.maxDuration
-      ? formatDuration(applicationEvent.minDuration)
-      : `${formatDuration(applicationEvent.minDuration)} - ${formatDuration(
-          applicationEvent.maxDuration
-        )}`;
+  const durationString = createDurationString(applicationEvent, t);
 
   const nReservationUnits =
     applicationEvent?.eventReservationUnits?.length ?? -1;
@@ -227,7 +224,7 @@ export function ApplicationEventCard({
         <div>
           {t("Allocation.applicationsWeek")}:{" "}
           <SemiBold>
-            {parsedDuration}, x{applicationEvent.eventsPerWeek}
+            {durationString}, x{applicationEvent.eventsPerWeek}
           </SemiBold>
         </div>
         <div>

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/modules/applicationRoundAllocation.ts
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/modules/applicationRoundAllocation.ts
@@ -9,6 +9,8 @@ import {
 import type { ApplicationEventSchedulePriority } from "common/types/common";
 import i18next from "i18next";
 import { filterNonNullable } from "common/src/helpers";
+import { formatDuration } from "common/src/common/util";
+import { type TFunction } from "next-i18next";
 
 const parseApplicationEventScheduleTime = (
   applicationEventSchedule: ApplicationEventScheduleNode
@@ -484,3 +486,20 @@ export type ApplicationEventScheduleResultStatuses = {
   acceptedSlots: string[];
   declinedSlots: string[];
 };
+
+export function createDurationString(
+  applicationEvent: ApplicationEventNode,
+  t: TFunction
+) {
+  const { minDuration, maxDuration } = applicationEvent;
+
+  const minDurString =
+    minDuration != null ? formatDuration(minDuration / 60, t) : undefined;
+  const maxDurString =
+    maxDuration != null ? formatDuration(maxDuration / 60, t) : undefined;
+  const durationString =
+    minDuration === maxDuration
+      ? minDurString
+      : `${minDurString ?? ""} - ${maxDurString ?? ""}`;
+  return durationString;
+}

--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -55,11 +55,7 @@ import {
 } from "@/modules/reservationUnit";
 import LoginFragment from "../LoginFragment";
 import { useDebounce } from "@/hooks/useDebounce";
-import {
-  capitalize,
-  formatDurationMinutes,
-  getPostLoginUrl,
-} from "@/modules/util";
+import { capitalize, formatDuration, getPostLoginUrl } from "@/modules/util";
 
 type Props<T> = {
   reservationUnit: ReservationUnitByPkType;
@@ -583,9 +579,7 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
     );
     const durationStr =
       end != null && begin != null
-        ? formatDurationMinutes(
-            differenceInMinutes(new Date(end), new Date(begin))
-          )
+        ? formatDuration(differenceInMinutes(new Date(end), new Date(begin)), t)
         : "";
 
     return `${dateStr}, ${durationStr}`;

--- a/apps/ui/components/calendar/ReservationDetails.tsx
+++ b/apps/ui/components/calendar/ReservationDetails.tsx
@@ -1,10 +1,10 @@
-import { getDay } from "date-fns";
+import { differenceInMinutes, getDay } from "date-fns";
 import { Button, IconCross } from "hds-react";
 import React, { ReactNode } from "react";
-import { useTranslation } from "next-i18next";
+import { type TFunction, useTranslation } from "next-i18next";
 import styled from "styled-components";
-import { parseTimeframeLength } from "common/src/calendar/util";
 import { fontMedium } from "common/src/common/typography";
+import { formatDuration } from "common/src/common/util";
 import { formatDate } from "../../modules/util";
 
 type EventEvent = {
@@ -29,6 +29,18 @@ const wrapperHeight = "150px";
 const Wrapper = styled.div`
   pointer-events: all;
 `;
+
+function parseTimeframeLength(
+  begin: string,
+  end: string,
+  t: TFunction
+): string {
+  const beginDate = new Date(begin);
+  const endDate = new Date(end);
+  const durMinutes = differenceInMinutes(endDate, beginDate);
+  const abbreviated = true;
+  return formatDuration(durMinutes, t, abbreviated);
+}
 
 const Modal = styled.div<{
   $top: number;
@@ -135,7 +147,7 @@ const ReservationDetails = ({
     >
       {React.Children.map(children, (child) => {
         const day = getDay(new Date(event.start));
-        const timeframe = parseTimeframeLength(event.start, event.end);
+        const timeframe = parseTimeframeLength(event.start, event.end, t);
         const props =
           child != null && typeof child === "object" && "props" in child
             ? child?.props

--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -4,7 +4,7 @@ import NextImage from "next/image";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { isReservationStartInFuture } from "common/src/calendar/util";
-import { formatSecondDuration } from "common/src/common/util";
+import { formatDuration } from "common/src/common/util";
 import { fontRegular, H2, H3 } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import {
@@ -161,15 +161,10 @@ const Head = ({
     return singleSearchUrl(omit(storedValues, "applicationRound"));
   }, [storedValues]);
 
-  const minReservationDuration = formatSecondDuration(
-    reservationUnit.minReservationDuration ?? 0,
-    true
-  );
-
-  const maxReservationDuration = formatSecondDuration(
-    reservationUnit.maxReservationDuration ?? 0,
-    true
-  );
+  const minDur = reservationUnit.minReservationDuration ?? 0;
+  const maxDur = reservationUnit.maxReservationDuration ?? 0;
+  const minReservationDuration = formatDuration(minDur / 60, t, true);
+  const maxReservationDuration = formatDuration(maxDur / 60, t, true);
 
   const pricing = getActivePricing(reservationUnit);
   const unitPrice = pricing ? getPrice({ pricing }) : undefined;

--- a/apps/ui/components/reservation-unit/ReservationInfoContainer.tsx
+++ b/apps/ui/components/reservation-unit/ReservationInfoContainer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatSecondDuration } from "common/src/common/util";
+import { formatDuration } from "common/src/common/util";
 import { ReservationUnitByPkType } from "common/types/gql-types";
 import ClientOnly from "common/src/ClientOnly";
 import { Trans, useTranslation } from "next-i18next";
@@ -168,12 +168,14 @@ const ReservationInfoContainer = ({
                 i18nKey="reservationUnit:reservationInfo3"
                 defaults="Varauksen keston tulee olla välillä <bold>{{minReservationDuration}}</bold> ja <bold>{{maxReservationDuration}}</bold>."
                 values={{
-                  minReservationDuration: formatSecondDuration(
-                    reservationUnit.minReservationDuration,
+                  minReservationDuration: formatDuration(
+                    reservationUnit.minReservationDuration / 60,
+                    t,
                     false
                   ),
-                  maxReservationDuration: formatSecondDuration(
-                    reservationUnit.maxReservationDuration,
+                  maxReservationDuration: formatDuration(
+                    reservationUnit.maxReservationDuration / 60,
+                    t,
                     false
                   ),
                 }}

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -39,7 +39,7 @@ import {
   isReservationReservable,
 } from "@/modules/reservation";
 import { getReservationUnitPrice } from "@/modules/reservationUnit";
-import { formatDurationMinutes, isTouchDevice } from "@/modules/util";
+import { formatDuration, isTouchDevice } from "@/modules/util";
 import { BlackButton, MediumButton } from "@/styles/util";
 import Legend from "../calendar/Legend";
 import ReservationCalendarControls from "../calendar/ReservationCalendarControls";
@@ -204,7 +204,7 @@ const EditStep0 = ({
           )
         : undefined;
     const diff = maybeDiff ?? 0;
-    const duration = diff >= 90 ? `(${formatDurationMinutes(diff)})` : "";
+    const duration = diff >= 90 ? `(${formatDuration(diff, t)})` : "";
     const shownReservation =
       initialReservation != null
         ? { ...initialReservation, state: "INITIAL" }

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -16,7 +16,7 @@ import type { ReservationType } from "common/types/gql-types";
 import { getReservationUnitPrice } from "@/modules/reservationUnit";
 import {
   capitalize,
-  formatDurationMinutes,
+  formatDuration,
   getImageSource,
   getMainImage,
   getTranslation,
@@ -183,7 +183,7 @@ const ReservationInfoCard = ({
         </Subheading>
         <Value data-testid="reservation__reservation-info-card__duration">
           <Strong>
-            {capitalize(timeString)}, {formatDurationMinutes(duration)}
+            {capitalize(timeString)}, {formatDuration(duration, t)}
           </Strong>
         </Value>
         <Value data-testid="reservation__reservation-info-card__price">

--- a/apps/ui/modules/util.ts
+++ b/apps/ui/modules/util.ts
@@ -30,6 +30,7 @@ import {
 } from "./const";
 import type { LocalizationLanguages } from "common/src/helpers";
 
+export { formatDuration } from "common/src/common/util";
 export { fromAPIDate, fromUIDate };
 export { getTranslation };
 
@@ -282,34 +283,6 @@ export const getReducedApplicationStatus = (
     default:
       return null;
   }
-};
-
-export const formatDurationMinutes = (
-  duration: number,
-  abbreviated = true
-): string => {
-  if (!duration) {
-    return "-";
-  }
-
-  const hour = Math.floor(duration / 60);
-  const min = Math.floor(duration % 60);
-
-  const hourKey = abbreviated ? "common:abbreviations.hour" : "common:hour";
-  const minuteKey = abbreviated
-    ? "common:abbreviations.minute"
-    : "common:minute";
-
-  const p = [];
-
-  if (hour && i18n?.t != null) {
-    p.push(i18n.t(hourKey, { count: hour }).toLocaleLowerCase());
-  }
-  if (min && i18n?.t != null) {
-    p.push(i18n.t(minuteKey, { count: min }).toLocaleLowerCase());
-  }
-
-  return p.join(" ");
 };
 
 export const getReadableList = (list: string[]): string => {

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -67,7 +67,7 @@ import { Map } from "@/components/Map";
 import Legend from "@/components/calendar/Legend";
 import ReservationCalendarControls from "@/components/calendar/ReservationCalendarControls";
 import {
-  formatDurationMinutes,
+  formatDuration,
   getTranslation,
   isTouchDevice,
   printErrorMessages,
@@ -726,7 +726,7 @@ const ReservationUnit = ({
             new Date(initialReservation.begin)
           )
         : 0;
-    const duration = diff >= 90 ? `(${formatDurationMinutes(diff)})` : "";
+    const duration = diff >= 90 ? `(${formatDuration(diff, t)})` : "";
 
     const existingReservations = filterNonNullable(
       reservationUnit?.reservations

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -34,7 +34,6 @@ import {
 import {
   convertHMSToSeconds,
   endOfWeek,
-  formatSecondDuration,
   parseDate,
   secondsToHms,
   startOfWeek,
@@ -648,13 +647,6 @@ export const getNormalizedReservationBeginTime = (
     new Date(reservationUnit.reservationBegins as string),
     negativeBuffer
   ).toISOString();
-};
-
-export const parseTimeframeLength = (begin: string, end: string): string => {
-  const beginDate = new Date(begin);
-  const endDate = new Date(end);
-  const diff = differenceInSeconds(endDate, beginDate);
-  return formatSecondDuration(diff);
 };
 
 export const getOpenDays = (

--- a/packages/common/src/common/util.ts
+++ b/packages/common/src/common/util.ts
@@ -10,7 +10,7 @@ import {
 } from "date-fns";
 import { fi } from "date-fns/locale";
 /* eslint-enable import/no-duplicates */
-import { capitalize, isNumber } from "lodash";
+import { capitalize } from "lodash";
 import { type TFunction, i18n } from "next-i18next";
 import { HMS } from "../../types/common";
 
@@ -65,51 +65,6 @@ export function formatDuration(
   }
 
   return p.join(" ");
-}
-
-/// @deprecated
-/// TODO this is duplicated code
-/// TODO this should take in t function and not use i18n directly (fails to load translations)
-function formatDurationString(
-  duration: string | null,
-  abbreviated = true
-): string {
-  if (!duration || isNumber(duration) || !duration?.includes(":")) {
-    return "-";
-  }
-
-  const hourKey = abbreviated ? "common:abbreviations.hour" : "common:hour";
-  const minuteKey = abbreviated
-    ? "common:abbreviations.minute"
-    : "common:minute";
-
-  const time = duration.split(":");
-  if (time.length < 3) {
-    return "-";
-  }
-
-  const hours = Number(time[0]);
-  const minutes = Number(time[1]);
-
-  return `${
-    hours
-      ? `${`${i18n?.t(hourKey, { count: hours }) || "".toLocaleLowerCase()}`} `
-      : ""
-  }${minutes ? i18n?.t(minuteKey, { count: minutes }) : ""}`.trim();
-}
-
-/// @deprecated
-/// TODO rename? or remove? we should always use a single format function that has consistent input types (seconds or minutes)
-export function formatSecondDuration(
-  duration: number,
-  abbreviated = true
-): string {
-  if (!duration || !isNumber(duration)) {
-    return "-";
-  }
-
-  const hms = secondsToHms(duration);
-  return formatDurationString(`${hms.h}:${hms.m}:${hms.s}`, abbreviated);
 }
 
 export const addYears = (date: Date, years: number): Date => {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Remove extra formatDuration utility function.
- Move formatDuration to common package.
- Fix: pass translation function to formatDuration so next-i18n hook picks up the translations automatically.
- Fix: don't print hours for reservation if they are 0.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check reservation and application durations (both admin and client ui's), minutes should be shown only if they !== 0 same with hours.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3169
