### PR TITLE
Fix preferred order filter

### DIFF
--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/AllocationCalendar.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/AllocationCalendar.tsx
@@ -308,22 +308,24 @@ export function AllocationCalendar({
   );
   const [focusedAllocated] = useFocusAllocatedSlot();
 
-  const aesForThisUnit = filterNonNullable(applicationSections);
   const data = WEEKDAYS.map((day) => {
     const isNotHandled = (ae: ApplicationSectionNode) =>
       ae.status !== ApplicationSectionStatusChoice.Handled;
+
     // Only show allocated that match the unit and day
-    const timeslots = aesForThisUnit
+    const timeslots = filterNonNullable(applicationSections)
       .filter(isNotHandled)
       .filter((ae) => ae.suitableTimeRanges?.some((tr) => isDay(tr, day)));
 
-    const resUnits = aesForThisUnit?.flatMap((ae) => ae.reservationUnitOptions);
+    const resUnits = applicationSections?.flatMap(
+      (ae) => ae.reservationUnitOptions
+    );
 
-    const allocated = resUnits
+    const allocated = filterNonNullable(resUnits)
       .filter((a) => a.allocatedTimeSlots?.some((ts) => isDay(ts, day)))
       .map((ts) => removeOtherAllocatedDays(ts, day));
 
-    const focusedAllocatedTimes = allocated.filter((a) =>
+    const focusedAllocatedTimes = filterNonNullable(allocated).filter((a) =>
       a.allocatedTimeSlots?.some((ts) => ts.pk === focusedAllocated)
     );
 

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/AllocationColumn.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/AllocationColumn.tsx
@@ -16,7 +16,6 @@ import {
 } from "common/types/gql-types";
 import { ShowAllContainer } from "common/src/components/";
 import { transformWeekday, type Day } from "common/src/conversion";
-import { filterNonNullable } from "common/src/helpers";
 import { ALLOCATION_CALENDAR_TIMES } from "@/common/const";
 import {
   type RelatedSlot,
@@ -283,17 +282,13 @@ export function AllocationColumn({
     applicationRoundStatus === ApplicationRoundStatusChoice.InAllocation;
 
   // NOTE have to reverse search for the pk, as the reservationUnitOption doesn't include any other fields than pk
-  const allocatedPks = filterNonNullable(
-    allocated
-      .flatMap((ruo) =>
-        ruo.allocatedTimeSlots?.map(
-          (ts) => ts.reservationUnitOption.applicationSection
-        )
-      )
-      .map((as) => as?.pk)
+  const allocatedPks = allocated.flatMap((ruo) =>
+    ruo.allocatedTimeSlots?.map(
+      (ts) => ts.reservationUnitOption.applicationSection.pk
+    )
   );
   const allocatedSections = aes.filter(
-    (as) => as.pk != null && allocatedPks.includes(as.pk)
+    (as) => as.pk != null && allocatedPks.find((x) => x === as.pk)
   );
 
   const doesCollideToOtherAllocations = relatedAllocations[day].some((slot) => {

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/ApplicationEvents.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/ApplicationEvents.tsx
@@ -144,21 +144,26 @@ export function AllocationPageContent({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- We only care if reservationUnit changes, and adding the rest causes an infinite loop
   }, [reservationUnit, params]);
 
-  /* TODO: rework / remove
-   * issues
-   * Any time anything is changed in the filters or selection this is going to reset.
-   * Rather make it a higher level hook (on the page level) and reset only for the few things that need it.
-   * Could also include it inside the Selection hook (pass things that should cause side effects to it).
-   * For now NOT reseting at all, add them individually as the client requests not before
-   * 2nd note: when reseting check if the value is valid or makes sense, don't just reset it
-   * 3rd note: make sure landing on the page with query params works as expected (and doesn't just remove them)
-  useEffect( () => setSelectedSlots([]),
-    [focusedApplicationEvent, reservationUnit]
-  );
-  */
-
   const relatedSpacesTimeSlotsByDayReduced =
     getRelatedTimeSlots(relatedAllocations);
+
+  // NOTE left hand cards include other reservation units as well (if they are allocated)
+  // remove those from the calendar and the right hand side
+  const aesForThisUnit = filterNonNullable(applicationSections)
+    .filter((ae) => {
+      if (ae.reservationUnitOptions.length === 0) {
+        return false;
+      }
+      return ae.reservationUnitOptions?.some(
+        (a) => a.reservationUnit.pk === reservationUnit.pk
+      );
+    })
+    .map((ae) => ({
+      ...ae,
+      reservationUnitOptions: ae.reservationUnitOptions?.filter(
+        (ruo) => ruo.reservationUnit.pk === reservationUnit.pk
+      ),
+    }));
 
   // TODO should use mobile menu layout if the screen is small (this page probably requires  >= 1200px)
   return (
@@ -168,11 +173,11 @@ export function AllocationPageContent({
         reservationUnit={reservationUnit}
       />
       <AllocationCalendar
-        applicationSections={applicationSections}
+        applicationSections={aesForThisUnit}
         relatedAllocations={relatedSpacesTimeSlotsByDayReduced}
       />
       <AllocationColumn
-        applicationSections={applicationSections}
+        applicationSections={aesForThisUnit}
         reservationUnit={reservationUnit}
         refetchApplicationEvents={refetchApplicationEvents}
         applicationRoundStatus={applicationRoundStatus}

--- a/packages/common/types/gql-types.ts
+++ b/packages/common/types/gql-types.ts
@@ -426,6 +426,8 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
@@ -565,7 +567,7 @@ export type ApplicationSectionNode = Node & {
 export type ApplicationSectionNodeReservationUnitOptionsArgs = {
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOptionOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-  preferredOrder?: InputMaybe<Scalars["Int"]["input"]>;
+  preferredOrder?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   reservationUnit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
 };
 
@@ -2363,6 +2365,8 @@ export type QueryReservationUnitsArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
@@ -3124,6 +3128,8 @@ export type ReservationNodeReservationUnitArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
@@ -3790,6 +3796,7 @@ export type ReservationUnitNode = Node & {
   nameEn?: Maybe<Scalars["String"]["output"]>;
   nameFi?: Maybe<Scalars["String"]["output"]>;
   nameSv?: Maybe<Scalars["String"]["output"]>;
+  numActiveUserReservations?: Maybe<Scalars["Int"]["output"]>;
   paymentMerchant?: Maybe<PaymentMerchantNode>;
   paymentProduct?: Maybe<PaymentProductNode>;
   paymentTerms?: Maybe<TermsOfUseNode>;
@@ -5022,6 +5029,8 @@ export type UnitNodeReservationunitSetArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -320,6 +320,8 @@ type ApplicationRoundNode implements Node {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal
@@ -493,7 +495,7 @@ type ApplicationSectionNode implements Node {
   ageGroup: AgeGroupNode
   reservationUnitOptions(
     pk: [Int]
-    preferredOrder: Int
+    preferredOrder: [Int]
     reservationUnit: [Int]
 
     """Järjestä"""
@@ -1903,6 +1905,8 @@ type Query {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal
@@ -2811,6 +2815,8 @@ type ReservationNode implements Node {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal
@@ -3689,6 +3695,7 @@ type ReservationUnitNode implements Node {
   firstReservableDatetime: DateTime
   haukiUrl: String
   reservableTimeSpans(startDate: Date!, endDate: Date!): [ReservableTimeSpanType]
+  numActiveUserReservations: Int
   calculatedSurfaceArea: Int
   pk: Int
 }
@@ -4762,6 +4769,8 @@ type UnitNode implements Node {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: allocation filtering by preferred order.
- Fix: allocation page calendar and buttons showing allocations that were for a different reservation unit (and allowing removing them).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing.
- Preferred order filter should work as expected.
- Neither the calendar nor the remove / allocate buttons should show application sections that are already allocated in another reservation unit (and not in this one). 
- All filters should be properly applied to the Calendar and Buttons.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3254](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3254)


[TILA-3254]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ