### PR TITLE
fix: application schedule incorrect time

### DIFF
--- a/apps/ui/components/application/ApplicationEvent.tsx
+++ b/apps/ui/components/application/ApplicationEvent.tsx
@@ -177,7 +177,12 @@ function ApplicationEventInner({
     return "";
   };
 
-  const durationOptions = getDurationOptions(t);
+  // convert from minutes to seconds (search page uses minutes, this uses seconds)
+  const durationOptions = getDurationOptions(t).map((x) => ({
+    label: x.label,
+    value: x.value * 60,
+  }));
+
   return (
     <>
       <SubHeadLine>

--- a/apps/ui/modules/const.ts
+++ b/apps/ui/modules/const.ts
@@ -55,6 +55,7 @@ function durationMinuteOptions(t: TFunction) {
   return durations;
 }
 
+/// @returns an array of duration options in minutes
 export function getDurationOptions(t: TFunction): DurationOption[] {
   const times: DurationOption[] = [];
   let hour = 2;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: Reuse of the duration options function broke schedule time: search page is in minutes, schedule in seconds.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: Make a new application schedule (page 1) mutation should work and time should be correctly calculated.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
