### PR TITLE
fix: ui search page incorrect purpose options

### DIFF
--- a/apps/ui/hooks/useOptions.ts
+++ b/apps/ui/hooks/useOptions.ts
@@ -29,6 +29,16 @@ export const OPTIONS_QUERY = gql`
         }
       }
     }
+    purposes {
+      edges {
+        node {
+          pk
+          nameFi
+          nameEn
+          nameSv
+        }
+      }
+    }
     reservationPurposes {
       edges {
         node {

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -74,7 +74,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     optionsData?.reservationUnitTypes?.edges?.map((edge) => edge?.node)
   );
   const purposes = filterNonNullable(
-    optionsData?.reservationPurposes?.edges?.map((edge) => edge?.node)
+    optionsData?.purposes?.edges?.map((edge) => edge?.node)
   );
 
   const reservationUnitTypeOptions = reservationUnitTypes.map((n) => ({

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -37,6 +37,10 @@ import { SEARCH_FORM_PARAMS_UNIT } from "@/modules/queries/params";
 import { getApplicationRoundName } from "@/modules/applicationRound";
 import { getUnitName } from "@/modules/reservationUnit";
 import { OPTIONS_QUERY } from "@/hooks/useOptions";
+import {
+  convertLanguageCode,
+  getTranslationSafe,
+} from "common/src/common/util";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 
@@ -79,11 +83,11 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
   const reservationUnitTypeOptions = reservationUnitTypes.map((n) => ({
     value: n.pk?.toString() ?? "",
-    label: n.nameFi ?? "",
+    label: getTranslationSafe(n, "name", convertLanguageCode(locale ?? "")),
   }));
   const purposeOptions = purposes.map((n) => ({
     value: n.pk?.toString() ?? "",
-    label: n.nameFi ?? "",
+    label: getTranslationSafe(n, "name", convertLanguageCode(locale ?? "")),
   }));
 
   const { data: unitData } = await apolloClient.query<Query, QueryUnitsArgs>({
@@ -98,7 +102,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   )
     .map((node) => ({
       pk: node.pk ?? 0,
-      name: getUnitName(node) ?? "",
+      name: getUnitName(node, locale) ?? "",
     }))
     .map((node) => ({
       value: node.pk,

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -87,7 +87,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     optionsData?.reservationUnitTypes?.edges?.map((edge) => edge?.node)
   );
   const purposes = filterNonNullable(
-    optionsData?.reservationPurposes?.edges?.map((edge) => edge?.node)
+    optionsData?.purposes?.edges?.map((edge) => edge?.node)
   );
   const equipments = filterNonNullable(
     optionsData?.equipments?.edges?.map((edge) => edge?.node)

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -31,6 +31,10 @@ import { useSearchValues } from "@/hooks/useSearchValues";
 import { OPTIONS_QUERY } from "@/hooks/useOptions";
 import { SEARCH_FORM_PARAMS_UNIT } from "@/modules/queries/params";
 import { getUnitName } from "@/modules/reservationUnit";
+import {
+  convertLanguageCode,
+  getTranslationSafe,
+} from "common/src/common/util";
 
 const Wrapper = styled.div`
   margin-bottom: var(--spacing-layout-l);
@@ -95,15 +99,15 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
   const reservationUnitTypeOptions = reservationUnitTypes.map((n) => ({
     value: n.pk?.toString() ?? "",
-    label: n.nameFi ?? "",
+    label: getTranslationSafe(n, "name", convertLanguageCode(locale ?? "")),
   }));
   const purposeOptions = purposes.map((n) => ({
     value: n.pk?.toString() ?? "",
-    label: n.nameFi ?? "",
+    label: getTranslationSafe(n, "name", convertLanguageCode(locale ?? "")),
   }));
   const equipmentsOptions = equipments.map((n) => ({
     value: n.pk ?? 0,
-    label: n.nameFi ?? "",
+    label: getTranslationSafe(n, "name", convertLanguageCode(locale ?? "")),
   }));
 
   const { data: unitData } = await apolloClient.query<Query, QueryUnitsArgs>({
@@ -118,7 +122,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   )
     .map((node) => ({
       pk: node.pk ?? 0,
-      name: getUnitName(node) ?? "",
+      name: getUnitName(node, locale) ?? "",
     }))
     .map((node) => ({
       value: node.pk,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: search pages (customer side) (both searches) used reservationPurpose instead of purpose.
- Fix: missing sv / en translations from the dropdown selects.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3337](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3337)


[TILA-3337]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ