### PR TITLE
Revert "fix: only relevant units are shown in search filter"

### DIFF
--- a/apps/ui/modules/queries/params.tsx
+++ b/apps/ui/modules/queries/params.tsx
@@ -4,15 +4,11 @@ export const SEARCH_FORM_PARAMS_UNIT = gql`
   query SearchFormParamsUnit(
     $publishedReservationUnits: Boolean
     $ownReservations: Boolean
-    $onlyDirectBookable: Boolean
-    $onlySeasonalBookable: Boolean
     $orderBy: [UnitOrderingChoices]
   ) {
     units(
       publishedReservationUnits: $publishedReservationUnits
       ownReservations: $ownReservations
-      onlyDirectBookable: $onlyDirectBookable
-      onlySeasonalBookable: $onlySeasonalBookable
       orderBy: $orderBy
     ) {
       edges {

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -94,7 +94,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     query: SEARCH_FORM_PARAMS_UNIT,
     variables: {
       publishedReservationUnits: true,
-      onlySeasonalBookable: true,
     },
   });
 

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -114,7 +114,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     query: SEARCH_FORM_PARAMS_UNIT,
     variables: {
       publishedReservationUnits: true,
-      onlyDirectBookable: true,
     },
   });
 


### PR DESCRIPTION
Reverts City-of-Helsinki/tilavarauspalvelu-ui#1166

Backend queries timeout in production.