### PR TITLE
Add sticky header to my units

### DIFF
--- a/apps/admin-ui/src/component/my-units/ReservationPopupContent.tsx
+++ b/apps/admin-ui/src/component/my-units/ReservationPopupContent.tsx
@@ -2,14 +2,18 @@ import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { ReservationType } from "common/types/gql-types";
-import { Permission } from "app/modules/permissionHelper";
-import { reservationUrl } from "../../common/urls";
-import { formatTime } from "../../common/util";
-import { DenseVerticalFlex } from "../../styles/layout";
+import { Permission } from "@/modules/permissionHelper";
+import { reservationUrl } from "@/common/urls";
+import { formatTime } from "@/common/util";
+import { truncate } from "@/helpers";
+import { DenseVerticalFlex } from "@/styles/layout";
 import { getReserveeName } from "../reservations/requested/util";
 import { CELL_BORDER } from "./const";
 import VisibleIfPermission from "../reservations/requested/VisibleIfPermission";
 import { useTranslation } from "next-i18next";
+
+const MAX_POPOVER_COMMENT_LENGTH = 140;
+const POPOVER_MAX_WIDTH = 300;
 
 const PopupContent = styled.div`
   border: ${CELL_BORDER};
@@ -17,6 +21,7 @@ const PopupContent = styled.div`
   padding: var(--spacing-xs);
   background-color: white;
   font-size: var(--fontsize-body-s);
+  max-width: ${POPOVER_MAX_WIDTH}px;
 `;
 
 const Heading = styled.div``;
@@ -29,13 +34,14 @@ const WorkingMemo = styled.div`
   background-color: var(--color-black-5);
   padding: var(--spacing-xs);
   border-radius: 4px;
+  max-width: ${POPOVER_MAX_WIDTH - 20}px;
 `;
 
-const ReservationPopupContent = ({
+export function ReservationPopupContent({
   reservation,
 }: {
   reservation: ReservationType;
-}): JSX.Element => {
+}): JSX.Element {
   const { t } = useTranslation();
   const eventName = getReserveeName(reservation, t, 22) || "-";
   return (
@@ -59,12 +65,12 @@ const ReservationPopupContent = ({
             )}
           </Reservee>
           {reservation.workingMemo && (
-            <WorkingMemo>{reservation.workingMemo}</WorkingMemo>
+            <WorkingMemo>
+              {truncate(reservation.workingMemo, MAX_POPOVER_COMMENT_LENGTH)}
+            </WorkingMemo>
           )}
         </VisibleIfPermission>
       </DenseVerticalFlex>
     </PopupContent>
   );
-};
-
-export default ReservationPopupContent;
+}

--- a/apps/admin-ui/src/component/my-units/UnitCalendar.tsx
+++ b/apps/admin-ui/src/component/my-units/UnitCalendar.tsx
@@ -23,14 +23,14 @@ import {
 } from "common/types/gql-types";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
+import { POST_PAUSE, PRE_PAUSE } from "@/common/calendarStyling";
+import { sortByName } from "@/common/util";
+import { useModal } from "@/context/ModalContext";
 import { CELL_BORDER, CELL_BORDER_LEFT, CELL_BORDER_LEFT_ALERT } from "./const";
-import ReservationPopupContent from "./ReservationPopupContent";
+import { ReservationPopupContent } from "./ReservationPopupContent";
 import resourceEventStyleGetter from "./eventStyleGetter";
-import { POST_PAUSE, PRE_PAUSE } from "../../common/calendarStyling";
 import { getReserveeName } from "../reservations/requested/util";
-import { sortByName } from "../../common/util";
 import CreateReservationModal from "./create-reservation/CreateReservationModal";
-import { useModal } from "../../context/ModalContext";
 
 export type Resource = {
   title: string;
@@ -396,10 +396,8 @@ const Events = ({
             >
               <EventContent style={{ ...eventStyleGetter(e).style }}>
                 <p>{title}</p>
-                <Popup
-                  position={["right center", "left center"]}
-                  trigger={EventTriggerButton}
-                >
+                {/* NOTE don't set position on Popup it breaks responsiveness */}
+                <Popup trigger={EventTriggerButton}>
                   {e.event && <ReservationPopupContent reservation={e.event} />}
                 </Popup>
               </EventContent>

--- a/apps/admin-ui/src/component/my-units/UnitReservations.tsx
+++ b/apps/admin-ui/src/component/my-units/UnitReservations.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import Loader from "../Loader";
 import Legend from "../reservations/requested/Legend";
 import { legend } from "./eventStyleGetter";
-import UnitCalendar from "./UnitCalendar";
+import { UnitCalendar } from "./UnitCalendar";
 import { useUnitResources } from "./hooks";
 
 type Props = {
@@ -19,11 +19,6 @@ const Legends = styled.div`
   flex-wrap: wrap;
   gap: var(--spacing-xl);
   padding: var(--spacing-m) 0;
-`;
-
-const Container = styled.div`
-  max-width: 100%;
-  overflow: auto hidden;
 `;
 
 const LegendContainer = styled.div`
@@ -53,17 +48,15 @@ const UnitReservations = ({
 
   return (
     <>
-      <Container>
-        {loading ? (
-          <Loader />
-        ) : (
-          <UnitCalendar
-            date={currentDate}
-            resources={resources}
-            refetch={refetch}
-          />
-        )}
-      </Container>
+      {loading ? (
+        <Loader />
+      ) : (
+        <UnitCalendar
+          date={currentDate}
+          resources={resources}
+          refetch={refetch}
+        />
+      )}
       <LegendContainer>
         <Legends>
           {legend.map((l) => (

--- a/apps/admin-ui/src/component/my-units/UnitReservationsView.tsx
+++ b/apps/admin-ui/src/component/my-units/UnitReservationsView.tsx
@@ -92,6 +92,7 @@ const UnitReservationsView = (): JSX.Element => {
         <DayNavigation date={begin} onDateChange={onDateChange} />
         <div />
       </HorisontalFlexWrapper>
+      {/* TODO missing unitId is an error, not return null */}
       {unitId ? (
         <UnitReservations
           reservationUnitTypes={state.reservationUnitType.map((option) =>

--- a/apps/admin-ui/src/variables.css
+++ b/apps/admin-ui/src/variables.css
@@ -31,8 +31,9 @@
   --tilavaraus-admin-stack-sticky-reservation-header: 101;
   --tilavaraus-admin-stack-sticky-filters: 5;
   --tilavaraus-admin-stack-calendar-buffer: 2;
-  --tilavaraus-admin-stack-select-over-calendar: 11;
-  --tilavaraus-admin-stack-calendar-title-cells: 10;
+  --tilavaraus-admin-stack-select-over-calendar: 12;
+  --tilavaraus-admin-stack-calendar-header-times: 11;
+  --tilavaraus-admin-stack-calendar-header-names: 10;
   --tilavaraus-stack-order-calendar-gutter: 9;
   --tilavaraus-calendar-selected: var(--color-bus);
   --tilavaraus-calendar-selected-secondary: #ffe977;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Add: Sticky times header to the my-units reservation calendar.
- Fix: Popover issues in the same calendar.
- Fix: No vertical scroll when landing on the page, only scroll the Calendar horizontally to the correct time.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

-

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3165, TILA-3170
