### PR TITLE
Fix duration options not respecting min duration

### DIFF
--- a/apps/ui/components/reservation-unit/utils.ts
+++ b/apps/ui/components/reservation-unit/utils.ts
@@ -107,15 +107,15 @@ const getAvailableTimesForDay = ({
       const endDate = addMinutes(startDate, duration ?? 0);
       const startTime = new Date(start);
       startTime.setHours(timeHours, timeMinutes, 0, 0);
-      return isReservationReservable({
+      const isReservable = isReservationReservable({
         reservationUnit,
         activeApplicationRounds,
         start: startDate,
         end: endDate,
         skipLengthCheck: false,
-      }) && !isBefore(startDate, startTime)
-        ? n.label
-        : null;
+      });
+
+      return isReservable && !isBefore(startDate, startTime) ? n.label : null;
     })
     .filter((n): n is NonNullable<typeof n> => n != null);
 };
@@ -190,7 +190,9 @@ const isSlotReservable = (
   activeApplicationRounds?: RoundPeriod[],
   skipLengthCheck = false
 ): boolean => {
-  if (!reservationUnit || !activeApplicationRounds) return false;
+  if (!reservationUnit || !activeApplicationRounds) {
+    return false;
+  }
   return isReservationReservable({
     reservationUnit,
     activeApplicationRounds,

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -266,12 +266,10 @@ const EditStep0 = ({
         : undefined;
 
     const bufferTimeBefore =
-      reservationUnit?.bufferTimeBefore != null &&
       reservationUnit.bufferTimeBefore !== 0
         ? reservationUnit.bufferTimeBefore.toString()
         : reservationBufferTimeBefore;
     const bufferTimeAfter =
-      reservationUnit?.bufferTimeAfter != null &&
       reservationUnit.bufferTimeAfter !== 0
         ? reservationUnit.bufferTimeAfter.toString()
         : reservationBufferTimeAfter;

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -198,18 +198,7 @@ const EditStep0 = ({
     [reservationUnit, reservation, activeApplicationRounds]
   );
 
-  const {
-    minReservationDuration,
-    maxReservationDuration,
-    reservationStartInterval,
-  } = reservationUnit || {};
-
-  const durationOptions = getDurationOptions(
-    minReservationDuration ?? undefined,
-    maxReservationDuration ?? undefined,
-    reservationStartInterval ?? 0,
-    t
-  );
+  const durationOptions = getDurationOptions(reservationUnit, t);
 
   const reservableTimeSpans = filterNonNullable(
     reservationUnit?.reservableTimeSpans

--- a/apps/ui/middleware.ts
+++ b/apps/ui/middleware.ts
@@ -48,7 +48,7 @@ function redirectCsrfToken(req: NextRequest): URL | undefined {
     requestUrl.pathname.startsWith("/healthcheck") ||
     requestUrl.pathname.startsWith("/_next") ||
     requestUrl.pathname.match(
-      /\.(js|css|png|jpg|jpeg|svg|gif|ico|json|woff|woff2|ttf|eot|otf)$/
+      /\.(webmanifest|js|css|png|jpg|jpeg|svg|gif|ico|json|woff|woff2|ttf|eot|otf)$/
     )
   ) {
     return undefined;

--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -44,14 +44,50 @@ describe("getDurationOptions", () => {
     const mockT = ((x: string) => x) as TFunction;
     const interval90 = ReservationStartInterval.Interval_90Mins;
     const interval60 = ReservationStartInterval.Interval_60Mins;
-    expect(getDurationOptions(0, 5400, interval90, mockT)).toEqual([]);
-    expect(getDurationOptions(5400, 0, interval60, mockT)).toEqual([]);
-    expect(getDurationOptions(0, 0, interval90, mockT)).toEqual([]);
+    expect(
+      getDurationOptions(
+        {
+          minReservationDuration: 0,
+          maxReservationDuration: 5400,
+          reservationStartInterval: interval90,
+        },
+        mockT
+      )
+    ).toEqual([]);
+    expect(
+      getDurationOptions(
+        {
+          minReservationDuration: 5400,
+          maxReservationDuration: 0,
+          reservationStartInterval: interval60,
+        },
+        mockT
+      )
+    ).toEqual([]);
+    expect(
+      getDurationOptions(
+        {
+          minReservationDuration: 0,
+          maxReservationDuration: 0,
+          reservationStartInterval: interval60,
+        },
+        mockT
+      )
+    ).toEqual([]);
   });
   test("with 15 min intervals", () => {
     const mockT = ((x: string) => x) as TFunction;
     const interval15 = ReservationStartInterval.Interval_15Mins;
-    expect(getDurationOptions(1800, 5400, interval15, mockT)).toEqual([
+    expect(
+      getDurationOptions(
+        {
+          minReservationDuration: 1800,
+          maxReservationDuration: 5400,
+          reservationStartInterval: interval15,
+        },
+        mockT
+      )
+    ).toEqual([
       {
         label: " common:abbreviations.minute",
         value: 30,
@@ -78,7 +114,16 @@ describe("getDurationOptions", () => {
   test("with 90 min intervals", () => {
     const mockT = ((x: string) => x) as TFunction;
     const interval90 = ReservationStartInterval.Interval_90Mins;
-    expect(getDurationOptions(1800, 30600, interval90, mockT)).toEqual([
+    expect(
+      getDurationOptions(
+        {
+          minReservationDuration: 1800,
+          maxReservationDuration: 30600,
+          reservationStartInterval: interval90,
+        },
+        mockT
+      )
+    ).toEqual([
       {
         label: " common:abbreviations.minute",
         value: 90,

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -381,16 +381,14 @@ export function getPossibleTimesForDay(
       const [slotH, slotM] = span.split(":").map(Number);
       const slotDate = new Date(date);
       slotDate.setHours(slotH, slotM, 0, 0);
-      return (
-        slotDate >= new Date() &&
-        isReservationReservable({
-          reservationUnit,
-          activeApplicationRounds,
-          start: slotDate,
-          end: addMinutes(slotDate, durationValue),
-          skipLengthCheck: false,
-        })
-      );
+      const isReservable = isReservationReservable({
+        reservationUnit,
+        activeApplicationRounds,
+        start: slotDate,
+        end: addMinutes(slotDate, durationValue),
+        skipLengthCheck: false,
+      });
+      return slotDate >= new Date() && isReservable;
     })
     .map((time) => ({ label: time, value: time }));
 }

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -454,9 +454,13 @@ const ReservationUnit = ({
 
   const durationOptions = getDurationOptions(reservationUnit, t);
 
+  // technically these can be left empty (backend allows it)
   const minReservationDurationMinutes = reservationUnit.minReservationDuration
     ? reservationUnit.minReservationDuration / 60
     : 30;
+  const maxReservationDurationMinutes = reservationUnit.maxReservationDuration
+    ? reservationUnit.maxReservationDuration / 60
+    : Number.MAX_SAFE_INTEGER;
 
   const searchUIDate = fromUIDate(searchDate ?? "");
   // TODO should be the first reservable day (the reservableTimeSpans logic is too complex and needs refactoring)
@@ -468,7 +472,10 @@ const ReservationUnit = ({
       searchUIDate != null && isValidDate(searchUIDate)
         ? searchDate ?? ""
         : defaultDateString,
-    duration: Math.max(searchDuration ?? 0, minReservationDurationMinutes),
+    duration: Math.min(
+      Math.max(searchDuration ?? 0, minReservationDurationMinutes),
+      maxReservationDurationMinutes
+    ),
     time: searchTime ?? getTimeString(defaultDate),
   };
 

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -452,19 +452,11 @@ const ReservationUnit = ({
 
   const reservableTimeSpans = reservationUnit?.reservableTimeSpans;
 
-  const { maxReservationDuration, reservationStartInterval } =
-    reservationUnit || {};
+  const durationOptions = getDurationOptions(reservationUnit, t);
 
-  const minReservationDuration = reservationUnit.minReservationDuration
+  const minReservationDurationMinutes = reservationUnit.minReservationDuration
     ? reservationUnit.minReservationDuration / 60
     : 30;
-
-  const durationOptions = getDurationOptions(
-    minReservationDuration ?? undefined,
-    maxReservationDuration ?? undefined,
-    reservationStartInterval,
-    t
-  );
 
   const searchUIDate = fromUIDate(searchDate ?? "");
   // TODO should be the first reservable day (the reservableTimeSpans logic is too complex and needs refactoring)
@@ -476,7 +468,7 @@ const ReservationUnit = ({
       searchUIDate != null && isValidDate(searchUIDate)
         ? searchDate ?? ""
         : defaultDateString,
-    duration: searchDuration ?? minReservationDuration,
+    duration: searchDuration ?? minReservationDurationMinutes,
     time: searchTime ?? getTimeString(defaultDate),
   };
 
@@ -488,7 +480,9 @@ const ReservationUnit = ({
 
   const { watch, setValue } = reservationForm;
   const durationValue =
-    watch("duration") ?? durationOptions[0]?.value ?? minReservationDuration;
+    watch("duration") ??
+    durationOptions[0]?.value ??
+    minReservationDurationMinutes;
   const dateValue = watch("date");
   const timeValue = watch("time") ?? getTimeString();
 

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -152,9 +152,9 @@ const doesSlotCollideWithApplicationRounds = (
   );
 };
 
-export const getIntervalMinutes = (
+export function getIntervalMinutes(
   reservationStartInterval: ReservationStartInterval
-): number => {
+): number {
   switch (reservationStartInterval) {
     case "INTERVAL_15_MINS":
       return 15;
@@ -177,9 +177,9 @@ export const getIntervalMinutes = (
     case "INTERVAL_420_MINS":
       return 420;
     default:
-      return 0;
+      throw new Error("Invalid reservation start interval");
   }
-};
+}
 
 export const generateSlots = (
   start: Date,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: min reservation time check failed when generating duration options defaulting to reservation interval.
- Fix: reservation calendar not possible to drag to modify the selected time.
- Fix: webmanifest incorrectly redirected to core for csrf (adding errors in tests).
- Fix: clamp the duration query param (passed from search page) between min / max reservation duration.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: Only normal user app changed. When making new reservations both calendar and quick reservation issues fixed.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
