### PR TITLE
fix: remove application round from remavable tags

### DIFF
--- a/apps/ui/components/search/SearchForm.tsx
+++ b/apps/ui/components/search/SearchForm.tsx
@@ -284,7 +284,7 @@ const SearchForm = ({
     [reservationUnitTypeOptions, unitOptions, purposeOptions]
   );
 
-  const formValueKeys = Object.keys(formValues);
+  const formValueKeys = Object.keys(formValues).filter((key) => key !== "applicationRound");
 
   return (
     <>


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Application round on recurring search page should never be empty, nor should it ever be deselected.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- There should be no way to deselect the application round on the search page anymore (no tag or clear option).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
