### PR TITLE
Remove service sector

### DIFF
--- a/apps/admin-ui/src/component/Unit/UnitsTable.tsx
+++ b/apps/admin-ui/src/component/Unit/UnitsTable.tsx
@@ -34,18 +34,8 @@ function getColConfig(t: TFunction, isMyUnits?: boolean): ColumnType[] {
           {truncate(nameFi ?? "-", MAX_UNIT_NAME_LENGTH)}
         </TableLink>
       ),
-      width: "50%",
+      width: "75%",
       isSortable: true,
-    },
-    {
-      headerName: t("Units.headings.serviceSector"),
-      key: "serviceSector",
-      isSortable: false,
-      transform: (unit: UnitNode) =>
-        (unit?.serviceSectors || [])
-          .map((serviceSector) => serviceSector?.nameFi)
-          .join(","),
-      width: "25%",
     },
     {
       headerName: t("Units.headings.reservationUnitCount"),

--- a/apps/admin-ui/src/component/Unit/queries.tsx
+++ b/apps/admin-ui/src/component/Unit/queries.tsx
@@ -18,9 +18,6 @@ export const UNITS_QUERY = gql`
         node {
           nameFi
           pk
-          serviceSectors {
-            nameFi
-          }
           reservationunitSet {
             pk
           }

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -82,6 +82,7 @@ const translations: ITranslations = {
   common: {
     week: ["Viikko"],
     showMore: ["Näytä lisää"],
+    view: ["Näytä"],
     clearAllSelections: ["Tyhjennä valinnat"],
     clear: ["Tyhjennä"],
     removeValue: ["Poista arvo"],

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/ApplicationRoundCard.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/ApplicationRoundCard.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { Card, IconArrowRight, IconCalendar } from "hds-react";
 import { ApplicationRoundNode } from "common/types/gql-types";
@@ -9,6 +8,7 @@ import { formatDate } from "@/common/util";
 import { applicationRoundUrl } from "@/common/urls";
 import { ApplicationRoundStatusTag } from "./ApplicationRoundStatusTag";
 import TimeframeStatus from "./TimeframeStatus";
+import { ButtonLikeLink } from "@/component/ButtonLikeLink";
 
 interface IProps {
   applicationRound: ApplicationRoundNode;
@@ -38,7 +38,7 @@ const TitleContainer = styled.div`
 
 const Name = styled.span`
   font-size: var(--fontsize-heading-s);
-  font-family: var(--font-medium);
+  font-family: var(--font-medium), serif;
   margin-bottom: var(--spacing-2-xs);
   order: 1;
 `;
@@ -53,6 +53,13 @@ const Times = styled.div`
   @media (width > ${breakpoints.s}) {
     flex-direction: row;
     gap: var(--spacing-l);
+  }
+`;
+
+const ButtonLink = styled(ButtonLikeLink)`
+  font-weight: bold;
+  span {
+    margin-right: var(--spacing-xs);
   }
 `;
 
@@ -129,7 +136,6 @@ export function ApplicationRoundCard({
     <StyledCard>
       <Layout>
         <TitleContainer>
-          <div>{applicationRound.serviceSector?.nameFi}</div>
           <Name>{applicationRound.nameFi}</Name>
         </TitleContainer>
         <Times>
@@ -162,9 +168,10 @@ export function ApplicationRoundCard({
               })}
             />
           </Stats>
-          <Link to={applicationRoundUrl(String(applicationRound.pk))}>
-            <IconArrowRight size="l" style={{ color: "var(--color-black)" }} />
-          </Link>
+          <ButtonLink to={applicationRoundUrl(String(applicationRound.pk))}>
+            <span>{t("common.view")}</span>
+            <IconArrowRight size="l" />
+          </ButtonLink>
         </BottomContainer>
       </Layout>
     </StyledCard>

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
@@ -22,10 +22,6 @@ export const APPLICATION_ROUNDS_QUERY = gql`
           applicationsCount
           reservationUnitCount
           statusTimestamp
-          serviceSector {
-            pk
-            nameFi
-          }
         }
       }
     }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Removes the service sector references and queries
- Replace the -> with a [Näytä ->] button, in the application round card

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Log into the admin view
- Go to "Omat toimipisteet": The table has only "Toimipisteen nimi" and "Varausyksiköitä" columns (service sector is gone)
- Go to "Hakukierrokset": 
  - The cards used to have the service sector as the first bit of info, above the application name. It's removed. 
  - The link to the application used to be an "->"-icon, but it's now a "Näytä ->" button.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3197 
- TILA-3218
