### PR TITLE
fix: Image carousel look and accessibility

### DIFF
--- a/apps/ui/components/Carousel.tsx
+++ b/apps/ui/components/Carousel.tsx
@@ -4,7 +4,7 @@ import { IconAngleLeft, IconAngleRight } from "hds-react";
 import styled from "styled-components";
 import { breakpoints } from "common/src/common/style";
 import { useTranslation } from "next-i18next";
-import { MediumButton } from "../styles/util";
+import { MediumButton } from "@/styles/util";
 
 type Props = {
   children: React.ReactNode[];
@@ -13,6 +13,7 @@ type Props = {
   cellSpacing?: number;
   wrapAround?: boolean;
   hideCenterControls?: boolean;
+  controlAriaLabel?: string;
 };
 
 const Button = styled(MediumButton).attrs({
@@ -84,6 +85,40 @@ const StyledCarousel = styled(NukaCarousel)<{
   }
 `;
 
+const CustomBottomControls = styled.div`
+  position: absolute;
+  bottom: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+
+  ul {
+    position: relative;
+    top: -10px;
+    display: flex;
+    margin: 0;
+    padding: 0 var(--spacing-3-xs);
+    list-style-type: none;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: var(--spacing-xs);
+
+    li {
+      button {
+        cursor: pointer;
+        background: transparent;
+        border: none;
+        fill: white;
+        opacity: 0.7;
+        &:hover {
+          opacity: 1;
+        }
+      }
+      &.active button {
+        fill: var(--color-bus);
+      }
+    }
+  }
+`;
+
 const Carousel = ({
   children,
   slidesToShow = 1,
@@ -91,6 +126,7 @@ const Carousel = ({
   cellSpacing = 1,
   wrapAround = true,
   hideCenterControls = false,
+  controlAriaLabel = "",
   ...rest
 }: Props): JSX.Element => {
   const { t } = useTranslation();
@@ -120,6 +156,28 @@ const Carousel = ({
         >
           <IconAngleRight />
         </ButtonComponent>
+      )}
+      renderBottomCenterControls={({ slideCount, currentSlide, goToSlide }) => (
+        <CustomBottomControls>
+          <ul>
+            {[...Array(slideCount)].map((key, idx) => (
+              <li
+                key={key}
+                className={currentSlide === idx ? "active" : undefined}
+              >
+                <button
+                  type="button"
+                  aria-label={`${controlAriaLabel} #${idx + 1}`}
+                  onClick={() => goToSlide(idx)}
+                >
+                  <svg width="12" height="12">
+                    <circle cx="5" cy="5" r="5" />
+                  </svg>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </CustomBottomControls>
       )}
       wrapAround={wrapAround}
       slidesToShow={slidesToShow}

--- a/apps/ui/components/common/Modal.tsx
+++ b/apps/ui/components/common/Modal.tsx
@@ -3,8 +3,9 @@ import React from "react";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { breakpoints } from "common/src/common/style";
-import { isBrowser } from "../../modules/const";
-import { MediumButton } from "../../styles/util";
+import { isBrowser } from "common/src/helpers";
+import { MediumButton } from "@/styles/util";
+import { IconCross } from "hds-react";
 
 type Props = {
   handleOk?: () => void;
@@ -13,6 +14,7 @@ type Props = {
   children: React.ReactNode;
   closeButtonKey?: string;
   okButtonKey?: string;
+  showControlButtons?: boolean;
 };
 
 const Overlay = styled.div`
@@ -23,7 +25,7 @@ const Overlay = styled.div`
 `;
 
 const ModalElement = styled.div`
-  padding: var(--spacing-layout-xs);
+  padding: var(--spacing-layout-2-xs);
   background: var(--color-white);
   max-width: 100%;
   position: fixed;
@@ -35,6 +37,22 @@ const ModalElement = styled.div`
   flex-direction: column;
   max-height: 90%;
   overflow-y: auto;
+
+  {/* The top close button */}
+  > button {
+    position: absolute;
+    top: var(--spacing-layout-xs);
+    right: var(--spacing-layout-xs);
+    border: 0;
+    span {
+      display: flex;
+      align-items: center;
+    }
+    @media (max-width: ${breakpoints.s}) {
+      top: 0;
+      right: 0;
+    }
+  }
 
   @media (max-width: ${breakpoints.s}) {
     height: 100%;
@@ -51,7 +69,6 @@ const ButtonContainer = styled.div`
   display: grid;
   gap: var(--spacing-layout-s);
   grid-template-columns: 1fr 1fr;
-  padding-top: var(--spacing-layout-s);
 
   > button {
     width: fit-content;
@@ -76,6 +93,7 @@ const Modal = ({
   children,
   closeButtonKey = "common:close",
   okButtonKey = "common:ok",
+  showControlButtons = true,
 }: Props): JSX.Element | null => {
   const { t } = useTranslation();
 
@@ -97,24 +115,35 @@ const Modal = ({
   }
 
   return (
-    <>
-      <Overlay role="none" onClick={handleClose} onKeyDown={handleClose} />
+    <Overlay role="none" onKeyDown={(e) => e.key === "Escape" && handleClose()}>
       <FocusTrap>
         <ModalElement>
-          <MainContainer>{children}</MainContainer>
-          <ButtonContainer>
-            {handleOk ? (
-              <MediumButton variant="primary" onClick={handleOk}>
-                {t(okButtonKey)}
-              </MediumButton>
-            ) : null}
-            <MediumButton variant="secondary" onClick={handleClose}>
-              {t(closeButtonKey)}
+          {!showControlButtons && (
+            <MediumButton
+              variant="secondary"
+              size="small"
+              onClick={handleClose}
+            >
+              {t("common:close")}
+              <IconCross />
             </MediumButton>
-          </ButtonContainer>
+          )}
+          <MainContainer>{children}</MainContainer>
+          {showControlButtons && (
+            <ButtonContainer>
+              {handleOk ? (
+                <MediumButton variant="primary" onClick={handleOk}>
+                  {t(okButtonKey)}
+                </MediumButton>
+              ) : null}
+              <MediumButton variant="secondary" onClick={handleClose}>
+                {t(closeButtonKey)}
+              </MediumButton>
+            </ButtonContainer>
+          )}
         </ModalElement>
       </FocusTrap>
-    </>
+    </Overlay>
   );
 };
 

--- a/apps/ui/components/reservation-unit/Images.tsx
+++ b/apps/ui/components/reservation-unit/Images.tsx
@@ -62,6 +62,7 @@ const ModalContent = styled.div`
 
   @media (max-width: ${breakpoints.s}) {
     margin: 0.5em;
+    margin-top: var(--spacing-layout-m);
   }
 `;
 
@@ -73,10 +74,10 @@ const ThumbnailButton = styled.button`
 `;
 
 const ModalImages = styled.div`
-  margin-top: var(--spacing-layout-s);
   display: flex;
   max-width: 100%;
   overflow-x: auto;
+  margin-top: var(--spacing-2-xs);
 
   button {
     margin-right: 1em;
@@ -102,7 +103,11 @@ export function Images({ images, contextName }: Props): JSX.Element {
 
   return (
     <>
-      <StyledCarousel>
+      <StyledCarousel
+        controlAriaLabel={t("common:imgAltForSpace", {
+          name: contextName,
+        })}
+      >
         {images?.map((image, index) => (
           <CarouselImage
             key={image.imageUrl}
@@ -126,6 +131,7 @@ export function Images({ images, contextName }: Props): JSX.Element {
         }}
         show={showModal}
         closeButtonKey="common:close"
+        showControlButtons={false}
       >
         <ModalContent>
           {currentImage ? (


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- adds custom bottom center controls for the image carousel on reservation-unit page
- aria-labels can be localised for the carousel center controls via the controlAriaLabel attribute
- the carousel modal closes only with esc-key, not any keyDown event
- new close-button and a bit of restyling for the image carousel modal

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- go to a reservation-unit page which has several images in it, and thus a carousel-element on the right
- inspect the bottom controls (circular small buttons - which are now bigger than before and themed to us)
- the aria-labels on the buttons should be dynamic and localized, so change language and check that the aria-label changes accordingly

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3089
