### PR TITLE
fix: non admin users permissions to check birthday

### DIFF
--- a/apps/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
@@ -590,7 +590,7 @@ const RequestedReservation = ({
               />
               <ApplicationData
                 label={t("RequestedReservation.birthDate")}
-                data={<BirthDate userPk={reservation?.user?.pk ?? 0} />}
+                data={<BirthDate reservationPk={reservation?.pk ?? 0} />}
               />
               <ApplicationData
                 label={t("RequestedReservation.addressStreet")}

--- a/apps/admin-ui/src/spa/applications/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/applications/[id]/index.tsx
@@ -992,7 +992,7 @@ function ApplicationDetails({
           />
           <ValueBox
             label={t("Application.headings.userBirthDate")}
-            value={<BirthDate userPk={application.user?.pk ?? 0} />}
+            value={<BirthDate applicationPk={application.pk ?? 0} />}
           />
         </EventProps>
         <H4>{t("Application.contactPersonInformation")}</H4>


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: without `can_view_users` permission it was impossible to check the users birthday even though if you can view a reservation or an application you need to be able to check the birthday of the user that made that application / reservation.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3329](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3329)


[TILA-3329]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ