### PR TITLE
Search filter label a18y

### DIFF
--- a/apps/ui/components/common/SingleLabelInputGroup.tsx
+++ b/apps/ui/components/common/SingleLabelInputGroup.tsx
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+import { fontMedium } from "common";
+import { ReactNode } from "react";
+
+type SingleLabelRangeInputProps = {
+  label: string;
+  children: ReactNode;
+};
+
+const InputContainer = styled.div`
+  display: grid;
+  grid-template-columns: 50% 50%;
+  grid-template-rows: auto auto;
+  {/* hide the HDS-labels visually, but retain them in the DOM */}
+  label {
+    height: 0;
+    overflow: hidden;
+  }
+  > :not(:last-child) > div {
+    border-right: none;
+  }
+`;
+
+const Label = styled.div`
+  ${fontMedium}
+`;
+
+// A wrapper to supply a singular label to two related input fields:
+// Visually hides the original input labels from HDS-components while retaining their aria-attributes for a18y,
+// thus removing the need to try using hacks like empty label strings for the desired effect
+const SingleLabelInputGroup = ({
+  label,
+  children,
+}: SingleLabelRangeInputProps) => {
+  return (
+    <div>
+      <Label aria-hidden>{label}</Label>
+      <InputContainer>{children}</InputContainer>
+    </div>
+  );
+};
+
+export default SingleLabelInputGroup;

--- a/apps/ui/components/form/DateRangePicker.tsx
+++ b/apps/ui/components/form/DateRangePicker.tsx
@@ -2,7 +2,6 @@ import { type FC, useState, useEffect } from "react";
 import { isBefore } from "date-fns";
 import { DateInput } from "hds-react";
 import { useTranslation } from "next-i18next";
-import styled from "styled-components";
 import { fromUIDate, toUIDate, isValidDate } from "common/src/common/util";
 import { getLocalizationLang } from "common/src/helpers";
 
@@ -30,12 +29,6 @@ export interface DateRangePickerProps {
     end?: string;
   };
 }
-
-const Wrapper = styled.div`
-  & > div:not(:first-child) {
-    margin-top: var(--spacing-s);
-  }
-`;
 
 const DateRangePicker: FC<DateRangePickerProps> = ({
   endDate,
@@ -181,7 +174,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
   const internalStartDate = fromUIDate(internalStartDateString);
 
   return (
-    <Wrapper className="date-range-input__wrapper">
+    <>
       <DateInput
         autoComplete="off"
         id="start-date"
@@ -222,7 +215,7 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
         required={required?.end}
         placeholder={placeholder?.end ?? t("dateSelector:placeholderEnd")}
       />
-    </Wrapper>
+    </>
   );
 };
 

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -483,7 +483,7 @@ const ReservationUnitReservationWithReservationProp = ({
   // NOTE: only navigate away from the page if the reservation is cancelled the confirmation hook handles delete
   const cancelReservation = useCallback(async () => {
     router.push(`${reservationUnitPrefix}/${reservationUnit?.pk}`);
-  }, [reservationUnitPrefix, reservationPk]);
+  }, [router, reservationUnit?.pk]);
 
   const shouldDisplayReservationUnitPrice = useMemo(() => {
     switch (step) {

--- a/packages/common/src/components/form/TimeRangePicker.tsx
+++ b/packages/common/src/components/form/TimeRangePicker.tsx
@@ -13,12 +13,13 @@ import { removeRefParam } from "../../reservation-form/util";
 
 interface TimeRangePickerProps<T extends FieldValues>
   extends Omit<UseControllerProps<T>, "name" | "disabled"> {
-  name: { begin: Path<T>; end: Path<T> };
+  names: { begin: Path<T>; end: Path<T> };
   error?: string;
   required?: { begin?: boolean; end?: boolean };
   disabled?: { begin?: boolean; end?: boolean };
-  label?: { begin?: string; end?: string };
-  placeholder?: { begin?: string; end?: string };
+  labels?: { begin?: string; end?: string };
+  commonLabel?: string;
+  placeholders?: { begin?: string; end?: string };
   clearable?: { begin?: boolean; end?: boolean };
 }
 
@@ -65,20 +66,20 @@ const StartBeforeEndError = styled.div`
  */
 const TimeRangePicker = <T extends FieldValues>({
   control,
-  name,
+  names,
   required,
-  label,
-  placeholder,
+  labels,
+  placeholders,
   clearable,
 }: TimeRangePickerProps<T>): JSX.Element => {
   const { field: beginField, fieldState: beginFieldState } = useController({
     control,
-    name: name?.begin,
+    name: names?.begin,
     rules: { required: required?.begin },
   });
   const { field: endField, fieldState: endFieldState } = useController({
     control,
-    name: name?.end,
+    name: names?.end,
     rules: { required: required?.end },
   });
   const { t } = useTranslation();
@@ -136,9 +137,9 @@ const TimeRangePicker = <T extends FieldValues>({
     <>
       <StyledSelect
         {...removeRefParam(beginField)}
-        label={label?.begin ?? t("common:beginLabel")}
+        label={labels?.begin ?? t("common:beginLabel")}
         options={populatedTimeOptions}
-        placeholder={placeholder?.begin}
+        placeholder={placeholders?.begin}
         required={required?.begin}
         error={beginFieldState.error && beginFieldState.error.message}
         clearable={clearable?.begin}
@@ -150,9 +151,9 @@ const TimeRangePicker = <T extends FieldValues>({
       />
       <StyledSelect
         {...removeRefParam(endField)}
-        label={label?.end ?? t("common:endLabel")}
+        label={labels?.end ?? t("common:endLabel")}
         options={populatedTimeOptions}
-        placeholder={placeholder?.end}
+        placeholder={placeholders?.end}
         required={required?.end}
         error={endFieldState.error && endFieldState.error.message}
         clearable={clearable?.end}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes the accessibility problems in input groups under one label.
- Adds `SingleLabelInputGroup` component, which:
  - wraps its `children` in a styled container, which shows them next to each other correctly
  - displays a common group label text above them (as defined by `label`)
  - visually hides the "proper" label texts from the HDS-component in question, so they can use whatever as their label text and it's decoupled from the group label

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to single search page and inspect the inputs which are grouped together (date, time, duration, amount of people)
- They should all have proper a18y (the `for` in the label, `aria-label`in the respective input)

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3090
