### PR TITLE
fix: remove interval options in edit reservation

### DIFF
--- a/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
+++ b/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
@@ -172,9 +172,15 @@ const DialogContent = ({ reservation, onAccept, onClose }: Props) => {
   const startDateTime = new Date(reservation.begin);
   const endDateTime = new Date(reservation.end);
 
+  const reservationUnit = reservation.reservationUnits?.find(() => true);
+
+  // TODO this matches the CreateReservationModal logic (should use a common function that is documented)
+  // not doing it right now because of open question and because of breaking enum name change.
   const interval =
-    reservation.reservationUnits?.find(() => true)?.reservationStartInterval ??
-    ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins;
+    reservationUnit?.reservationStartInterval ===
+    ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins
+      ? ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_15Mins
+      : ReservationUnitsReservationUnitReservationStartIntervalChoices.Interval_30Mins;
 
   const form = useForm<FormValueType>({
     resolver: zodResolver(TimeChangeFormSchemaRefined(interval)),
@@ -217,8 +223,6 @@ const DialogContent = ({ reservation, onAccept, onClose }: Props) => {
       },
     });
   };
-
-  const reservationUnit = reservation.reservationUnits?.find(() => true);
 
   const formDate = watch("date");
   const formEndTime = watch("endTime");


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: edit time validation missing that admin reservation intervals max out at 30 minutes.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- There should be no validation errors when moving a reservation on admin side (except for 15 and 30 minute intervals which should be translated). All longer intervals default to 30 min validation, same as creating a new reservation.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
