### PR TITLE
fix: check for correct user when displaying reservation

### DIFF
--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -170,6 +170,7 @@ export const GET_RESERVATION = gql`
       calendarUrl
       user {
         email
+        pk
       }
       state
       price


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Checks that the viewer is the owner of the reservation, so that reservation info can't be viewed by just anyone by typing in the url

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Make a reservation with one user, go to its page and copy the url. Log in as another user and try to view that url.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3184
