### PR TITLE
add: unit group column to Units table

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -1880,6 +1880,7 @@ export type Query = {
   taxPercentages?: Maybe<TaxPercentageNodeConnection>;
   termsOfUse?: Maybe<TermsOfUseNodeConnection>;
   unit?: Maybe<UnitNode>;
+  unitGroups?: Maybe<UnitGroupNodeConnection>;
   units?: Maybe<UnitNodeConnection>;
   user?: Maybe<UserNode>;
 };
@@ -2429,6 +2430,14 @@ export type QueryTermsOfUseArgs = {
 
 export type QueryUnitArgs = {
   id: Scalars["ID"]["input"];
+};
+
+export type QueryUnitGroupsArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryUnitsArgs = {
@@ -4907,6 +4916,22 @@ export type UnitGroupNodeUnitsArgs = {
   serviceSector?: InputMaybe<Scalars["Decimal"]["input"]>;
 };
 
+export type UnitGroupNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<UnitGroupNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `UnitGroupNode` and its cursor. */
+export type UnitGroupNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<UnitGroupNode>;
+};
+
 export type UnitNode = Node & {
   description: Scalars["String"]["output"];
   descriptionEn?: Maybe<Scalars["String"]["output"]>;
@@ -4931,6 +4956,7 @@ export type UnitNode = Node & {
   shortDescriptionSv?: Maybe<Scalars["String"]["output"]>;
   spaces: Array<SpaceNode>;
   tprekId?: Maybe<Scalars["String"]["output"]>;
+  unitGroups: Array<UnitGroupNode>;
   webPage: Scalars["String"]["output"];
 };
 
@@ -5032,6 +5058,10 @@ export enum UnitOrderingChoices {
   RankDesc = "rankDesc",
   ReservationCountAsc = "reservationCountAsc",
   ReservationCountDesc = "reservationCountDesc",
+  ReservationUnitsCountAsc = "reservationUnitsCountAsc",
+  ReservationUnitsCountDesc = "reservationUnitsCountDesc",
+  UnitGroupNameAsc = "unitGroupNameAsc",
+  UnitGroupNameDesc = "unitGroupNameDesc",
 }
 
 /** An enumeration. */
@@ -6606,6 +6636,7 @@ export type UnitsQuery = {
         id: string;
         nameFi?: string | null;
         pk?: number | null;
+        unitGroups: Array<{ id: string; nameFi?: string | null }>;
         reservationunitSet: Array<{ id: string; pk?: number | null }>;
       } | null;
     } | null>;
@@ -11001,6 +11032,10 @@ export const UnitsDocument = gql`
           id
           nameFi
           pk
+          unitGroups {
+            id
+            nameFi
+          }
           reservationunitSet {
             id
             pk

--- a/apps/admin-ui/src/component/Unit/UnitsDataLoader.tsx
+++ b/apps/admin-ui/src/component/Unit/UnitsDataLoader.tsx
@@ -79,6 +79,14 @@ function transformSortString(orderBy: string | null): UnitOrderingChoices[] {
       return [UnitOrderingChoices.NameFiAsc];
     case "-nameFi":
       return [UnitOrderingChoices.NameFiDesc];
+    case "typeFi":
+      return [UnitOrderingChoices.ReservationCountAsc];
+    case "-typeFi":
+      return [UnitOrderingChoices.ReservationCountDesc];
+    case "unitGroup":
+      return [UnitOrderingChoices.UnitGroupNameAsc];
+    case "-unitGroup":
+      return [UnitOrderingChoices.UnitGroupNameDesc];
     default:
       return [];
   }

--- a/apps/admin-ui/src/component/Unit/UnitsTable.tsx
+++ b/apps/admin-ui/src/component/Unit/UnitsTable.tsx
@@ -43,10 +43,20 @@ function getColConfig(t: TFunction, isMyUnits?: boolean): ColumnType[] {
     {
       headerName: t("Units.headings.reservationUnitCount"),
       key: "typeFi",
-      isSortable: false,
+      isSortable: true,
       transform: (unit: UnitType) => (
         <> {unit?.reservationunitSet?.length ?? 0} </>
       ),
+      width: "25%",
+    },
+    {
+      headerName: t("Units.headings.unitGroup"),
+      key: "unitGroup",
+      isSortable: true,
+      transform: (unit: UnitType) =>
+        (unit?.unitGroups || [])
+          .map((unitGroup) => unitGroup?.nameFi)
+          .join(","),
       width: "25%",
     },
   ];

--- a/apps/admin-ui/src/component/Unit/queries.tsx
+++ b/apps/admin-ui/src/component/Unit/queries.tsx
@@ -19,6 +19,10 @@ export const UNITS_QUERY = gql`
           id
           nameFi
           pk
+          unitGroups {
+            id
+            nameFi
+          }
           reservationunitSet {
             id
             pk

--- a/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/__test__/mocks.ts
+++ b/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/__test__/mocks.ts
@@ -121,6 +121,15 @@ const unitResponse: ReservationUnitNode = {
         name: "service sector",
       },
     ],
+    unitGroups: [
+      {
+        id: "1",
+        pk: 1,
+        name: "unit group",
+        nameFi: "Unit group",
+        units: [],
+      },
+    ],
   },
   metadataSet: {
     id: "1",

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -920,12 +920,12 @@ const translations: ITranslations = {
     descriptionLinkHref: ["https://asiointi.hel.fi/tprperhe/etusivu/"],
     filters: {
       nameLabel: ["Toimipisteen nimi"],
-      serviceSector: ["Palvelu"],
-      serviceSectorTag: ["Palvelu: {{value}}"],
+      unitGroup: ["Toimipisteryhmä"],
+      unitGroupTag: ["Toimipisteryhmä: {{value}}"],
     },
     headings: {
       name: ["Toimipisteen nimi"],
-      serviceSector: ["Palvelu"],
+      unitGroup: ["Toimipisteryhmä"],
       reservationUnitCount: ["Varausyksiköitä"],
     },
   },

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -1880,6 +1880,7 @@ export type Query = {
   taxPercentages?: Maybe<TaxPercentageNodeConnection>;
   termsOfUse?: Maybe<TermsOfUseNodeConnection>;
   unit?: Maybe<UnitNode>;
+  unitGroups?: Maybe<UnitGroupNodeConnection>;
   units?: Maybe<UnitNodeConnection>;
   user?: Maybe<UserNode>;
 };
@@ -2429,6 +2430,14 @@ export type QueryTermsOfUseArgs = {
 
 export type QueryUnitArgs = {
   id: Scalars["ID"]["input"];
+};
+
+export type QueryUnitGroupsArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryUnitsArgs = {
@@ -4907,6 +4916,22 @@ export type UnitGroupNodeUnitsArgs = {
   serviceSector?: InputMaybe<Scalars["Decimal"]["input"]>;
 };
 
+export type UnitGroupNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<UnitGroupNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `UnitGroupNode` and its cursor. */
+export type UnitGroupNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<UnitGroupNode>;
+};
+
 export type UnitNode = Node & {
   description: Scalars["String"]["output"];
   descriptionEn?: Maybe<Scalars["String"]["output"]>;
@@ -4931,6 +4956,7 @@ export type UnitNode = Node & {
   shortDescriptionSv?: Maybe<Scalars["String"]["output"]>;
   spaces: Array<SpaceNode>;
   tprekId?: Maybe<Scalars["String"]["output"]>;
+  unitGroups: Array<UnitGroupNode>;
   webPage: Scalars["String"]["output"];
 };
 
@@ -5032,6 +5058,10 @@ export enum UnitOrderingChoices {
   RankDesc = "rankDesc",
   ReservationCountAsc = "reservationCountAsc",
   ReservationCountDesc = "reservationCountDesc",
+  ReservationUnitsCountAsc = "reservationUnitsCountAsc",
+  ReservationUnitsCountDesc = "reservationUnitsCountDesc",
+  UnitGroupNameAsc = "unitGroupNameAsc",
+  UnitGroupNameDesc = "unitGroupNameDesc",
 }
 
 /** An enumeration. */

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -1880,6 +1880,7 @@ export type Query = {
   taxPercentages?: Maybe<TaxPercentageNodeConnection>;
   termsOfUse?: Maybe<TermsOfUseNodeConnection>;
   unit?: Maybe<UnitNode>;
+  unitGroups?: Maybe<UnitGroupNodeConnection>;
   units?: Maybe<UnitNodeConnection>;
   user?: Maybe<UserNode>;
 };
@@ -2429,6 +2430,14 @@ export type QueryTermsOfUseArgs = {
 
 export type QueryUnitArgs = {
   id: Scalars["ID"]["input"];
+};
+
+export type QueryUnitGroupsArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryUnitsArgs = {
@@ -4907,6 +4916,22 @@ export type UnitGroupNodeUnitsArgs = {
   serviceSector?: InputMaybe<Scalars["Decimal"]["input"]>;
 };
 
+export type UnitGroupNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<UnitGroupNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `UnitGroupNode` and its cursor. */
+export type UnitGroupNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<UnitGroupNode>;
+};
+
 export type UnitNode = Node & {
   description: Scalars["String"]["output"];
   descriptionEn?: Maybe<Scalars["String"]["output"]>;
@@ -4931,6 +4956,7 @@ export type UnitNode = Node & {
   shortDescriptionSv?: Maybe<Scalars["String"]["output"]>;
   spaces: Array<SpaceNode>;
   tprekId?: Maybe<Scalars["String"]["output"]>;
+  unitGroups: Array<UnitGroupNode>;
   webPage: Scalars["String"]["output"];
 };
 
@@ -5032,6 +5058,10 @@ export enum UnitOrderingChoices {
   RankDesc = "rankDesc",
   ReservationCountAsc = "reservationCountAsc",
   ReservationCountDesc = "reservationCountDesc",
+  ReservationUnitsCountAsc = "reservationUnitsCountAsc",
+  ReservationUnitsCountDesc = "reservationUnitsCountDesc",
+  UnitGroupNameAsc = "unitGroupNameAsc",
+  UnitGroupNameDesc = "unitGroupNameDesc",
 }
 
 /** An enumeration. */

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -2655,6 +2655,13 @@ type Query {
     """
     id: ID!
   ): UnitNode
+  unitGroups(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    offset: Int
+  ): UnitGroupNodeConnection
   units(
     after: String
     before: String
@@ -5552,6 +5559,32 @@ type UnitGroupNode implements Node {
   ): [UnitNode!]!
 }
 
+type UnitGroupNodeConnection {
+  """
+  Contains the nodes in this connection.
+  """
+  edges: [UnitGroupNodeEdge]!
+  """
+  Pagination data for this connection.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+"""
+A Relay edge containing a `UnitGroupNode` and its cursor.
+"""
+type UnitGroupNodeEdge {
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+  """
+  The item at the end of the edge
+  """
+  node: UnitGroupNode
+}
+
 type UnitNode implements Node {
   description: String!
   descriptionEn: String
@@ -5648,6 +5681,7 @@ type UnitNode implements Node {
     pk: [Int]
   ): [SpaceNode!]!
   tprekId: String
+  unitGroups: [UnitGroupNode!]!
   webPage: String!
 }
 
@@ -5693,6 +5727,10 @@ enum UnitOrderingChoices {
   rankDesc
   reservationCountAsc
   reservationCountDesc
+  reservationUnitsCountAsc
+  reservationUnitsCountDesc
+  unitGroupNameAsc
+  unitGroupNameDesc
 }
 
 """


### PR DESCRIPTION
## 🛠️ Changelog

These changes require that this PR 1190 is merged to the backend/core
(https://github.com/City-of-Helsinki/tilavarauspalvelu-core/pull/1190)

[//]: # "Describe the changes in this pull request here."

- Adds unit group column to UnitsTable

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to Omat toimipisteet
- Check that the table has a "Toimipisteryhmä" column
- Both "Varausyksiköitä" and "Toimipisteryhmä" should be sortable columns

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3217
