### PR TITLE
Fix missing application round info

### DIFF
--- a/apps/ui/components/reservation/ReservationEdit.tsx
+++ b/apps/ui/components/reservation/ReservationEdit.tsx
@@ -45,7 +45,6 @@ import {
   OPENING_HOURS,
   RESERVATION_UNIT,
 } from "@/modules/queries/reservationUnit";
-import { createMockOpeningTimes } from "@/modules/reservationUnit";
 import EditStep0 from "./EditStep0";
 import EditStep1 from "./EditStep1";
 import { reservationsPrefix } from "@/modules/const";
@@ -241,21 +240,13 @@ const ReservationEdit = ({ id, apiBaseUrl }: Props): JSX.Element => {
       return;
     }
 
-    const { allowReservationsWithoutOpeningHours } =
-      reservationUnitData?.reservationUnitByPk ?? {};
-
     const timespans = filterNonNullable(
       reservationUnitData?.reservationUnitByPk?.reservableTimeSpans
     );
     const moreTimespans = filterNonNullable(
       additionalData?.reservationUnitByPk?.reservableTimeSpans
     ).filter((n) => n?.startDatetime != null && n?.endDatetime != null);
-    const reservableTimeSpans = [
-      ...timespans,
-      ...(allowReservationsWithoutOpeningHours
-        ? createMockOpeningTimes(id)
-        : moreTimespans),
-    ];
+    const reservableTimeSpans = [...timespans, ...moreTimespans];
     setReservationUnit({
       ...reservationUnitData?.reservationUnitByPk,
       reservableTimeSpans,

--- a/apps/ui/modules/queries/applicationRound.ts
+++ b/apps/ui/modules/queries/applicationRound.ts
@@ -37,6 +37,9 @@ export const APPLICATION_ROUNDS_PERIODS = gql`
           reservationPeriodEnd
           applicationPeriodBegin
           status
+          reservationUnits {
+            pk
+          }
         }
       }
     }

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -4,9 +4,9 @@ import {
   getReservationVolume,
 } from "common";
 import { flatten, trim, uniq } from "lodash";
-import { addDays, format, isAfter, isBefore, isSameDay, set } from "date-fns";
+import { format, isAfter, isBefore, isSameDay, set } from "date-fns";
 import { i18n } from "next-i18next";
-import { toApiDate, toUIDate } from "common/src/common/util";
+import { toUIDate } from "common/src/common/util";
 import {
   type RoundPeriod,
   getDayIntervals,
@@ -299,73 +299,6 @@ export const getReservationUnitPrice = (
   return pricing
     ? getPrice({ pricing, minutes, trailingZeros, asInt })
     : undefined;
-};
-
-// Create multiple mock opening times for reservation unit
-// if pk is even, return one 4 year span (tests the case of 24 / 7 open)
-// if pk is odd, return 100 days from 12:00 to 20:00
-// assuming that the backend will add TZ info to the dates
-// NOTE this is not a good solution but Hauki doesn't work locally so have to leave it
-// proper solution would be to mock it on the backend or a mock service so this code is never in production
-export const createMockOpeningTimes = (pk: number) => {
-  // Two short intervals per day
-  if (pk % 7 === 0) {
-    return Array.from(Array(100))
-      .map((_, index) => {
-        const start = toApiDate(addDays(new Date(), index));
-        return [
-          {
-            startDatetime: `${start}T09:00:00+02:00`,
-            endDatetime: `${start}T11:00:00+02:00`,
-          },
-          {
-            startDatetime: `${start}T12:00:00+02:00`,
-            endDatetime: `${start}T20:00:00+02:00`,
-          },
-        ];
-      })
-      .flat();
-  }
-  // A weird case where the end time < start time (different days)
-  if (pk % 5 === 0) {
-    const start = toApiDate(addDays(new Date(), -4));
-    const end = toApiDate(addDays(new Date(), 4));
-    return [
-      {
-        startDatetime: `${start}T23:00:00+02:00`,
-        endDatetime: `${end}T01:00:00+02:00`,
-      },
-    ];
-  }
-
-  // all day x 100 days (technical limitation for the 23:59)
-  if (pk % 3 === 0) {
-    return Array.from(Array(100)).map((_, index) => {
-      const start = toApiDate(addDays(new Date(), index));
-      return {
-        startDatetime: `${start}T00:00:00+02:00`,
-        endDatetime: `${start}T23:59:00+02:00`,
-      };
-    });
-  }
-
-  // 24 / 7 for 4 years, single interval
-  if (pk % 2 === 0) {
-    return [
-      {
-        startDatetime: "2023-01-01T04:00:00+02:00",
-        endDatetime: "2027-12-31T20:00:00+02:00",
-      },
-    ];
-  }
-  // reasonable default case for 100 days
-  return Array.from(Array(100)).map((_, index) => {
-    const start = toApiDate(addDays(new Date(), index));
-    return {
-      startDatetime: `${start}T12:00:00+02:00`,
-      endDatetime: `${start}T20:00:00+02:00`,
-    };
-  });
 };
 
 export const isReservationUnitPaidInFuture = (

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -82,7 +82,6 @@ import {
   LIST_RESERVATIONS,
 } from "@/modules/queries/reservation";
 import {
-  createMockOpeningTimes,
   getFuturePricing,
   getPrice,
   isReservationUnitPaidInFuture,
@@ -255,21 +254,17 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
       };
     }
 
-    const allowReservationsWithoutOpeningHours =
-      reservationUnitData?.reservationUnitByPk
-        ?.allowReservationsWithoutOpeningHours;
-
     const timespans = filterNonNullable(
       additionalData.reservationUnitByPk?.reservableTimeSpans
     );
-    const reservableTimeSpans = !allowReservationsWithoutOpeningHours
-      ? [
-          ...timespans,
-          ...(reservationUnitData.reservationUnitByPk?.reservableTimeSpans ??
-            []),
-        ]
-      : createMockOpeningTimes(id);
+    const moreTimespans = filterNonNullable(
+      reservationUnitData.reservationUnitByPk?.reservableTimeSpans
+    );
+    const reservableTimeSpans = [...timespans, ...moreTimespans];
 
+    const reservations = filterNonNullable(
+      additionalData?.reservationUnitByPk?.reservations
+    );
     return {
       props: {
         key: `${id}-${locale}`,
@@ -278,10 +273,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
         reservationUnit: {
           ...reservationUnitData?.reservationUnitByPk,
           reservableTimeSpans,
-          reservations:
-            additionalData?.reservationUnitByPk?.reservations?.filter(
-              (n) => n
-            ) || [],
+          reservations,
         },
         relatedReservationUnits,
         activeApplicationRounds,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: not showing seasonal times on reservation-unit page.
- Refactor: remove mock times (moved to backend and data generation).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that seasonal reservable times are rendered if the reservation-unit is on an open round, not if it's not.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3214](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3214)

[TILA-3214]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ