### PR TITLE
fix: page overflowing causing empty space after footer

### DIFF
--- a/apps/ui/styles/global.scss
+++ b/apps/ui/styles/global.scss
@@ -27,10 +27,10 @@ body {
 
 #__next {
   min-height: 100vh;
-  height: 100%;
   position: relative;
   display: flex;
   flex-direction: column;
+  overflow-y: hidden;
 }
 
 // utils


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes page content overflow, causing unnecessary empty space below the footer

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check frontpage, see that the footer is at the bottom of the page

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
