### PR TITLE
fix: use active reservations in reservation quota check

### DIFF
--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -53,6 +53,7 @@ const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
     minReservationDuration
     maxReservationDuration
     maxReservationsPerUser
+    numActiveUserReservations
     reservationsMinDaysBefore
     reservationsMaxDaysBefore
     requireReservationHandling

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -1091,7 +1091,8 @@ const ReservationUnit = ({
                             isReservationQuotaReached ? "Full" : ""
                           }`,
                           {
-                            count: userReservations?.length,
+                            count:
+                              reservationUnit.numActiveUserReservations ?? 0,
                             total: reservationUnit.maxReservationsPerUser,
                           }
                         )}

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -610,10 +610,14 @@ const ReservationUnit = ({
   const isReservationQuotaReached = useMemo(() => {
     return (
       reservationUnit?.maxReservationsPerUser != null &&
-      userReservations?.length != null &&
-      userReservations?.length >= reservationUnit?.maxReservationsPerUser
+      reservationUnit?.numActiveUserReservations != null &&
+      reservationUnit?.numActiveUserReservations >=
+        reservationUnit?.maxReservationsPerUser
     );
-  }, [reservationUnit?.maxReservationsPerUser, userReservations]);
+  }, [
+    reservationUnit?.maxReservationsPerUser,
+    reservationUnit?.numActiveUserReservations,
+  ]);
 
   const shouldDisplayApplicationRoundTimeSlots =
     !!activeApplicationRounds?.length;

--- a/packages/common/types/gql-types.ts
+++ b/packages/common/types/gql-types.ts
@@ -356,6 +356,10 @@ export type ApplicationRoundNode = Node & {
   nameEn?: Maybe<Scalars["String"]["output"]>;
   nameFi?: Maybe<Scalars["String"]["output"]>;
   nameSv?: Maybe<Scalars["String"]["output"]>;
+  notesWhenApplying: Scalars["String"]["output"];
+  notesWhenApplyingEn?: Maybe<Scalars["String"]["output"]>;
+  notesWhenApplyingFi?: Maybe<Scalars["String"]["output"]>;
+  notesWhenApplyingSv?: Maybe<Scalars["String"]["output"]>;
   pk?: Maybe<Scalars["Int"]["output"]>;
   publicDisplayBegin: Scalars["DateTime"]["output"];
   publicDisplayEnd: Scalars["DateTime"]["output"];
@@ -426,6 +430,8 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
@@ -565,7 +571,7 @@ export type ApplicationSectionNode = Node & {
 export type ApplicationSectionNodeReservationUnitOptionsArgs = {
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOptionOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-  preferredOrder?: InputMaybe<Scalars["Int"]["input"]>;
+  preferredOrder?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   reservationUnit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
 };
 
@@ -911,59 +917,6 @@ export enum CustomerTypeChoice {
   Nonprofit = "NONPROFIT",
 }
 
-/** Debugging information for the current query. */
-export type DjangoDebug = {
-  __typename?: "DjangoDebug";
-  /** Raise exceptions for this API query. */
-  exceptions?: Maybe<Array<Maybe<DjangoDebugException>>>;
-  /** Executed SQL queries for this API query. */
-  sql?: Maybe<Array<Maybe<DjangoDebugSql>>>;
-};
-
-/** Represents a single exception raised. */
-export type DjangoDebugException = {
-  __typename?: "DjangoDebugException";
-  /** The class of the exception */
-  excType: Scalars["String"]["output"];
-  /** The message of the exception */
-  message: Scalars["String"]["output"];
-  /** The stack trace */
-  stack: Scalars["String"]["output"];
-};
-
-/** Represents a single database query made to a Django managed DB. */
-export type DjangoDebugSql = {
-  __typename?: "DjangoDebugSQL";
-  /** The Django database alias (e.g. 'default'). */
-  alias: Scalars["String"]["output"];
-  /** Duration of this database query in seconds. */
-  duration: Scalars["Float"]["output"];
-  /** Postgres connection encoding if available. */
-  encoding?: Maybe<Scalars["String"]["output"]>;
-  /** Whether this database query was a SELECT. */
-  isSelect: Scalars["Boolean"]["output"];
-  /** Whether this database query took more than 10 seconds. */
-  isSlow: Scalars["Boolean"]["output"];
-  /** Postgres isolation level if available. */
-  isoLevel?: Maybe<Scalars["String"]["output"]>;
-  /** JSON encoded database query parameters. */
-  params: Scalars["String"]["output"];
-  /** The raw SQL of this query, without params. */
-  rawSql: Scalars["String"]["output"];
-  /** The actual SQL sent to this database. */
-  sql?: Maybe<Scalars["String"]["output"]>;
-  /** Start time of this database query. */
-  startTime: Scalars["Float"]["output"];
-  /** Stop time of this database query. */
-  stopTime: Scalars["Float"]["output"];
-  /** Postgres transaction ID if available. */
-  transId?: Maybe<Scalars["String"]["output"]>;
-  /** Postgres transaction status if available. */
-  transStatus?: Maybe<Scalars["String"]["output"]>;
-  /** The type of database being used (e.g. postrgesql, mysql, sqlite). */
-  vendor: Scalars["String"]["output"];
-};
-
 export type EquipmentCategoryCreateMutationInput = {
   name: Scalars["String"]["input"];
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
@@ -1141,6 +1094,7 @@ export enum GeneralPermissionChoices {
   CanManageGeneralRoles = "CAN_MANAGE_GENERAL_ROLES",
   CanManageNotifications = "CAN_MANAGE_NOTIFICATIONS",
   CanManagePurposes = "CAN_MANAGE_PURPOSES",
+  CanManageQualifiers = "CAN_MANAGE_QUALIFIERS",
   CanManageReservations = "CAN_MANAGE_RESERVATIONS",
   CanManageReservationPurposes = "CAN_MANAGE_RESERVATION_PURPOSES",
   CanManageReservationUnits = "CAN_MANAGE_RESERVATION_UNITS",
@@ -1181,6 +1135,24 @@ export type GeneralRolePermissionNode = Node & {
   id: Scalars["ID"]["output"];
   permission?: Maybe<GeneralPermissionChoices>;
   pk?: Maybe<Scalars["Int"]["output"]>;
+};
+
+export type HelsinkiProfileDataNode = {
+  __typename?: "HelsinkiProfileDataNode";
+  birthday?: Maybe<Scalars["Date"]["output"]>;
+  city?: Maybe<Scalars["String"]["output"]>;
+  email?: Maybe<Scalars["String"]["output"]>;
+  firstName?: Maybe<Scalars["String"]["output"]>;
+  isStrongLogin: Scalars["Boolean"]["output"];
+  lastName?: Maybe<Scalars["String"]["output"]>;
+  loginMethod?: Maybe<LoginMethod>;
+  municipalityCode?: Maybe<Scalars["String"]["output"]>;
+  municipalityName?: Maybe<Scalars["String"]["output"]>;
+  phone?: Maybe<Scalars["String"]["output"]>;
+  pk: Scalars["Int"]["output"];
+  postalCode?: Maybe<Scalars["String"]["output"]>;
+  ssn?: Maybe<Scalars["String"]["output"]>;
+  streetAddress?: Maybe<Scalars["String"]["output"]>;
 };
 
 /** An enumeration. */
@@ -1336,6 +1308,13 @@ export enum LocationType {
   Fixed = "FIXED",
   /** Siirrettävä */
   Movable = "MOVABLE",
+}
+
+/** An enumeration. */
+export enum LoginMethod {
+  Ad = "AD",
+  Other = "OTHER",
+  Profile = "PROFILE",
 }
 
 export type Mutation = {
@@ -1890,7 +1869,6 @@ export enum QualifierOrderingChoices {
 
 export type Query = {
   __typename?: "Query";
-  _debug?: Maybe<DjangoDebug>;
   /**
    * Return all allocations that affect allocations for given reservation unit
    * (through space hierarchy or common resource) during the given time period.
@@ -1918,6 +1896,8 @@ export type Query = {
   keywords?: Maybe<KeywordNodeConnection>;
   metadataSets?: Maybe<ReservationMetadataSetNodeConnection>;
   order?: Maybe<PaymentOrderNode>;
+  /** Get information about the user, using Helsinki profile if necessary. */
+  profileData?: Maybe<HelsinkiProfileDataNode>;
   purposes?: Maybe<PurposeNodeConnection>;
   qualifiers?: Maybe<QualifierNodeConnection>;
   recurringReservation?: Maybe<RecurringReservationNode>;
@@ -2186,6 +2166,11 @@ export type QueryOrderArgs = {
   orderUuid: Scalars["String"]["input"];
 };
 
+export type QueryProfileDataArgs = {
+  applicationId?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationId?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
 export type QueryPurposesArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>;
   before?: InputMaybe<Scalars["String"]["input"]>;
@@ -2363,6 +2348,8 @@ export type QueryReservationUnitsArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
@@ -3124,6 +3111,8 @@ export type ReservationNodeReservationUnitArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
@@ -3790,6 +3779,7 @@ export type ReservationUnitNode = Node & {
   nameEn?: Maybe<Scalars["String"]["output"]>;
   nameFi?: Maybe<Scalars["String"]["output"]>;
   nameSv?: Maybe<Scalars["String"]["output"]>;
+  numActiveUserReservations?: Maybe<Scalars["Int"]["output"]>;
   paymentMerchant?: Maybe<PaymentMerchantNode>;
   paymentProduct?: Maybe<PaymentProductNode>;
   paymentTerms?: Maybe<TermsOfUseNode>;
@@ -5022,6 +5012,8 @@ export type UnitNodeReservationunitSetArgs = {
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
+  tprekId?: InputMaybe<Scalars["String"]["input"]>;
   typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -295,6 +295,10 @@ type ApplicationRoundNode implements Node {
   criteriaFi: String
   criteriaEn: String
   criteriaSv: String
+  notesWhenApplying: String!
+  notesWhenApplyingFi: String
+  notesWhenApplyingEn: String
+  notesWhenApplyingSv: String
   applicationPeriodBegin: DateTime!
   applicationPeriodEnd: DateTime!
   reservationPeriodBegin: Date!
@@ -320,6 +324,8 @@ type ApplicationRoundNode implements Node {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal
@@ -493,7 +499,7 @@ type ApplicationSectionNode implements Node {
   ageGroup: AgeGroupNode
   reservationUnitOptions(
     pk: [Int]
-    preferredOrder: Int
+    preferredOrder: [Int]
     reservationUnit: [Int]
 
     """Järjestä"""
@@ -860,72 +866,6 @@ scalar DateTime
 """The `Decimal` scalar type represents a python Decimal."""
 scalar Decimal
 
-"""Debugging information for the current query."""
-type DjangoDebug {
-  """Executed SQL queries for this API query."""
-  sql: [DjangoDebugSQL]
-
-  """Raise exceptions for this API query."""
-  exceptions: [DjangoDebugException]
-}
-
-"""Represents a single exception raised."""
-type DjangoDebugException {
-  """The class of the exception"""
-  excType: String!
-
-  """The message of the exception"""
-  message: String!
-
-  """The stack trace"""
-  stack: String!
-}
-
-"""Represents a single database query made to a Django managed DB."""
-type DjangoDebugSQL {
-  """The type of database being used (e.g. postrgesql, mysql, sqlite)."""
-  vendor: String!
-
-  """The Django database alias (e.g. 'default')."""
-  alias: String!
-
-  """The actual SQL sent to this database."""
-  sql: String
-
-  """Duration of this database query in seconds."""
-  duration: Float!
-
-  """The raw SQL of this query, without params."""
-  rawSql: String!
-
-  """JSON encoded database query parameters."""
-  params: String!
-
-  """Start time of this database query."""
-  startTime: Float!
-
-  """Stop time of this database query."""
-  stopTime: Float!
-
-  """Whether this database query took more than 10 seconds."""
-  isSlow: Boolean!
-
-  """Whether this database query was a SELECT."""
-  isSelect: Boolean!
-
-  """Postgres transaction ID if available."""
-  transId: String
-
-  """Postgres transaction status if available."""
-  transStatus: String
-
-  """Postgres isolation level if available."""
-  isoLevel: String
-
-  """Postgres connection encoding if available."""
-  encoding: String
-}
-
 """Represents a DurationField value as an integer in seconds."""
 scalar Duration
 
@@ -1095,6 +1035,7 @@ enum GeneralPermissionChoices {
   CAN_MANAGE_PURPOSES
   CAN_MANAGE_RESERVATION_PURPOSES
   CAN_MANAGE_AGE_GROUPS
+  CAN_MANAGE_QUALIFIERS
   CAN_MANAGE_ABILITY_GROUPS
   CAN_MANAGE_RESERVATION_UNIT_TYPES
   CAN_MANAGE_EQUIPMENT_CATEGORIES
@@ -1140,6 +1081,23 @@ type GeneralRolePermissionNode implements Node {
   """The ID of the object"""
   id: ID!
   pk: Int
+}
+
+type HelsinkiProfileDataNode {
+  pk: Int!
+  firstName: String
+  lastName: String
+  email: String
+  phone: String
+  birthday: Date
+  ssn: String
+  streetAddress: String
+  postalCode: String
+  city: String
+  municipalityCode: String
+  municipalityName: String
+  loginMethod: LoginMethod
+  isStrongLogin: Boolean!
 }
 
 """An enumeration."""
@@ -1299,6 +1257,13 @@ enum LocationType {
 
   """Siirrettävä"""
   MOVABLE
+}
+
+"""An enumeration."""
+enum LoginMethod {
+  PROFILE
+  AD
+  OTHER
 }
 
 type Mutation {
@@ -1903,6 +1868,8 @@ type Query {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal
@@ -2207,6 +2174,9 @@ type Query {
     id: ID!
   ): UserNode
   currentUser: UserNode
+
+  """Get information about the user, using Helsinki profile if necessary."""
+  profileData(reservationId: Int, applicationId: Int): HelsinkiProfileDataNode
   termsOfUse(
     first: Int
     last: Int
@@ -2238,7 +2208,6 @@ type Query {
     orderBy: [BannerNotificationOrderingChoices]
   ): BannerNotificationNodeConnection
   serviceSectors(first: Int, last: Int, offset: Int, after: String, before: String): ServiceSectorNodeConnection
-  _debug: DjangoDebug
 }
 
 input RecurringReservationCreateMutationInput {
@@ -2811,6 +2780,8 @@ type ReservationNode implements Node {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal
@@ -3689,6 +3660,7 @@ type ReservationUnitNode implements Node {
   firstReservableDatetime: DateTime
   haukiUrl: String
   reservableTimeSpans(startDate: Date!, endDate: Date!): [ReservableTimeSpanType]
+  numActiveUserReservations: Int
   calculatedSurfaceArea: Int
   pk: Int
 }
@@ -4762,6 +4734,8 @@ type UnitNode implements Node {
     descriptionEn: String
     descriptionEn_Icontains: String
     pk: [Int]
+    tprekId: String
+    tprekDepartmentId: String
     unit: [Int]
     reservationUnitType: [Int]
     minPersonsGte: Decimal


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Switch to using the new `numActiveUserReservations`, which is up to date with active reservations. Corrects the problem where past reservations from today were considered as part of the reservation quota, altho they were in the past.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to a reservation unit (preferrably one with a small maximum reservation quota and minimum reservation time). Make the max amount of reservations with the first one being the next possible reservation. Wait for that first reservation to pass, and note that your reservation quota is accurate, and you can make a new reservation.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3236
