### PR TITLE
fix: remove the 15min interval options from search duration filter

### DIFF
--- a/apps/ui/components/single-search/SearchForm.tsx
+++ b/apps/ui/components/single-search/SearchForm.tsx
@@ -275,13 +275,13 @@ const SearchForm = ({
   );
   const durationMinuteOptions = () => {
     const durations: OptionType[] = [];
-    let minute = 15; // no zero duration option, as all available reservations have a positive/non-zero duration
+    let minute = 30; // no zero duration option, as all available reservations have a positive/non-zero duration
     while (minute <= 90) {
       durations.push({
         label: t("common:minute_other", { count: minute }),
         value: minute,
       });
-      minute += 15;
+      minute += 30;
     }
     return durations;
   };


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Makes the search page duration option interval 30 minutes instead of the 15 it was previously.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to the search page and check out the options for duration. Try to make a search with some duration option selected to make sure the search didn't break.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-????
