### PR TITLE
fix: select default reservation unit in calendar

### DIFF
--- a/apps/admin-ui/src/component/my-units/ReservationUnitCalendarView.tsx
+++ b/apps/admin-ui/src/component/my-units/ReservationUnitCalendarView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { addDays, formatISO, startOfDay, subDays } from "date-fns";
 import { AutoGrid, HorisontalFlex } from "@/styles/layout";
 import { ReservationUnitCalendar } from "./ReservationUnitCalendar";
@@ -19,9 +19,14 @@ export function ReservationUnitCalendarView({
   const [reservationUnitPk, setReservationUnitPk] = useState(-1);
 
   const valueOption =
-    reservationUnitOptions.find((o) => o.value === reservationUnitPk) ??
-    reservationUnitOptions[0] ??
-    null;
+    reservationUnitOptions.find((o) => o.value === reservationUnitPk) ?? null;
+
+  // Set the first reservation unit as the default
+  useEffect(() => {
+    if (reservationUnitOptions.length > 0) {
+      setReservationUnitPk(reservationUnitOptions[0].value);
+    }
+  }, [reservationUnitOptions]);
 
   const onChange = (reservationUnits: { label: string; value: number }) => {
     setReservationUnitPk(reservationUnits.value);


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: default reservation unit was shown as selected in input component but it's reservations for it were not shown.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: my-units second tab (single reservation unit) should show reservations without changing the selection from dropdown.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
