### PR TITLE
Fix max length text fields overflowing

### DIFF
--- a/apps/admin-ui/src/component/reservations/ReservationsDataLoader.tsx
+++ b/apps/admin-ui/src/component/reservations/ReservationsDataLoader.tsx
@@ -129,7 +129,7 @@ const ReservationsDataLoader = ({
     sort
   );
 
-  if (loading && !data) {
+  if (loading && data.length === 0) {
     return <Loader />;
   }
 

--- a/apps/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
@@ -80,6 +80,24 @@ const ApplicationProp = ({
     </div>
   ) : null;
 
+// Need to set max-width otherwise word-break doesn't work, different max-width because of the side menu.
+const KVPair = styled.div<{ $wide?: boolean }>`
+  font-weight: 400;
+  max-width: calc(50vw - 32px);
+  grid-column: ${({ $wide }) => ($wide ? "1 / span 2" : "auto")};
+  @media (width > ${breakpoints.m}) {
+    max-width: calc(50vw - 100px);
+  }
+`;
+const Label = styled.div`
+  padding-bottom: var(--spacing-xs);
+  color: var(--color-black-70);
+`;
+const Value = styled.div`
+  font-size: var(--fontsize-body-l);
+  word-wrap: break-word;
+`;
+
 const ApplicationData = ({
   label,
   data,
@@ -89,17 +107,10 @@ const ApplicationData = ({
   data?: Maybe<string> | number | JSX.Element;
   wide?: boolean;
 }) => (
-  <div style={{ fontWeight: "400", gridColumn: wide ? "1 / span 2" : "auto" }}>
-    <div
-      style={{
-        paddingBottom: "var(--spacing-xs)",
-        color: "var(--color-black-70)",
-      }}
-    >
-      <span>{label}</span>
-    </div>
-    <span style={{ fontSize: "var(--fontsize-body-l)" }}>{data}</span>
-  </div>
+  <KVPair $wide={wide}>
+    <Label>{label}</Label>
+    <Value>{data}</Value>
+  </KVPair>
 );
 
 const ButtonsWithPermChecks = ({
@@ -520,7 +531,6 @@ const RequestedReservation = ({
               />
             </ApplicationDatas>
           </Accordion>
-
           {isNonFree && (
             <Accordion heading={t("RequestedReservation.pricingDetails")}>
               <ApplicationDatas>

--- a/packages/common/src/reservation-form/ReservationFormField.tsx
+++ b/packages/common/src/reservation-form/ReservationFormField.tsx
@@ -344,7 +344,7 @@ const ReservationFormField = ({
         errorText={errorText}
         invalid={!!error}
         required={required}
-        maxLength={MAX_TEXT_LENGTH}
+        maxLength={MAX_TEXT_LENGTH - (isEmailField ? 1 : 0)}
         $isWide={isWideRow}
         $hidden={
           field.includes("billing") && watch("showBillingAddress") !== true
@@ -445,7 +445,8 @@ const ReservationFormField = ({
           defaultValue={defaultValue ? String(defaultValue) : undefined}
           invalid={!!error}
           required={required}
-          maxLength={MAX_TEXT_LENGTH}
+          // email field is special and has one less character than the rest
+          maxLength={MAX_TEXT_LENGTH - (isEmailField ? 1 : 0)}
           $isWide={isWideRow}
           $hidden={
             field.includes("billing") && watch("showBillingAddress") !== true


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: (admin) reservation list first load not showing loader.
- fix: (admin) reservation info text boxes overflowing.
- fix: (ui): email input in reservation form causing a backend error.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Follow up for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1055
- Follow up for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1044

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3209](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3209)


[TILA-3209]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ