### PR TITLE
fix: isReservable check failing with large interval

### DIFF
--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -294,7 +294,6 @@ export function isReservationReservable({
       reservationsMaxDaysBefore: reservationsMaxDaysBefore ?? 0,
       reservationsMinDaysBefore: reservationsMinDaysBefore ?? 0,
       activeApplicationRounds,
-      reservationStartInterval,
     })
   ) {
     return false;

--- a/packages/common/src/calendar/util.ts
+++ b/packages/common/src/calendar/util.ts
@@ -21,7 +21,7 @@ import {
   type ReservationNode,
   type ReservationUnitNode,
   ReservationKind,
-  type ReservationStartInterval,
+  ReservationStartInterval,
 } from "../../types/gql-types";
 import {
   type CalendarEventBuffer,
@@ -230,7 +230,6 @@ export const isRangeReservable = ({
   reservationsMinDaysBefore = 0,
   reservationsMaxDaysBefore = 0,
   activeApplicationRounds = [],
-  reservationStartInterval,
 }: {
   range: Date[];
   reservableTimeSpans: ReservableTimeSpanType[];
@@ -239,9 +238,12 @@ export const isRangeReservable = ({
   reservationBegins?: Date;
   reservationEnds?: Date;
   activeApplicationRounds: RoundPeriod[];
-  reservationStartInterval: ReservationStartInterval;
 }): boolean => {
-  const slots = generateSlots(range[0], range[1], reservationStartInterval);
+  const slots = generateSlots(
+    range[0],
+    range[1],
+    ReservationStartInterval.Interval_15Mins
+  );
 
   if (
     !slots.every((slot) =>


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: large reservation interval in reservation unit settings causing the `isReservable` check (used when selecting reservation time) incorrectly allowing times that are not reservable.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: selecting a time for new reservation should be more correct (resulting in no / fewer backend errors).
- Should not affect small reservation intervals, should make large intervals behave more correctly (especially if the reservation unit is closed for a small amount of time in the middle of the day).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3387](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3387)


[TILA-3387]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ