### PR TITLE
fix: remove todays reservastions from past list

### DIFF
--- a/apps/ui/pages/reservations/index.tsx
+++ b/apps/ui/pages/reservations/index.tsx
@@ -23,6 +23,7 @@ import Head from "@/components/reservations/Head";
 import { CenterSpinner } from "@/components/common/common";
 import { getCommonServerSideProps } from "@/modules/serverUtils";
 import { toApiDate } from "common/src/common/util";
+import { addDays } from "date-fns";
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale } = ctx;
@@ -106,8 +107,9 @@ const Reservations = (): JSX.Element | null => {
             ],
       orderBy: tab === "upcoming" ? "begin" : "-begin",
       user: currentUser?.pk?.toString(),
+      // NOTE today's reservations are always shown in upcoming (even when they are in the past)
       beginDate: tab === "upcoming" ? toApiDate(today) : undefined,
-      endDate: tab === "past" ? toApiDate(today) : undefined,
+      endDate: tab === "past" ? toApiDate(addDays(today, -1)) : undefined,
     },
   });
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- My reservations list shows yesterdays and older reservations (not todays).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Customer side my reservations list different combinations should never show today in past listing, and should always show today in upcoming even when the time of the reservation is already past.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
