### PR TITLE
fix: limit reservation text areas to 255 chars

### DIFF
--- a/packages/common/src/reservation-form/ReservationFormField.tsx
+++ b/packages/common/src/reservation-form/ReservationFormField.tsx
@@ -120,6 +120,11 @@ const ControlledCheckbox = (props: {
   />
 );
 
+/* NOTE: backend returns validation errors if text fields are too long
+ * remove maxlength after adding proper schema validation
+ */
+const MAX_TEXT_LENGTH = 255;
+
 const ReservationFormField = ({
   field,
   options,
@@ -331,6 +336,7 @@ const ReservationFormField = ({
         errorText={errorText}
         invalid={!!error}
         required={required}
+        maxLength={MAX_TEXT_LENGTH}
         $isWide={isWideRow}
         $hidden={
           field.includes("billing") && watch("showBillingAddress") !== true
@@ -383,6 +389,7 @@ const ReservationFormField = ({
           errorText={errorText}
           invalid={!!error}
           required={isFreeOfChargeReasonRequired}
+          maxLength={MAX_TEXT_LENGTH}
           $hidden={!watch("applyingForFreeOfCharge")}
           $isWide
           $height="92px"
@@ -403,9 +410,7 @@ const ReservationFormField = ({
           errorText={errorText}
           invalid={!!error}
           required={required}
-          maxLength={
-            255 /* TODO: Might want to remove this once proper validation works */
-          }
+          maxLength={MAX_TEXT_LENGTH}
           $isWide={isWideRow}
           $hidden={
             watch("reserveeIsUnregisteredAssociation") === undefined
@@ -432,9 +437,7 @@ const ReservationFormField = ({
           defaultValue={defaultValue ? String(defaultValue) : undefined}
           invalid={!!error}
           required={required}
-          maxLength={
-            255 /* TODO: Might want to remove this once proper validation works */
-          }
+          maxLength={MAX_TEXT_LENGTH}
           $isWide={isWideRow}
           $hidden={
             field.includes("billing") && watch("showBillingAddress") !== true


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: don't allow inputing too much text in reservation form because the mutation fails with it.
- Fix: the text areas (regular text input:s were fixed already).
- Quick fix using html maxlength. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Submitting a new reservation with any of the forms should no longer fail with backend errors. The text fields are restricted to 255 characters always (the exception of email field which is regex checked).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3209](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3209)

[TILA-3209]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ