### PR TITLE
Fix application saving incorrect units

### DIFF
--- a/apps/ui/components/application/ReservationUnitList.tsx
+++ b/apps/ui/components/application/ReservationUnitList.tsx
@@ -31,10 +31,13 @@ type Props = {
 
 const MainContainer = styled.div`
   margin-top: var(--spacing-l);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-l);
 `;
 
 const ButtonContainer = styled.div`
-  margin-top: var(--spacing-layout-m);
+  margin-top: var(--spacing-s);
 `;
 
 const Notification = styled(HDSNotification)`
@@ -53,7 +56,8 @@ const ReservationUnitList = ({
   const [showModal, setShowModal] = useState(false);
 
   const form = useFormContext<ApplicationFormValues>();
-  const { clearErrors, setError, watch, setValue } = form;
+  const { clearErrors, setError, watch, setValue, formState } = form;
+  const { errors } = formState;
 
   const isValid = (units: ReservationUnitType[]) => {
     const error = units
@@ -134,8 +138,21 @@ const ReservationUnitList = ({
     setReservationUnits(move(reservationUnits, from, to));
   };
 
+  // Only checking for the required error here, other errors are handled in the ReservationUnitCard
+  const unitErros = errors.applicationSections?.[index]?.reservationUnits;
+  const hasNoUnitsError = unitErros != null && unitErros.message === "Required";
+
   return (
     <MainContainer>
+      {hasNoUnitsError && (
+        <Notification
+          type="error"
+          label={t("application:error.noReservationUnits")}
+          size="small"
+        >
+          {t("application:error.noReservationUnits")}
+        </Notification>
+      )}
       <Notification
         size="small"
         label={t("reservationUnitList:infoReservationUnits")}

--- a/apps/ui/components/reservation-unit/ReservationUnitCard.tsx
+++ b/apps/ui/components/reservation-unit/ReservationUnitCard.tsx
@@ -111,7 +111,10 @@ const MaxPersonsContainer = styled.div`
 const DeleteButton = styled(MediumButton)`
   white-space: nowrap;
   margin: var(--spacing-s) var(--spacing-s) var(--spacing-s) 0;
-  place-self: flex-end;
+  place-self: flex-start;
+  @media (min-width: ${breakpoints.m}) {
+    place-self: flex-end;
+  }
 `;
 
 const ArrowContainer = styled.div`

--- a/apps/ui/components/reservation-unit/ReservationUnitCard.tsx
+++ b/apps/ui/components/reservation-unit/ReservationUnitCard.tsx
@@ -30,12 +30,11 @@ type Props = {
   invalid: boolean;
 };
 
-const NameCardContainer = styled.div`
-  margin-top: var(--spacing-l);
-`;
+const NameCardContainer = styled.div``;
 
 const PreCardLabel = styled(H6).attrs({ as: "h3" })`
   margin-bottom: 0;
+  margin-top: 0;
 `;
 
 const CardButtonContainer = styled.div`

--- a/apps/ui/pages/application/[...params].tsx
+++ b/apps/ui/pages/application/[...params].tsx
@@ -171,7 +171,7 @@ function ApplicationRootPage({
     };
 
   const { reservationUnits: selectedReservationUnits } =
-    useReservationUnitsList();
+    useReservationUnitsList(applicationRound);
 
   const begin = new Date(applicationRound.reservationPeriodBegin);
   const end = new Date(applicationRound.reservationPeriodEnd);


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: selected reservation units not on that application round got incorrectly included when saving the application.
- fix: not any reservation units selected validation error not correctly shown.
- fix: search showing incorrectly selected reservation units after changing application round filter.
- fix: application mobile layout delete and arrow buttons on top of each other.
- refactor: prefer gap over margin-top.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- A new application should never include reservation units not on that application round.
- When selecting different round in the search the count at the bottom of the page should reflect only the reservation units on that round.
- Mobile delete and arrow buttons should be clickable and in the correct place.
- It should not be possible to save an application without any reservation units (or with just invalid reservation units) and it should show an missing field error to the user. 

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
