### PR TITLE
fix: application modal text wrapping

### DIFF
--- a/apps/ui/components/application/ApplicationEventSummary.tsx
+++ b/apps/ui/components/application/ApplicationEventSummary.tsx
@@ -21,6 +21,7 @@ const Message = styled.div`
 const CustomIconWithText = styled(IconWithText)`
   font-size: var(--fontsize-body-m);
   margin-top: var(--spacing-2-xs);
+  white-space: unset;
 `;
 
 const SubHeadLine = styled(H5).attrs({

--- a/apps/ui/components/common/IconWithText.tsx
+++ b/apps/ui/components/common/IconWithText.tsx
@@ -13,6 +13,7 @@ const Container = styled.div`
   align-items: center;
   grid-template-columns: 1.5em 1fr 4fr;
   margin-top: var(--spacing-s);
+  white-space: nowrap;
 `;
 
 const SpanTwoColumns = styled.span`


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: icon + text wrapping weirdly, default to nowrap and add exception to the single case that has long text.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: should fix application modal weird line break.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
