### PR TITLE
fix: don't show error in unpaid notification if the time has run out

### DIFF
--- a/apps/ui/hooks/reservation.tsx
+++ b/apps/ui/hooks/reservation.tsx
@@ -116,10 +116,7 @@ export function useDeleteReservation() {
   const [mutation, { data, error, loading }] = useMutation<
     { deleteReservation: ReservationDeleteMutationPayload },
     { input: ReservationDeleteMutationInput }
-  >(DELETE_RESERVATION, {
-    // catch all thrown errors so we don't crash
-    onError: () => {},
-  });
+  >(DELETE_RESERVATION);
 
   const deleted = data?.deleteReservation.deleted ?? false;
 

--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -102,6 +102,7 @@ export const LIST_RESERVATIONS = gql`
           bufferTimeAfter
           order {
             orderUuid
+            expiresInMinutes
           }
           isBlocked
           reservationUnit {

--- a/apps/ui/public/locales/en/notification.json
+++ b/apps/ui/public/locales/en/notification.json
@@ -1,8 +1,9 @@
 {
   "waitingForPayment": {
     "title": "Your booking is waiting for payment",
-    "body": "Your booking will be cancelled automatically, if the booking won’t be paid within 20 minutes.",
+    "body": "Your booking will be cancelled automatically, if the booking won’t be paid within {{time}} minutes.",
     "cancelReservation": "Cancel booking",
+    "cancelingReservation": "Canceling booking...",
     "payReservation": "Pay",
     "reservationCancelledTitle": "Your booking has been cancelled."
   },

--- a/apps/ui/public/locales/fi/notification.json
+++ b/apps/ui/public/locales/fi/notification.json
@@ -1,8 +1,9 @@
 {
   "waitingForPayment": {
     "title": "Varauksesi odottaa maksua",
-    "body": "Varauksesi peruuntuu automaattisesti, jos maksua ei suoriteta 20 minuutin kuluessa.",
+    "body": "Varauksesi peruuntuu automaattisesti, jos maksua ei suoriteta {{time}} minuutin kuluessa.",
     "cancelReservation": "Peru varaus",
+    "cancelingReservation": "Perutaan varausta...",
     "payReservation": "Maksa varaus",
     "reservationCancelledTitle": "Varauksesi on peruttu!"
   },

--- a/apps/ui/public/locales/sv/notification.json
+++ b/apps/ui/public/locales/sv/notification.json
@@ -1,8 +1,9 @@
 {
   "waitingForPayment": {
     "title": "Din bokning väntar på betalning",
-    "body": "Din bokning annulleras automatiskt om betalning inte görs inom 20 minuter.",
+    "body": "Din bokning annulleras automatiskt om betalning inte görs inom {{time}} minuter.",
     "cancelReservation": "Avboka bokningen",
+    "cancelingReservation": "Avbokar bokningen...",
     "payReservation": "Betala",
     "reservationCancelledTitle": "Din bokning har avbokats!"
   },


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- shows the time until expiry dynamically (counting down the minutes in the front end, based on the value received in the query on page load)
- adds isLoading text to the cancel-button ("Canceling booking..."), so the button doesn't behave weirdly when in isLoading state (== have only the loading spinner as a label)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Make a reservation which requires payment, and stop the process without paying. 
- Open two duplicate tabs of the homepage 
- You should see the unpaid reservation notification banner in both of the duplicates.
- Cancel the reservation in one of them - should give you a notification that the reservation has been cancelled
- In the other tab (which still has the notification banner) click on "Cancel reservation" => this shouldn't result in any error messages, but simply reload the page.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3207
