### PR TITLE
fix: link colours inverted

### DIFF
--- a/apps/ui/components/common/StartApplicationBar.tsx
+++ b/apps/ui/components/common/StartApplicationBar.tsx
@@ -8,6 +8,7 @@ import ClientOnly from "common/src/ClientOnly";
 import { JustForDesktop, JustForMobile } from "@/modules/style/layout";
 import { truncatedText } from "@/styles/util";
 import Link from "next/link";
+import { focusStyles } from "common/styles/cssFragments";
 
 type Props = {
   count: number;
@@ -78,11 +79,20 @@ const DeleteButton = styled(Button).attrs({
 `;
 
 const StyledLink = styled(Link)`
-  background-color: var(--color-white);
-  color: var(--color-bus);
+  background-color: transparent;
+  color: var(--color-white);
   ${truncatedText}
   display: flex;
   gap: var(--spacing-2-xs);
+  ${focusStyles}
+  padding: var(--spacing-2-xs) var(--spacing-s);
+  && {
+    --color-focus: var(--color-white);
+    --focus-outline-color: var(--color-white);
+  }
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 const StartApplicationBar = ({


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: start application link had inverted colours.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Begin a new application and pick some reservation units, the link should now have white text and transparent background like it used.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
