### PR TITLE
add: loading states to reservation funnel pages

### DIFF
--- a/apps/ui/components/reservation/Step0.tsx
+++ b/apps/ui/components/reservation/Step0.tsx
@@ -195,6 +195,7 @@ const Step0 = ({
           type="submit"
           iconRight={<IconArrowRight aria-hidden />}
           data-test="reservation__button--update"
+          isLoading={isSubmitted}
         >
           {t("reservationCalendar:nextStep")}
         </MediumButton>

--- a/apps/ui/components/reservation/Step1.tsx
+++ b/apps/ui/components/reservation/Step1.tsx
@@ -350,6 +350,7 @@ const Step1 = ({
           type="submit"
           iconRight={<IconArrowRight aria-hidden />}
           data-test="reservation__button--update"
+          isLoading={isSubmitted}
         >
           {t(
             `reservationCalendar:${

--- a/apps/ui/components/reservation/styles.ts
+++ b/apps/ui/components/reservation/styles.ts
@@ -22,6 +22,8 @@ export const ActionContainer = styled.div`
   @media (min-width: ${breakpoints.s}) {
     & > button:first-of-type {
       order: 1;
+      {/* set min-width so the buttons retains their placements even when isLoading is triggered */}
+      min-width: 130px;
     }
 
     display: flex;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds the `isLoading` state to the buttons in the reservation funnel pages. They were accidentally deleted when removing the "Peru"-buttons `isLoading` states on the same pages.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Same as to the original [PR](#1000), but this time the buttons mentioned above actually have `isLoading` indicators.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3160
