### PR TITLE
fix: show cancel button for ongoing (recurring) reservations

### DIFF
--- a/apps/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/RecurringReservationsView.tsx
@@ -79,6 +79,7 @@ function RecurringReservationsView({
   const forDisplay = reservations.map((x) => {
     const buttons = [];
     const startDate = new Date(x.begin);
+    const endDate = new Date(x.end);
     const now = new Date();
 
     if (x.state !== State.Denied) {
@@ -103,7 +104,7 @@ function RecurringReservationsView({
           />
         );
       }
-      if (startDate > now) {
+      if (endDate <= now) {
         buttons.push(
           <ReservationListButton
             key="deny"
@@ -117,7 +118,7 @@ function RecurringReservationsView({
     return {
       date: startDate,
       startTime: format(startDate, "H:mm"),
-      endTime: format(new Date(x.end), "H:mm"),
+      endTime: format(endDate, "H:mm"),
       isRemoved: x.state === "DENIED",
       buttons,
     };


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Canceling a single reservation for recurring reservations should be possible for an ongoing reservation, but not once it's over. Changed the conditions for showing the Cancel-button as specified in the ticket.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- The Cancel-button should be visible for an ongoing reservation, but hidden for already ended ones

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3253
