### PR TITLE
fix: set 255 maxLength for the metafields text inputs

### DIFF
--- a/packages/common/src/reservation-form/ReservationFormField.tsx
+++ b/packages/common/src/reservation-form/ReservationFormField.tsx
@@ -403,6 +403,9 @@ const ReservationFormField = ({
           errorText={errorText}
           invalid={!!error}
           required={required}
+          maxLength={
+            255 /* TODO: Might want to remove this once proper validation works */
+          }
           $isWide={isWideRow}
           $hidden={
             watch("reserveeIsUnregisteredAssociation") === undefined
@@ -429,6 +432,9 @@ const ReservationFormField = ({
           defaultValue={defaultValue ? String(defaultValue) : undefined}
           invalid={!!error}
           required={required}
+          maxLength={
+            255 /* TODO: Might want to remove this once proper validation works */
+          }
           $isWide={isWideRow}
           $hidden={
             field.includes("billing") && watch("showBillingAddress") !== true


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds maxLength to reservation input fields, as a quick fix

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- The fields in the ticket shouldn't allow longer values than 255 characters.
- The free-of-charge reason field length is not a problem, as it's not limited in the back end

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3209