### PR TITLE
DONT MERGE: fix: get csrf token before making graphql requests

### DIFF
--- a/apps/ui/hooks/useApplicationQuery.tsx
+++ b/apps/ui/hooks/useApplicationQuery.tsx
@@ -9,6 +9,7 @@ export const useApplicationQuery = (pk?: number) => {
   const { data, error, loading } = useQuery<Query, QueryApplicationArgs>(
     APPLICATION_QUERY,
     {
+      fetchPolicy: "no-cache",
       variables: {
         id,
       },

--- a/apps/ui/pages/application/[id]/preview.tsx
+++ b/apps/ui/pages/application/[id]/preview.tsx
@@ -133,7 +133,7 @@ function Preview(props: PropsNarrowed): JSX.Element {
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { locale } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const tos = await getGenericTerms(apolloClient);
 

--- a/apps/ui/pages/application/[id]/view.tsx
+++ b/apps/ui/pages/application/[id]/view.tsx
@@ -64,7 +64,7 @@ type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const tos = await getGenericTerms(apolloClient);
 

--- a/apps/ui/pages/criteria/[id].tsx
+++ b/apps/ui/pages/criteria/[id].tsx
@@ -20,7 +20,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale, params } = ctx;
   const id = Number(params?.id);
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const { data } = await apolloClient.query<Query, QueryApplicationRoundsArgs>({
     fetchPolicy: "no-cache",

--- a/apps/ui/pages/index.tsx
+++ b/apps/ui/pages/index.tsx
@@ -40,7 +40,7 @@ const Home = ({ purposes, units }: Props): JSX.Element => {
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const { data: purposeData } = await apolloClient.query<
     Query,

--- a/apps/ui/pages/intro.tsx
+++ b/apps/ui/pages/intro.tsx
@@ -31,7 +31,7 @@ type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const { data } = await apolloClient.query<Query, QueryApplicationRoundsArgs>({
     query: APPLICATION_ROUNDS,

--- a/apps/ui/pages/recurring/index.tsx
+++ b/apps/ui/pages/recurring/index.tsx
@@ -26,7 +26,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const now = new Date();
   const { locale } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const { data } = await apolloClient.query<Query, QueryApplicationRoundsArgs>({
     query: APPLICATION_ROUNDS,

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -70,7 +70,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale, params } = ctx;
   const [reservationUnitPk, path, reservationPk] = params?.params ?? [];
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   if (Number.isFinite(Number(reservationUnitPk)) && path === "reservation") {
     const typename = "ReservationUnitNode";

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -151,7 +151,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const pk = Number(params?.id);
   const uuid = query.ru;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   // TODO does this return only possible rounds or do we need to do frontend filtering on them?
   const { data } = await apolloClient.query<Query>({

--- a/apps/ui/pages/reservations/[id]/cancel.tsx
+++ b/apps/ui/pages/reservations/[id]/cancel.tsx
@@ -26,7 +26,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const pk = params?.id;
 
   const commonProps = getCommonServerSideProps();
-  const client = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const client = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   if (Number.isFinite(Number(pk))) {
     const typename = "ReservationNode";

--- a/apps/ui/pages/reservations/[id]/edit.tsx
+++ b/apps/ui/pages/reservations/[id]/edit.tsx
@@ -29,7 +29,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const pk = params?.id;
 
   const commonProps = getCommonServerSideProps();
-  const client = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const client = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   if (Number.isFinite(Number(pk))) {
     // TODO why are we doing two separate queries? the linked reservationUnit should be part of the reservation query

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -69,7 +69,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { locale, params } = ctx;
   const pk = Number(params?.id);
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   if (isFinite(pk)) {
     const bookingTerms = await getGenericTerms(apolloClient);

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -43,7 +43,7 @@ type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale, query } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const { data } = await apolloClient.query<Query, QueryApplicationRoundsArgs>({
     fetchPolicy: "no-cache",

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -69,7 +69,7 @@ const StyledSorting = styled(Sorting)`
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { locale, query } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
   // TODO type this properly
   const values = query as Record<string, string>;
   const { data } = await apolloClient.query<Query, QueryReservationUnitsArgs>({

--- a/apps/ui/pages/terms/[id].tsx
+++ b/apps/ui/pages/terms/[id].tsx
@@ -24,7 +24,7 @@ type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale, params } = ctx;
   const commonProps = getCommonServerSideProps();
-  const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
+  const apolloClient = await createApolloClient(commonProps.apiBaseUrl, ctx);
 
   const genericTermsId = params?.id;
   const { data: genericTermsData } = await apolloClient.query<


### PR DESCRIPTION
NOT this one (the other PR is better for the same problem due to async issues with cache).

Closing this after I move the SSR changes to another PR.

## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: ui not working without being logged in after backend added csrf token checks to graphql endpoint.
- Graphql is only POST requests and Django wants the csrf token to be set before making a POST request. So if the cookie is not set we need to make separate dummy GET request on both SSR and Browser to fix that.
- Requires: https://github.com/City-of-Helsinki/tilavarauspalvelu-core/pull/1161

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Deployment should always fail because of health checks if the SSR version doesn't work.
- Browser version can be checked from search page (if it says error, and there is 403 in the console it's broken).
- Manual with other tickets (if they are fine so is this).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
