### PR TITLE
Fix seconds causing reservation failure

### DIFF
--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -422,10 +422,12 @@ const ReservationCalendarControls = <T extends Record<string, unknown>>({
       const [durationHours, durationMinutes] = String(duration.value).split(
         ":"
       );
-      startDate.setHours(Number(hours), Number(minutes));
+      startDate.setHours(Number(hours), Number(minutes), 0, 0);
       endDate.setHours(
         Number(hours) + Number(durationHours),
-        Number(minutes) + Number(durationMinutes)
+        Number(minutes) + Number(durationMinutes),
+        0,
+        0
       );
 
       if (isSlotReservable(startDate, endDate)) {

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -747,7 +747,7 @@ const ReservationUnit = ({
   });
 
   const createReservation = useCallback(
-    (res: ReservationProps): void => {
+    async (res: ReservationProps): Promise<void> => {
       setErrorMsg(null);
       setIsReserving(true);
       const { begin, end } = res;
@@ -765,11 +765,12 @@ const ReservationUnit = ({
         end,
       });
 
-      addReservation({
+      await addReservation({
         variables: {
           input,
         },
       });
+      setIsReserving(false);
     },
     [addReservation, reservationUnit?.pk, setInitialReservation]
   );


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: seconds sent through new reservation mutation causing it to always fail when using CalendarControls.
- Fix: permanent loading spinner when failing to create a reservation.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Try making a new reservation using the CalendarControls (below the reservation calendar), normally it shouldn't fail, but if it does the button should return back to non loading state.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
