### PR TITLE
fix: django 5 logout is POST not GET

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -44,7 +44,8 @@
   "peerDependencies": {
     "@apollo/client": "^3.8.10",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "typescript-cookie": "^1.0.6"
   },
   "devDependencies": {
     "@apollo/client": "^3.8.10",
@@ -71,6 +72,7 @@
     "stylelint-config-standard": "^36.0.0",
     "stylelint-config-styled-components": "^0.1.1",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "typescript-cookie": "^1.0.6"
   }
 }

--- a/packages/common/src/urlBuilder.ts
+++ b/packages/common/src/urlBuilder.ts
@@ -45,5 +45,5 @@ export function getSignInUrl(
 /// @return url for logging out with redirect url to /logout
 export function getSignOutUrl(apiBaseUrl: string): string {
   const authUrl = buildAuthUrl(apiBaseUrl);
-  return `${authUrl}logout`;
+  return `${authUrl}logout/`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
+      typescript-cookie:
+        specifier: ^1.0.6
+        version: 1.0.6
 
   packages/eslint-config-custom:
     devDependencies:
@@ -16820,7 +16823,6 @@ packages:
   /typescript-cookie@1.0.6:
     resolution: {integrity: sha512-s+BZr7/9BUG6Kg7jGGcOY/4XJcP+iZRFdF3q4FPTfRSP83ivLWF94OcH8PrzGmnS8Ab9qP7ENu/ikLwNFsIafA==}
     engines: {node: '>=14'}
-    dev: false
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: Django 5 doesn't allow GET request to logout. Replace logout function with dynamic form creation + submit.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Do logout buttons work in both fronts. Also they should remove Tunnistamo session forcing the next login to go through Tunnistamo.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
