### PR TITLE
fix: my units calendar now shows the reservation name with prefix

### DIFF
--- a/apps/admin-ui/src/component/my-units/ReservationUnitCalendar.tsx
+++ b/apps/admin-ui/src/component/my-units/ReservationUnitCalendar.tsx
@@ -28,6 +28,7 @@ import {
 } from "common/src/helpers";
 import { RELATED_RESERVATION_STATES } from "common/src/const";
 import { ReservationUnitWithAffectingArgs } from "common/src/queries/fragments";
+import { TFunction } from "next-i18next";
 
 type Props = {
   begin: string;
@@ -50,14 +51,16 @@ const Container = styled.div`
 const getEventTitle = ({
   reservationUnitPk,
   reservation,
+  t,
 }: {
   reservationUnitPk: number;
   reservation: ReservationNode;
+  t: TFunction;
 }) => {
   const reservationUnit = reservation.reservationUnit?.[0];
   const isOtherReservationUnit = reservationUnitPk !== reservationUnit?.pk;
 
-  const reserveeName = getReserveeName(reservation);
+  const reserveeName = getReserveeName(reservation, t);
   if (isOtherReservationUnit) {
     const reservationUnitName = reservationUnit?.nameFi ?? "";
 
@@ -67,10 +70,15 @@ const getEventTitle = ({
   return [reserveeName, ""];
 };
 
-const constructEventTitle = (res: ReservationNode, resUnitPk: number) => {
+const constructEventTitle = (
+  res: ReservationNode,
+  resUnitPk: number,
+  t: TFunction
+) => {
   const [reservee, unit] = getEventTitle({
     reservationUnitPk: resUnitPk,
     reservation: res,
+    t,
   });
   if (unit.length > 0) {
     return `${reservee} (${unit})`;
@@ -124,7 +132,7 @@ export function ReservationUnitCalendar({
   const events = reservations.map((reservation) => {
     const isBlocked = reservation.type === ReservationTypeChoice.Blocked;
     const title = !isBlocked
-      ? constructEventTitle(reservation, reservationUnitPk)
+      ? constructEventTitle(reservation, reservationUnitPk, t)
       : t("MyUnits.Calendar.legend.closed");
     return {
       title,

--- a/apps/admin-ui/src/component/my-units/UnitCalendar.tsx
+++ b/apps/admin-ui/src/component/my-units/UnitCalendar.tsx
@@ -317,7 +317,7 @@ function getEventTitle({
   }
 
   return event && event?.pk !== event?.reservationUnit?.[0]?.pk
-    ? getReserveeName(event)
+    ? getReserveeName(event, t)
     : title;
 }
 

--- a/apps/admin-ui/src/component/reservations/requested/util.ts
+++ b/apps/admin-ui/src/component/reservations/requested/util.ts
@@ -198,7 +198,7 @@ export const getTranslationKeyForCustomerTypeChoice = (
 
 export const getReserveeName = (
   reservation: ReservationNode,
-  t?: TFunction,
+  t: TFunction,
   length = 50
 ): string => {
   let prefix = "";


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- the staff/behalf prefix was not showing in the calendar entries on the my units page. now they are.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- go to My Units, and make a reservation choosing the staff-option. The calendar entry should show "Sis. |" in front of the reservation name.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3171
