### PR TITLE
fix: only relevant units are shown in search filter

### DIFF
--- a/apps/ui/modules/queries/params.tsx
+++ b/apps/ui/modules/queries/params.tsx
@@ -4,11 +4,15 @@ export const SEARCH_FORM_PARAMS_UNIT = gql`
   query SearchFormParamsUnit(
     $publishedReservationUnits: Boolean
     $ownReservations: Boolean
+    $onlyDirectBookable: Boolean
+    $onlySeasonalBookable: Boolean
     $orderBy: [UnitOrderingChoices]
   ) {
     units(
       publishedReservationUnits: $publishedReservationUnits
       ownReservations: $ownReservations
+      onlyDirectBookable: $onlyDirectBookable
+      onlySeasonalBookable: $onlySeasonalBookable
       orderBy: $orderBy
     ) {
       edges {

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -90,6 +90,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     query: SEARCH_FORM_PARAMS_UNIT,
     variables: {
       publishedReservationUnits: true,
+      onlySeasonalBookable: true,
     },
   });
 

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -110,6 +110,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     query: SEARCH_FORM_PARAMS_UNIT,
     variables: {
       publishedReservationUnits: true,
+      onlyDirectBookable: true,
     },
   });
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- add the toggle to each search so only relevant units are shown in filter

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Units with only seasonal and only direct reservations available aren't shown in single and seasonal searches respectively. In lieu of exhaustively checking every unit a simple test could be to see that the unit lists in the filter should be different on each of the search pages.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3247
- TILA-3248
