### PR TITLE
Fix time input crashing on keyboard input

### DIFF
--- a/apps/admin-ui/src/component/my-units/DayNavigation.tsx
+++ b/apps/admin-ui/src/component/my-units/DayNavigation.tsx
@@ -8,8 +8,9 @@ import { breakpoints } from "common";
 import { toMondayFirstUnsafe } from "common/src/helpers";
 
 type Props = {
+  // both in ui string format
   date: string;
-  onDateChange: ({ date }: { date: Date }) => void;
+  onDateChange: (date: string) => void;
 };
 
 const Wrapper = styled.div`
@@ -48,11 +49,17 @@ const SimpleDatePicker = styled(DateInput)`
 `;
 
 const DayNavigation = ({ date, onDateChange }: Props): JSX.Element => {
-  const d = new Date(date);
+  const d = fromUIDate(date);
   const { t } = useTranslation();
 
-  const onPreviousDay = () => onDateChange({ date: subDays(d, 1) });
-  const onNextDay = () => onDateChange({ date: addDays(d, 1) });
+  const onPreviousDay = () => {
+    if (!d) return;
+    onDateChange(toUIDate(subDays(d, 1)));
+  };
+  const onNextDay = () => {
+    if (!d) return;
+    onDateChange(toUIDate(addDays(d, 1)));
+  };
 
   return (
     <Wrapper>
@@ -65,16 +72,14 @@ const DayNavigation = ({ date, onDateChange }: Props): JSX.Element => {
       >
         {" "}
       </Button>
-      <WeekDay>{`${t(`dayShort.${toMondayFirstUnsafe(d.getDay())}`)} `}</WeekDay>
+      <WeekDay>{`${t(`dayShort.${toMondayFirstUnsafe(d?.getDay() ?? 0)}`)} `}</WeekDay>
       <SimpleDatePicker
         disableConfirmation
         id="date-input"
-        initialMonth={d}
+        initialMonth={d ?? new Date()}
         language="fi"
         required
-        onChange={(value) =>
-          onDateChange({ date: fromUIDate(value) ?? new Date() })
-        }
+        onChange={(value) => onDateChange(value)}
         value={toUIDate(d)}
       />
       <Button

--- a/apps/admin-ui/src/component/my-units/UnitReservations.tsx
+++ b/apps/admin-ui/src/component/my-units/UnitReservations.tsx
@@ -7,8 +7,10 @@ import Legend from "../reservations/requested/Legend";
 import { legend } from "./eventStyleGetter";
 import { UnitCalendar } from "./UnitCalendar";
 import { useUnitResources } from "./hooks";
+import { fromUIDate, isValidDate } from "common/src/common/util";
 
 type Props = {
+  // date in ui string format
   begin: string;
   unitPk: string;
   reservationUnitTypes: number[];
@@ -36,26 +38,31 @@ const UnitReservations = ({
   unitPk,
   reservationUnitTypes,
 }: Props): JSX.Element => {
-  const currentDate = new Date(begin);
+  const currentDate = fromUIDate(begin);
+
+  // TODO if the date is invalid show it to the user and disable the calendar
+  if (currentDate == null || Number.isNaN(currentDate.getTime())) {
+    // eslint-disable-next-line no-console
+    console.warn("UnitReservations: Invalid date", begin);
+  }
 
   const { t } = useTranslation();
 
   const { loading, resources, refetch } = useUnitResources(
-    currentDate,
+    currentDate ?? new Date(),
     unitPk,
     reservationUnitTypes
   );
+
+  const date =
+    currentDate && isValidDate(currentDate) ? currentDate : new Date();
 
   return (
     <>
       {loading ? (
         <Loader />
       ) : (
-        <UnitCalendar
-          date={currentDate}
-          resources={resources}
-          refetch={refetch}
-        />
+        <UnitCalendar date={date} resources={resources} refetch={refetch} />
       )}
       <LegendContainer>
         <Legends>

--- a/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
+++ b/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
@@ -12,7 +12,7 @@ import {
 } from "common/types/gql-types";
 import styled from "styled-components";
 import { camelCase, get } from "lodash";
-import { format, isValid as isDateValid } from "date-fns";
+import { format } from "date-fns";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -21,13 +21,11 @@ import {
   type ReservationFormMeta,
 } from "app/schemas";
 import { breakpoints } from "common/src/common/style";
-import { fromUIDate } from "common/src/common/util";
-import { setTimeOnDate } from "app/component/reservations/utils";
-import { useCheckCollisions } from "app/component/reservations/requested/hooks";
-import { dateTime } from "app/helpers";
+import { useCheckCollisions } from "@/component/reservations/requested/hooks";
+import Loader from "@/component/Loader";
+import { dateTime, parseDateTimeSafe } from "@/helpers";
 import { useModal } from "@/context/ModalContext";
 import { CREATE_STAFF_RESERVATION } from "./queries";
-import Loader from "../../Loader";
 import { useNotification } from "@/context/NotificationContext";
 import { flattenMetadata } from "./utils";
 import { useReservationUnitQuery } from "../hooks";
@@ -106,18 +104,13 @@ const useCheckFormCollisions = ({
       ? reservationUnit.bufferTimeAfter
       : 0;
 
-  const d = fromUIDate(formDate);
+  const start = parseDateTimeSafe(formDate, formStartTime);
+  const end = parseDateTimeSafe(formDate, formEndTime);
   const { hasCollisions } = useCheckCollisions({
     reservationPk: undefined,
     reservationUnitPk: reservationUnit?.pk ?? 0,
-    start:
-      d && isDateValid(d) && formStartTime
-        ? setTimeOnDate(d, formStartTime)
-        : undefined,
-    end:
-      d && isDateValid(d) && formEndTime
-        ? setTimeOnDate(d, formEndTime)
-        : undefined,
+    start,
+    end,
     buffers: {
       before: bufferBeforeSeconds,
       after: bufferAfterSeconds,

--- a/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
+++ b/apps/admin-ui/src/component/reservations/EditTimeModal.tsx
@@ -286,7 +286,7 @@ const DialogContent = ({ reservation, onAccept, onClose }: Props) => {
   return (
     <Dialog.Content>
       <StyledForm onSubmit={handleSubmit(onSubmit)} noValidate>
-        {reservation.recurringReservation ? (
+        {reservation.recurringReservation && (
           <TimeInfoBox>
             {t("Reservation.EditTime.recurringInfoLabel")}:{" "}
             <Bold>
@@ -304,7 +304,7 @@ const DialogContent = ({ reservation, onAccept, onClose }: Props) => {
               })}
             </Bold>
           </TimeInfoBox>
-        ) : null}
+        )}
         <TimeInfoBox>
           {t("Reservation.EditTime.originalTime")}: <Bold>{originalTime}</Bold>
         </TimeInfoBox>


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Invalid date can be created with keyboard input, those were not properly handled and the frontend crashed.
- Fix: CreateReservationModal crashing on invalid dates.
- Fix: EditTimeModal crashing on invalid dates.
- Fix: MyUnits calendar crashing on invalid dates.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- All changes are only for the admin frontend (not customer).
- Test creating a new reservation and with an invalid date using the keyboard.
- Test changing a reservation time and with an invalid date using the keyboard.
- Test changing the current date in my-units and with an invalid date using the keyboard.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
