### PR TITLE
Add mass reject application options

### DIFF
--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -190,6 +190,7 @@ const translations: ITranslations = {
     errorFetchingData: ["Virhe haettaessa tietoja"],
     errorFetchingApplication: ["Virhe haettaessa hakemusta"],
     errorFetchingApplications: ["Virhe haettaessa hakemuksia"],
+    errorRejectingApplication: ["Virhe hylätessä hakemusta"],
     // TODO describe what failed if you don't know why it failed
     functionFailedTitle: ["Toiminto epäonnistui"],
     unexpectedError: ["Odottamaton virhe"],
@@ -416,10 +417,14 @@ const translations: ITranslations = {
     authenticatedUser: ["Tunnistautunut käyttäjä"],
     emptyFilterPageName: ["hakemusta"],
     rejected: ["Hylätty"],
-    btnReject: ["Hylkää"],
-    btnRevert: ["Palauta"],
-    btnRejectAll: ["Hylkää kaikki"],
-    btnRestoreAll: ["Palauta kaikki"],
+    btnRestore: ["Palauta koko hakemus"],
+    btnReject: ["Hylkää koko hakemus"],
+    section: {
+      btnReject: ["Hylkää"],
+      btnRestore: ["Palauta"],
+      btnRejectAll: ["Hylkää kaikki"],
+      btnRestoreAll: ["Palauta kaikki"],
+    },
     headings: {
       id: ["id"],
       customer: ["Hakija"],

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -418,6 +418,8 @@ const translations: ITranslations = {
     rejected: ["Hylätty"],
     btnReject: ["Hylkää"],
     btnRevert: ["Palauta"],
+    btnRejectAll: ["Hylkää kaikki"],
+    btnRestoreAll: ["Palauta kaikki"],
     headings: {
       id: ["id"],
       customer: ["Hakija"],

--- a/apps/admin-ui/src/spa/applications/queries.tsx
+++ b/apps/admin-ui/src/spa/applications/queries.tsx
@@ -31,3 +31,23 @@ export const RESTORE_ALL_SECTION_OPTIONS = gql`
     }
   }
 `;
+
+export const REJECT_APPLICATION = gql`
+  mutation rejectAllApplicationOptions(
+    $input: RejectAllApplicationOptionsMutationInput!
+  ) {
+    rejectAllApplicationOptions(input: $input) {
+      pk
+    }
+  }
+`;
+
+export const RESTORE_APPLICATION = gql`
+  mutation restoreAllApplicationOptions(
+    $input: RestoreAllApplicationOptionsMutationInput!
+  ) {
+    restoreAllApplicationOptions(input: $input) {
+      pk
+    }
+  }
+`;

--- a/apps/admin-ui/src/spa/applications/queries.tsx
+++ b/apps/admin-ui/src/spa/applications/queries.tsx
@@ -11,3 +11,23 @@ export const APPLICATION_ADMIN_QUERY = gql`
     }
   }
 `;
+
+export const REJECT_ALL_SECTION_OPTIONS = gql`
+  mutation rejectAllSectionOptions(
+    $input: RejectAllSectionOptionsMutationInput!
+  ) {
+    rejectAllSectionOptions(input: $input) {
+      pk
+    }
+  }
+`;
+
+export const RESTORE_ALL_SECTION_OPTIONS = gql`
+  mutation restoreAllSectionOptions(
+    $input: RestoreAllSectionOptionsMutationInput!
+  ) {
+    restoreAllSectionOptions(input: $input) {
+      pk
+    }
+  }
+`;

--- a/packages/common/src/queries/application.tsx
+++ b/packages/common/src/queries/application.tsx
@@ -212,6 +212,7 @@ export const APPLICATION_ADMIN_FRAGMENT = gql`
     }
     applicationSections {
       ...ApplicationSectionUIFragment
+      allocations
       reservationUnitOptions {
         rejected
         allocatedTimeSlots {

--- a/packages/common/types/gql-types.ts
+++ b/packages/common/types/gql-types.ts
@@ -356,6 +356,10 @@ export type ApplicationRoundNode = Node & {
   nameEn?: Maybe<Scalars["String"]["output"]>;
   nameFi?: Maybe<Scalars["String"]["output"]>;
   nameSv?: Maybe<Scalars["String"]["output"]>;
+  notesWhenApplying: Scalars["String"]["output"];
+  notesWhenApplyingEn?: Maybe<Scalars["String"]["output"]>;
+  notesWhenApplyingFi?: Maybe<Scalars["String"]["output"]>;
+  notesWhenApplyingSv?: Maybe<Scalars["String"]["output"]>;
   pk?: Maybe<Scalars["Int"]["output"]>;
   publicDisplayBegin: Scalars["DateTime"]["output"];
   publicDisplayEnd: Scalars["DateTime"]["output"];
@@ -1143,6 +1147,7 @@ export enum GeneralPermissionChoices {
   CanManageGeneralRoles = "CAN_MANAGE_GENERAL_ROLES",
   CanManageNotifications = "CAN_MANAGE_NOTIFICATIONS",
   CanManagePurposes = "CAN_MANAGE_PURPOSES",
+  CanManageQualifiers = "CAN_MANAGE_QUALIFIERS",
   CanManageReservations = "CAN_MANAGE_RESERVATIONS",
   CanManageReservationPurposes = "CAN_MANAGE_RESERVATION_PURPOSES",
   CanManageReservationUnits = "CAN_MANAGE_RESERVATION_UNITS",
@@ -1183,6 +1188,24 @@ export type GeneralRolePermissionNode = Node & {
   id: Scalars["ID"]["output"];
   permission?: Maybe<GeneralPermissionChoices>;
   pk?: Maybe<Scalars["Int"]["output"]>;
+};
+
+export type HelsinkiProfileDataNode = {
+  __typename?: "HelsinkiProfileDataNode";
+  birthday?: Maybe<Scalars["Date"]["output"]>;
+  city?: Maybe<Scalars["String"]["output"]>;
+  email?: Maybe<Scalars["String"]["output"]>;
+  firstName?: Maybe<Scalars["String"]["output"]>;
+  isStrongLogin: Scalars["Boolean"]["output"];
+  lastName?: Maybe<Scalars["String"]["output"]>;
+  loginMethod?: Maybe<LoginMethod>;
+  municipalityCode?: Maybe<Scalars["String"]["output"]>;
+  municipalityName?: Maybe<Scalars["String"]["output"]>;
+  phone?: Maybe<Scalars["String"]["output"]>;
+  pk: Scalars["Int"]["output"];
+  postalCode?: Maybe<Scalars["String"]["output"]>;
+  ssn?: Maybe<Scalars["String"]["output"]>;
+  streetAddress?: Maybe<Scalars["String"]["output"]>;
 };
 
 /** An enumeration. */
@@ -1340,6 +1363,13 @@ export enum LocationType {
   Movable = "MOVABLE",
 }
 
+/** An enumeration. */
+export enum LoginMethod {
+  Ad = "AD",
+  Other = "OTHER",
+  Profile = "PROFILE",
+}
+
 export type Mutation = {
   __typename?: "Mutation";
   adjustReservationTime?: Maybe<ReservationAdjustTimeMutationPayload>;
@@ -1373,7 +1403,11 @@ export type Mutation = {
   denyReservation?: Maybe<ReservationDenyMutationPayload>;
   refreshOrder?: Maybe<RefreshOrderMutationPayload>;
   refundReservation?: Maybe<ReservationRefundMutationPayload>;
+  rejectAllApplicationOptions?: Maybe<RejectAllApplicationOptionsMutationPayload>;
+  rejectAllSectionOptions?: Maybe<RejectAllSectionOptionsMutationPayload>;
   requireHandlingForReservation?: Maybe<ReservationRequiresHandlingMutationPayload>;
+  restoreAllApplicationOptions?: Maybe<RestoreAllApplicationOptionsMutationPayload>;
+  restoreAllSectionOptions?: Maybe<RestoreAllSectionOptionsMutationPayload>;
   sendApplication?: Maybe<ApplicationSendMutationPayload>;
   staffAdjustReservationTime?: Maybe<ReservationStaffAdjustTimeMutationPayload>;
   staffReservationModify?: Maybe<ReservationStaffModifyMutationPayload>;
@@ -1519,8 +1553,24 @@ export type MutationRefundReservationArgs = {
   input: ReservationRefundMutationInput;
 };
 
+export type MutationRejectAllApplicationOptionsArgs = {
+  input: RejectAllApplicationOptionsMutationInput;
+};
+
+export type MutationRejectAllSectionOptionsArgs = {
+  input: RejectAllSectionOptionsMutationInput;
+};
+
 export type MutationRequireHandlingForReservationArgs = {
   input: ReservationRequiresHandlingMutationInput;
+};
+
+export type MutationRestoreAllApplicationOptionsArgs = {
+  input: RestoreAllApplicationOptionsMutationInput;
+};
+
+export type MutationRestoreAllSectionOptionsArgs = {
+  input: RestoreAllSectionOptionsMutationInput;
 };
 
 export type MutationSendApplicationArgs = {
@@ -1920,6 +1970,8 @@ export type Query = {
   keywords?: Maybe<KeywordNodeConnection>;
   metadataSets?: Maybe<ReservationMetadataSetNodeConnection>;
   order?: Maybe<PaymentOrderNode>;
+  /** Get information about the user, using Helsinki profile if necessary. */
+  profileData?: Maybe<HelsinkiProfileDataNode>;
   purposes?: Maybe<PurposeNodeConnection>;
   qualifiers?: Maybe<QualifierNodeConnection>;
   recurringReservation?: Maybe<RecurringReservationNode>;
@@ -2186,6 +2238,11 @@ export type QueryMetadataSetsArgs = {
 
 export type QueryOrderArgs = {
   orderUuid: Scalars["String"]["input"];
+};
+
+export type QueryProfileDataArgs = {
+  applicationId?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationId?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryPurposesArgs = {
@@ -2684,6 +2741,24 @@ export type RefreshOrderMutationPayload = {
   orderUuid?: Maybe<Scalars["String"]["output"]>;
   reservationPk?: Maybe<Scalars["Int"]["output"]>;
   status?: Maybe<Scalars["String"]["output"]>;
+};
+
+export type RejectAllApplicationOptionsMutationInput = {
+  pk: Scalars["Int"]["input"];
+};
+
+export type RejectAllApplicationOptionsMutationPayload = {
+  __typename?: "RejectAllApplicationOptionsMutationPayload";
+  pk?: Maybe<Scalars["Int"]["output"]>;
+};
+
+export type RejectAllSectionOptionsMutationInput = {
+  pk: Scalars["Int"]["input"];
+};
+
+export type RejectAllSectionOptionsMutationPayload = {
+  __typename?: "RejectAllSectionOptionsMutationPayload";
+  pk?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type ReservableTimeSpanType = {
@@ -4518,6 +4593,24 @@ export type ResourceUpdateMutationPayload = {
   nameSv?: Maybe<Scalars["String"]["output"]>;
   pk?: Maybe<Scalars["Int"]["output"]>;
   space?: Maybe<Scalars["Int"]["output"]>;
+};
+
+export type RestoreAllApplicationOptionsMutationInput = {
+  pk: Scalars["Int"]["input"];
+};
+
+export type RestoreAllApplicationOptionsMutationPayload = {
+  __typename?: "RestoreAllApplicationOptionsMutationPayload";
+  pk?: Maybe<Scalars["Int"]["output"]>;
+};
+
+export type RestoreAllSectionOptionsMutationInput = {
+  pk: Scalars["Int"]["input"];
+};
+
+export type RestoreAllSectionOptionsMutationPayload = {
+  __typename?: "RestoreAllSectionOptionsMutationPayload";
+  pk?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type ServiceNode = Node & {

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -295,6 +295,10 @@ type ApplicationRoundNode implements Node {
   criteriaFi: String
   criteriaEn: String
   criteriaSv: String
+  notesWhenApplying: String!
+  notesWhenApplyingFi: String
+  notesWhenApplyingEn: String
+  notesWhenApplyingSv: String
   applicationPeriodBegin: DateTime!
   applicationPeriodEnd: DateTime!
   reservationPeriodBegin: Date!
@@ -1097,6 +1101,7 @@ enum GeneralPermissionChoices {
   CAN_MANAGE_PURPOSES
   CAN_MANAGE_RESERVATION_PURPOSES
   CAN_MANAGE_AGE_GROUPS
+  CAN_MANAGE_QUALIFIERS
   CAN_MANAGE_ABILITY_GROUPS
   CAN_MANAGE_RESERVATION_UNIT_TYPES
   CAN_MANAGE_EQUIPMENT_CATEGORIES
@@ -1142,6 +1147,23 @@ type GeneralRolePermissionNode implements Node {
   """The ID of the object"""
   id: ID!
   pk: Int
+}
+
+type HelsinkiProfileDataNode {
+  pk: Int!
+  firstName: String
+  lastName: String
+  email: String
+  phone: String
+  birthday: Date
+  ssn: String
+  streetAddress: String
+  postalCode: String
+  city: String
+  municipalityCode: String
+  municipalityName: String
+  loginMethod: LoginMethod
+  isStrongLogin: Boolean!
 }
 
 """An enumeration."""
@@ -1303,6 +1325,13 @@ enum LocationType {
   MOVABLE
 }
 
+"""An enumeration."""
+enum LoginMethod {
+  PROFILE
+  AD
+  OTHER
+}
+
 type Mutation {
   createApplication(input: ApplicationCreateMutationInput!): ApplicationCreateMutationPayload
   updateApplication(input: ApplicationUpdateMutationInput!): ApplicationUpdateMutationPayload
@@ -1314,6 +1343,10 @@ type Mutation {
   createAllocatedTimeslot(input: AllocatedTimeSlotCreateMutationInput!): AllocatedTimeSlotCreateMutationPayload
   deleteAllocatedTimeslot(input: AllocatedTimeSlotDeleteMutationInput!): AllocatedTimeSlotDeleteMutationPayload
   updateReservationUnitOption(input: ReservationUnitOptionUpdateMutationInput!): ReservationUnitOptionUpdateMutationPayload
+  rejectAllSectionOptions(input: RejectAllSectionOptionsMutationInput!): RejectAllSectionOptionsMutationPayload
+  restoreAllSectionOptions(input: RestoreAllSectionOptionsMutationInput!): RestoreAllSectionOptionsMutationPayload
+  rejectAllApplicationOptions(input: RejectAllApplicationOptionsMutationInput!): RejectAllApplicationOptionsMutationPayload
+  restoreAllApplicationOptions(input: RestoreAllApplicationOptionsMutationInput!): RestoreAllApplicationOptionsMutationPayload
   updateUnit(input: UnitUpdateMutationInput!): UnitUpdateMutationPayload
   createResource(input: ResourceCreateMutationInput!): ResourceCreateMutationPayload
   updateResource(input: ResourceUpdateMutationInput!): ResourceUpdateMutationPayload
@@ -2211,6 +2244,9 @@ type Query {
     id: ID!
   ): UserNode
   currentUser: UserNode
+
+  """Get information about the user, using Helsinki profile if necessary."""
+  profileData(reservationId: Int, applicationId: Int): HelsinkiProfileDataNode
   termsOfUse(
     first: Int
     last: Int
@@ -2416,6 +2452,22 @@ type RefreshOrderMutationPayload {
   orderUuid: String
   status: String
   reservationPk: Int
+}
+
+input RejectAllApplicationOptionsMutationInput {
+  pk: Int!
+}
+
+type RejectAllApplicationOptionsMutationPayload {
+  pk: Int
+}
+
+input RejectAllSectionOptionsMutationInput {
+  pk: Int!
+}
+
+type RejectAllSectionOptionsMutationPayload {
+  pk: Int
 }
 
 type ReservableTimeSpanType {
@@ -4264,6 +4316,22 @@ type ResourceUpdateMutationPayload {
   space: Int
   bufferTimeBefore: Duration
   bufferTimeAfter: Duration
+}
+
+input RestoreAllApplicationOptionsMutationInput {
+  pk: Int!
+}
+
+type RestoreAllApplicationOptionsMutationPayload {
+  pk: Int
+}
+
+input RestoreAllSectionOptionsMutationInput {
+  pk: Int!
+}
+
+type RestoreAllSectionOptionsMutationPayload {
+  pk: Int
 }
 
 type ServiceNode implements Node {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Add: mass reject buttons to application page.
- Requires: https://github.com/City-of-Helsinki/tilavarauspalvelu-core/pull/1182

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: mass reject / return reservation unit options per application. 

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3302](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3302)
- [TILA-3300](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3300)


[TILA-3302]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3300]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ