### PR TITLE
Fix quick reservation missing options

### DIFF
--- a/apps/ui/components/reservation-unit/QuickReservation.tsx
+++ b/apps/ui/components/reservation-unit/QuickReservation.tsx
@@ -38,8 +38,6 @@ type Props = {
   LoginAndSubmit: JSX.Element;
 };
 
-const timeItems = 24;
-
 const Wrapper = styled.form`
   background-color: var(--color-gold-light);
   margin-bottom: var(--spacing-l);
@@ -193,10 +191,11 @@ const QuickReservation = ({
     const itemsPerChunk = 8;
 
     return chunkArray(
-      startingTimeOptions.map((opt) => (opt.label ? opt.label.toString() : "")),
+      startingTimeOptions.map((opt) => opt.label),
       itemsPerChunk
-    ).slice(0, timeItems / itemsPerChunk);
+    );
   }, [startingTimeOptions]);
+
   // Find out which slide has the slot that reflects the selected focusSlot
   let activeChunk = 0;
   for (let i = 0; i < timeChunks.length; i++) {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix (ui): remove ghost buffers from reservation calendar when no time was selected.
- Fix (ui): show all quick reservation times. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: reservation process: calendar buffer visibility, quick reservation options.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
