### PR TITLE
fix: updated feedback-page url

### DIFF
--- a/apps/admin-ui/src/App.tsx
+++ b/apps/admin-ui/src/App.tsx
@@ -60,9 +60,14 @@ const ApplicationRoundAllocation = dynamic(
 const withAuthorization = (
   component: JSX.Element,
   apiBaseUrl: string,
+  feedbackUrl: string,
   permission?: Permission
 ) => (
-  <AuthorizationChecker permission={permission} apiUrl={apiBaseUrl}>
+  <AuthorizationChecker
+    permission={permission}
+    apiUrl={apiBaseUrl}
+    feedbackUrl={feedbackUrl}
+  >
     {component}
   </AuthorizationChecker>
 );
@@ -70,6 +75,7 @@ const withAuthorization = (
 type Props = {
   reservationUnitPreviewUrl: string;
   apiBaseUrl: string;
+  feedbackUrl: string;
 };
 const UnitsRouter = ({
   reservationUnitPreviewUrl,
@@ -117,16 +123,26 @@ const ApplicationRoundsRouter = () => (
   </Routes>
 );
 
-const PremisesRouter = () => (
+const PremisesRouter = ({
+  apiBaseUrl,
+  feedbackUrl,
+}: Omit<Props, "reservationUnitPreviewUrl">) => (
   <Routes>
     <Route
       path="spaces"
-      element={withAuthorization(<SpacesList />, Permission.CAN_MANAGE_SPACES)}
+      element={withAuthorization(
+        <SpacesList />,
+        apiBaseUrl,
+        feedbackUrl,
+        Permission.CAN_MANAGE_SPACES
+      )}
     />
     <Route
       path={`${prefixes.reservationUnits}`}
       element={withAuthorization(
         <ReservationUnits />,
+        apiBaseUrl,
+        feedbackUrl,
         Permission.CAN_MANAGE_UNITS
       )}
     />
@@ -134,30 +150,43 @@ const PremisesRouter = () => (
       path="resources"
       element={withAuthorization(
         <ResourcesList />,
+        apiBaseUrl,
+        feedbackUrl,
         Permission.CAN_MANAGE_RESOURCES
       )}
     />
     <Route
       path="units"
-      element={withAuthorization(<Units />, Permission.CAN_MANAGE_UNITS)}
+      element={withAuthorization(
+        <Units />,
+        apiBaseUrl,
+        feedbackUrl,
+        Permission.CAN_MANAGE_UNITS
+      )}
     />
   </Routes>
 );
 
-function ClientApp({ reservationUnitPreviewUrl, apiBaseUrl }: Props) {
+function ClientApp({
+  reservationUnitPreviewUrl,
+  apiBaseUrl,
+  feedbackUrl,
+}: Props) {
   return (
     <BrowserRouter basename={PUBLIC_URL}>
-      <PageWrapper apiBaseUrl={apiBaseUrl}>
+      <PageWrapper apiBaseUrl={apiBaseUrl} feedbackUrl={feedbackUrl}>
         <Routes>
           <Route path="*" element={<Error404 />} />
           <Route
             path="/"
-            element={withAuthorization(<HomePage />, apiBaseUrl)}
+            element={withAuthorization(<HomePage />, apiBaseUrl, feedbackUrl)}
           />
           <Route
             path={`${prefixes.applications}/*`}
             element={withAuthorization(
               <ApplicationRouter />,
+              apiBaseUrl,
+              feedbackUrl,
               Permission.CAN_VALIDATE_APPLICATIONS
             )}
           />
@@ -165,12 +194,21 @@ function ClientApp({ reservationUnitPreviewUrl, apiBaseUrl }: Props) {
             path={`${prefixes.recurringReservations}/application-rounds/*`}
             element={withAuthorization(
               <ApplicationRoundsRouter />,
+              apiBaseUrl,
+              feedbackUrl,
               Permission.CAN_VALIDATE_APPLICATIONS
             )}
           />
           <Route
             path="/premises-and-settings/*"
-            element={withAuthorization(<PremisesRouter />, apiBaseUrl)}
+            element={withAuthorization(
+              <PremisesRouter
+                apiBaseUrl={apiBaseUrl}
+                feedbackUrl={feedbackUrl}
+              />,
+              apiBaseUrl,
+              feedbackUrl
+            )}
           />
           <Route
             path="/unit/*"
@@ -178,21 +216,32 @@ function ClientApp({ reservationUnitPreviewUrl, apiBaseUrl }: Props) {
               <UnitsRouter
                 reservationUnitPreviewUrl={reservationUnitPreviewUrl}
               />,
-              apiBaseUrl
+              apiBaseUrl,
+              feedbackUrl
             )}
           />
           <Route
             path="/reservations/*"
-            element={withAuthorization(<ReservationsRouter />, apiBaseUrl)}
+            element={withAuthorization(
+              <ReservationsRouter />,
+              apiBaseUrl,
+              feedbackUrl
+            )}
           />
           <Route
             path="/my-units/*"
-            element={withAuthorization(<MyUnitsRouter />, apiBaseUrl)}
+            element={withAuthorization(
+              <MyUnitsRouter />,
+              apiBaseUrl,
+              feedbackUrl
+            )}
           />
           <Route
             path="/messaging/notifications/*"
             element={withAuthorization(
               <NotificationsRouter />,
+              apiBaseUrl,
+              feedbackUrl,
               Permission.CAN_MANAGE_BANNER_NOTIFICATIONS
             )}
           />

--- a/apps/admin-ui/src/common/AuthorizationChecker.tsx
+++ b/apps/admin-ui/src/common/AuthorizationChecker.tsx
@@ -10,9 +10,11 @@ const AuthorisationChecker = ({
   apiUrl,
   children,
   permission,
+  feedbackUrl,
 }: {
   apiUrl: string;
   children: React.ReactNode;
+  feedbackUrl: string;
   permission?: Permission;
 }) => {
   const { hasAnyPermission, hasSomePermission } = usePermissionSuspended();
@@ -29,7 +31,11 @@ const AuthorisationChecker = ({
   // Use suspense to avoid flash of unauthorised content
   return (
     <Suspense fallback={<Loader />}>
-      {hasAccess ? children : <Error403 apiBaseUrl={apiUrl} />}
+      {hasAccess ? (
+        children
+      ) : (
+        <Error403 apiBaseUrl={apiUrl} feedbackUrl={feedbackUrl} />
+      )}
     </Suspense>
   );
 };

--- a/apps/admin-ui/src/common/Error403.tsx
+++ b/apps/admin-ui/src/common/Error403.tsx
@@ -8,23 +8,33 @@ import { breakpoints } from "common/src/common/style";
 import { PUBLIC_URL } from "./const";
 
 const Wrapper = styled.div`
-  margin: var(--spacing-layout-s);
+  padding: var(--spacing-layout-s);
   word-break: break-word;
   gap: var(--spacing-layout-m);
   h1 {
     margin-bottom: 0;
     font-size: 2.5em;
   }
+  p {
+    margin-bottom: var(--spacing-layout-m);
+  }
 
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
 
   @media (min-width: ${breakpoints.l}) {
-    margin: var(--spacing-layout-m);
+    grid-template-columns: minmax(400px, 600px) 400px;
+    margin: 0 auto;
     h1 {
       font-size: 4em;
     }
   }
+`;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-layout-2-xs);
 `;
 
 const Image = styled.img`
@@ -35,21 +45,24 @@ const ButtonContainer = styled.div`
   margin-top: var(--spacing-s);
 `;
 
-const LogoutSection = ({ apiBaseUrl }: { apiBaseUrl: string }): JSX.Element => {
+const LogoutSection = ({
+  apiBaseUrl,
+  feedbackUrl,
+}: {
+  apiBaseUrl: string;
+  feedbackUrl: string;
+}): JSX.Element => {
   const { isAuthenticated } = useSession();
 
   const { t } = useTranslation();
 
   return (
-    <>
+    <Column>
       <Link external href="/">
-        {t("errorPages.accessForbidden.linkToVaraamo")}
+        {t("errorPages.linkToVaraamo")}
       </Link>
-      <Link
-        external
-        href="https://app.helmet-kirjasto.fi/forms/?site=varaamopalaute&ref=https://tilavaraus.hel.fi/"
-      >
-        {t("errorPages.accessForbidden.giveFeedback")}
+      <Link external href={feedbackUrl}>
+        {t("errorPages.giveFeedback")}
       </Link>
       {isAuthenticated && (
         <ButtonContainer>
@@ -58,16 +71,16 @@ const LogoutSection = ({ apiBaseUrl }: { apiBaseUrl: string }): JSX.Element => {
           </Button>
         </ButtonContainer>
       )}
-    </>
+    </Column>
   );
 };
 
 const Error403 = ({
   apiBaseUrl,
-  showLogoutSection,
+  feedbackUrl,
 }: {
   apiBaseUrl: string;
-  showLogoutSection?: boolean;
+  feedbackUrl: string;
 }): JSX.Element => {
   const { t } = useTranslation();
 
@@ -76,7 +89,7 @@ const Error403 = ({
       <div>
         <H1 $legacy>403 - {t("errorPages.accessForbidden.title")}</H1>
         <p>{t("errorPages.accessForbidden.description")}</p>
-        {showLogoutSection && <LogoutSection apiBaseUrl={apiBaseUrl} />}
+        <LogoutSection apiBaseUrl={apiBaseUrl} feedbackUrl={feedbackUrl} />
       </div>
       <Image src={`${PUBLIC_URL}/403.png`} />
     </Wrapper>

--- a/apps/admin-ui/src/common/Error5xx.tsx
+++ b/apps/admin-ui/src/common/Error5xx.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { H1 } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import { PUBLIC_URL } from "./const";
+import { useTranslation } from "react-i18next";
 
 const Wrapper = styled.div`
   margin: 0 var(--spacing-s);
@@ -42,23 +43,19 @@ const Image = styled.img`
   }
 `;
 
-const Error5xx = (): JSX.Element => {
+const Error5xx = ({ feedbackUrl }: { feedbackUrl: string }): JSX.Element => {
+  const { t } = useTranslation();
+
   return (
     <Wrapper>
       <Content>
-        <H1 $legacy>Jokin meni vikaan</H1>
-        <p>
-          Pahoittelut, emme valitettavasti pysty näyttämään sivua juuri nyt.
-          Yritä myöhemmin uudelleen!
-        </p>
+        <H1 $legacy>{t("errorPages.generalError.title")}</H1>
+        <p>{t("errorPages.generalError.title")}</p>
         <Link external href="/">
-          Siirry Varaamon etusivulle
+          {t("errorPages.linkToVaraamo")}
         </Link>
-        <Link
-          external
-          href="https://app.helmet-kirjasto.fi/forms/?site=varaamopalaute&ref=https://tilavaraus.hel.fi/"
-        >
-          Anna palautetta
+        <Link external href={feedbackUrl}>
+          {t("errorPages.giveFeedback")}
         </Link>
       </Content>
       <Image src={`${PUBLIC_URL}/5xx.png`} />

--- a/apps/admin-ui/src/component/PageWrapper.tsx
+++ b/apps/admin-ui/src/component/PageWrapper.tsx
@@ -16,6 +16,7 @@ import { MainLander } from "./MainLander";
 
 type Props = {
   apiBaseUrl: string;
+  feedbackUrl: string;
   children: React.ReactNode;
 };
 
@@ -32,22 +33,23 @@ const Wrapper = styled.div`
   flex-grow: 1;
 `;
 
-const FallbackComponent = (err: unknown) => {
+const FallbackComponent = (err: unknown, feedbackUrl: string) => {
   // eslint-disable-next-line no-console
   console.error(err);
   Sentry.captureException(err);
-  return <Error5xx />;
+  return <Error5xx feedbackUrl={feedbackUrl} />;
 };
 
 // NOTE client only because Navigation requires react-router-dom
 export default function PageWrapper({
   apiBaseUrl,
+  feedbackUrl,
   children,
 }: Props): JSX.Element {
   const { hasAnyPermission, user } = usePermission();
   const hasAccess = user && hasAnyPermission();
   return (
-    <ErrorBoundary FallbackComponent={FallbackComponent}>
+    <ErrorBoundary FallbackComponent={(e) => FallbackComponent(e, feedbackUrl)}>
       <ClientOnly>
         <Navigation apiBaseUrl={apiBaseUrl} />
         <Wrapper>

--- a/apps/admin-ui/src/env.mjs
+++ b/apps/admin-ui/src/env.mjs
@@ -17,8 +17,10 @@ const ServerSchema = z.object({
   TUNNISTAMO_URL: z.string().optional(),
   RESERVATION_UNIT_PREVIEW_URL_PREFIX: z.string().optional(),
   // mandatory because the SSR can't connect to the API without it
-  // frontend SSR is running on a different host than the backend
+  // frontend SSR is running on a different
+  // host than the backend
   TILAVARAUS_API_URL: z.string().url(),
+  EMAIL_VARAAMO_EXT_LINK: z.string().url().optional(),
 });
 
 // NOTE if you add a new variable to client it will be fixed in the build

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -255,9 +255,15 @@ const translations: ITranslations = {
       description: [
         "Sivu on nähtävillä vain kirjautuneille käyttäjille. Voit nähdä sivun sisällön, jos kirjaudut sisään ja sinulla on riittävän laajat käyttöoikeudet.",
       ],
-      linkToVaraamo: ["Siirry Varaamon etusivulle"],
-      giveFeedback: ["Anna palautetta"],
     },
+    generalError: {
+      title: ["Jokin meni vikaan"],
+      description: [
+        "Pahoittelut, emme valitettavasti pysty näyttämään sivua juuri nyt. Yritä myöhemmin uudelleen!",
+      ],
+    },
+    linkToVaraamo: ["Siirry Varaamon etusivulle"],
+    giveFeedback: ["Ota yhteyttä"],
   },
   // TODO used inside the ReservationUnitEditor
   ArchiveReservationUnitDialog: {

--- a/apps/admin-ui/src/pages/index.tsx
+++ b/apps/admin-ui/src/pages/index.tsx
@@ -18,6 +18,7 @@ export const getServerSideProps = async () => {
     props: {
       reservationUnitPreviewUrl: env.RESERVATION_UNIT_PREVIEW_URL_PREFIX ?? "",
       apiBaseUrl: env.TILAVARAUS_API_URL ?? "",
+      feedbackUrl: env.EMAIL_VARAAMO_EXT_LINK ?? "",
       // TODO can't use SSR translations because our translations aren't in public folder
       // ...(await serverSideTranslations(locale ?? "fi")),
     },

--- a/apps/ui/components/common/Footer.tsx
+++ b/apps/ui/components/common/Footer.tsx
@@ -18,9 +18,23 @@ const Wrapper = styled(HDSFooter)`
   }
 `;
 
-const Footer = (): JSX.Element => {
+const constructFeedbackUrl = (
+  feedbackUrl: string,
+  i18n: { language: string }
+) => {
+  try {
+    const url = new URL(feedbackUrl);
+    url.searchParams.set("lang", i18n.language);
+    return url.toString();
+  } catch (e) {
+    return null;
+  }
+};
+
+const Footer = ({ feedbackUrl }: { feedbackUrl: string }): JSX.Element => {
   const { t, i18n } = useTranslation("footer");
   const locale = i18n.language === "fi" ? "" : `/${i18n.language}`;
+  const languageUrl = constructFeedbackUrl(feedbackUrl, i18n);
   // TODO HDS:Footer causes a hydration error
   // related to hydration problems, any params we set to it are ignored in SSR
   // so if the page is static this renders the default style
@@ -45,15 +59,15 @@ const Footer = (): JSX.Element => {
           icon={<IconLinkExternal size="s" aria-hidden />}
           rel="noopener noreferrer"
         />
-        <HDSFooter.Item
-          href={`https://app.helmet-kirjasto.fi/forms/?site=varaamopalaute&ref=https://tilavaraus.hel.fi/${
-            locale !== "" ? `&lang=${i18n.language}` : ""
-          }`}
-          label={t(`footer:Navigation.feedbackLabel`)}
-          target="_blank"
-          icon={<IconLinkExternal size="s" aria-hidden />}
-          rel="noopener noreferrer"
-        />
+        {languageUrl && (
+          <HDSFooter.Item
+            href={languageUrl}
+            label={t(`footer:Navigation.feedbackLabel`)}
+            target="_blank"
+            icon={<IconLinkExternal size="s" aria-hidden />}
+            rel="noopener noreferrer"
+          />
+        )}
       </HDSFooter.Navigation>
       <HDSFooter.Base
         copyrightHolder={t("footer:Base.copyrightHolder")}

--- a/apps/ui/components/common/PageWrapper.tsx
+++ b/apps/ui/components/common/PageWrapper.tsx
@@ -12,6 +12,7 @@ interface Props {
   overrideBackgroundColor?: string;
   apiBaseUrl: string;
   profileLink: string;
+  feedbackUrl: string;
 }
 
 const Main = styled.main<{ $bgColor?: string }>`
@@ -23,6 +24,7 @@ const Main = styled.main<{ $bgColor?: string }>`
 function PageWrapper({
   apiBaseUrl,
   profileLink,
+  feedbackUrl,
   children,
   overrideBackgroundColor,
 }: Props): JSX.Element {
@@ -44,7 +46,7 @@ function PageWrapper({
       >
         {children}
       </Main>
-      <Footer />
+      <Footer feedbackUrl={feedbackUrl} />
       <div id="modal-root" />
     </>
   );

--- a/apps/ui/env.mjs
+++ b/apps/ui/env.mjs
@@ -24,6 +24,7 @@ const ServerSchema = z.object({
   // mandatory because the SSR can't connect to the API without it
   // frontend SSR is running on a different host than the backend
   TILAVARAUS_API_URL: z.string().url(),
+  EMAIL_VARAAMO_EXT_LINK: z.string().url().optional(),
 });
 
 // NOTE if you add a new variable to client it will be fixed in the build

--- a/apps/ui/modules/serverUtils.ts
+++ b/apps/ui/modules/serverUtils.ts
@@ -16,6 +16,7 @@ export function getCommonServerSideProps() {
   const hotjarEnabled = env.HOTJAR_ENABLED ?? false;
   const profileLink = env.PROFILE_UI_URL ?? "";
   const apiBaseUrl = env.TILAVARAUS_API_URL ?? "";
+  const feedbackUrl = env.EMAIL_VARAAMO_EXT_LINK ?? "";
 
   return {
     cookiehubEnabled,
@@ -23,6 +24,7 @@ export function getCommonServerSideProps() {
     hotjarEnabled,
     profileLink,
     apiBaseUrl,
+    feedbackUrl,
   };
 }
 

--- a/apps/ui/public/locales/en/footer.json
+++ b/apps/ui/public/locales/en/footer.json
@@ -1,6 +1,6 @@
 {
   "Navigation": {
-    "feedbackLabel": "Send feedback",
+    "feedbackLabel": "Contact us",
     "serviceTermsLabel": "General Terms of Service"
   },
   "Base": {

--- a/apps/ui/public/locales/fi/footer.json
+++ b/apps/ui/public/locales/fi/footer.json
@@ -1,6 +1,6 @@
 {
   "Navigation": {
-    "feedbackLabel": "Lähetä palautetta",
+    "feedbackLabel": "Ota yhteyttä",
     "serviceTermsLabel": "Palvelun yleiset käyttöehdot"
   },
   "Base": {

--- a/apps/ui/public/locales/sv/footer.json
+++ b/apps/ui/public/locales/sv/footer.json
@@ -1,6 +1,6 @@
 {
   "Navigation": {
-    "feedbackLabel": "Ge respons",
+    "feedbackLabel": "Ta kontakt",
     "serviceTermsLabel": "Allmänna användarvillkor"
   },
   "Base": {


### PR DESCRIPTION
## 🛠️ Changelog
- the url is defined as `EMAIL_VARAAMO_EXT_LINK` env-variable
- implemented in the `Footer` on ui pages
- implemented in 403 & 5xx error pages on admin pages
- reorganise the error texts in the localization files to make link texts more generic
- make 5xx text contents dynamic, as they were hardcoded before

## 🧪 Test plan
- Check the footer-link on ui side
- Try to access admin pages with invalid credentials, and check the 403 error page
- Induce a 5xx-error to see the link in action on the 5xx-error page

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3293
