### PR TITLE
Add permission checks to application rounds

### DIFF
--- a/apps/admin-ui/src/hooks/usePermission.ts
+++ b/apps/admin-ui/src/hooks/usePermission.ts
@@ -3,6 +3,7 @@ import type {
   UnitNode,
   ReservationNode,
   UserNode,
+  ApplicationRoundNode,
 } from "common/types/gql-types";
 import {
   hasPermission as baseHasPermission,
@@ -83,6 +84,24 @@ const usePermission = () => {
     return baseHasAnyPermission(user);
   };
 
+  // TODO restrict the Permission type to only those that are applicable to application rounds
+  const hasApplicationRoundPermission = (
+    applicationRound: ApplicationRoundNode,
+    permission: Permission
+  ) => {
+    if (!user) return false;
+    const units = filterNonNullable(
+      applicationRound.reservationUnits.flatMap((ru) => ru.unit)
+    );
+    for (const unit of units) {
+      if (hasUnitPermission(user, permission, unit)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // TODO this is becoming convoluted with the addition of a new function for each object type
   return {
     user,
     hasPermission: (
@@ -94,6 +113,7 @@ const usePermission = () => {
     hasAnyPermission,
     hasUnitPermission: (permission: Permission, unit: UnitNode) =>
       hasUnitPermission(user, permission, unit),
+    hasApplicationRoundPermission,
   };
 };
 

--- a/apps/admin-ui/src/modules/permissionHelper.ts
+++ b/apps/admin-ui/src/modules/permissionHelper.ts
@@ -20,6 +20,7 @@ export enum Permission {
   CAN_MANAGE_RESOURCES = GeneralPermissionChoices.CanManageResources,
   CAN_MANAGE_UNITS = GeneralPermissionChoices.CanManageUnits,
   CAN_VALIDATE_APPLICATIONS = GeneralPermissionChoices.CanValidateApplications,
+  CAN_MANAGE_APPLICATIONS = GeneralPermissionChoices.CanHandleApplications,
   CAN_MANAGE_BANNER_NOTIFICATIONS = GeneralPermissionChoices.CanManageNotifications,
 }
 /* eslint-enable @typescript-eslint/prefer-literal-enum-member */

--- a/apps/admin-ui/src/spa/applications/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/applications/[id]/index.tsx
@@ -824,6 +824,7 @@ function ApplicationDetails({
     data,
     loading: isLoading,
     refetch,
+    error,
   } = useQuery<Query, QueryApplicationArgs>(APPLICATION_ADMIN_QUERY, {
     skip: applicationPk === 0,
     variables: { id },
@@ -837,6 +838,17 @@ function ApplicationDetails({
 
   if (isLoading) {
     return <Loader />;
+  }
+
+  if (error) {
+    return <div>{t("errors.errorFetchingApplication")}</div>;
+  }
+
+  // NOTE id query will return null if the application is not found or the user does not have permission
+  // we can't distinguish between these two cases
+  const canView = application != null;
+  if (!canView) {
+    return <div>{t("errors.noPermission")}</div>;
   }
 
   const isOrganisation = application?.organisation != null;

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/index.tsx
@@ -2,34 +2,38 @@ import React from "react";
 import { useQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { type Query } from "common/types/gql-types";
+import {
+  type Query,
+  type QueryApplicationRoundArgs,
+} from "common/types/gql-types";
 import { useNotification } from "@/context/NotificationContext";
 import BreadcrumbWrapper from "@/component/BreadcrumbWrapper";
 import Loader from "@/component/Loader";
 import { Review } from "./review/Review";
 import { APPLICATION_ROUND_QUERY } from "../queries";
+import usePermission from "@/hooks/usePermission";
+import { Permission } from "@/modules/permissionHelper";
+import { base64encode } from "common/src/helpers";
 
-function ApplicationRound({
-  applicationRoundId,
-}: {
-  applicationRoundId: number;
-}): JSX.Element | null {
+function ApplicationRound({ pk }: { pk: number }): JSX.Element {
   const { notifyError } = useNotification();
   const { t } = useTranslation();
 
-  const { data, loading: isLoading } = useQuery<Query>(
-    APPLICATION_ROUND_QUERY,
-    {
-      skip: !applicationRoundId,
-      variables: {
-        pk: [applicationRoundId],
-      },
-      onError: () => {
-        notifyError(t("errors.errorFetchingData"));
-      },
-    }
-  );
-  const applicationRound = data?.applicationRounds?.edges?.[0]?.node;
+  const id = base64encode(`ApplicationRoundNode:${pk}`);
+  const { data, loading: isLoading } = useQuery<
+    Query,
+    QueryApplicationRoundArgs
+  >(APPLICATION_ROUND_QUERY, {
+    skip: !pk,
+    variables: { id },
+    onError: () => {
+      notifyError(t("errors.errorFetchingData"));
+    },
+  });
+
+  const { applicationRound } = data ?? {};
+
+  const { hasApplicationRoundPermission } = usePermission();
 
   if (isLoading) {
     return <Loader />;
@@ -37,6 +41,18 @@ function ApplicationRound({
 
   if (!applicationRound) {
     return <div>{t("errors.applicationRoundNotFound")}</div>;
+  }
+
+  const canView = hasApplicationRoundPermission(
+    applicationRound,
+    Permission.CAN_VALIDATE_APPLICATIONS
+  );
+  const canManage = hasApplicationRoundPermission(
+    applicationRound,
+    Permission.CAN_MANAGE_APPLICATIONS
+  );
+  if (!canView && !canManage) {
+    return <div>{t("errors.noPermission")}</div>;
   }
 
   const route = [
@@ -70,10 +86,12 @@ function ApplicationRoundRouted(): JSX.Element | null {
   const { t } = useTranslation();
   const { applicationRoundId } = useParams<IParams>();
 
-  if (!applicationRoundId || Number.isNaN(Number(applicationRoundId))) {
-    return <div>{t("errors.router.invalidApplicationRoundNumber")}</div>;
+  const pk = Number(applicationRoundId);
+  if (pk > 0) {
+    return <ApplicationRound pk={pk} />;
   }
-  return <ApplicationRound applicationRoundId={Number(applicationRoundId)} />;
+
+  return <div>{t("errors.router.invalidApplicationRoundNumber")}</div>;
 }
 
 export default ApplicationRoundRouted;

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
@@ -32,23 +32,18 @@ export const APPLICATION_ROUNDS_QUERY = gql`
   }
 `;
 
-// TODO replace with relay query
 export const APPLICATION_ROUND_QUERY = gql`
   ${APPLICATION_ROUND_FRAGMENT}
-  query ApplicationRound($pk: [Int]!) {
-    applicationRounds(pk: $pk) {
-      edges {
-        node {
-          ...ApplicationRoundFragment
-          applicationsCount
-          reservationUnits {
-            pk
-            nameFi
-            unit {
-              pk
-              nameFi
-            }
-          }
+  query ApplicationRound($id: ID!) {
+    applicationRound(id: $id) {
+      ...ApplicationRoundFragment
+      applicationsCount
+      reservationUnits {
+        pk
+        nameFi
+        unit {
+          pk
+          nameFi
         }
       }
     }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Add: admin app permission checks for application and application-round pages.
- Refactor: use relay query for application-round.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: application-round, allocation, and application page should correctly return permission error pages if the user doesn't have `can_validate_applications` or `can_handle_applications`.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3206](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3206)


[TILA-3206]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ