### PR TITLE
fix: tax percentage label not translated

### DIFF
--- a/apps/admin-ui/src/spa/ReservationUnit/edit/PricingType.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/PricingType.tsx
@@ -108,7 +108,7 @@ function PaidPricingPart({
             id={`pricings.${index}.taxPercentage.pk`}
             placeholder={t("common.select")}
             required
-            label={t(`ReservationUnitEditor.label.taxPercentagePk`)}
+            label={t(`ReservationUnitEditor.label.taxPercentage`)}
             options={taxPercentageOptions}
             onChange={(v: { value: number; label: string }) => {
               onChange({ pk: v.value, value: Number(v.label) });


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: edit reservation unit page tax percentage didn't get translated because key's have changed. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
