### PR TITLE
fix: incorrect enum translation

### DIFF
--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -566,7 +566,7 @@ const translations: ITranslations = {
     HANDLED: ["Hyväksytty"],
     IN_ALLOCATION: ["Käsittelyssä"],
     RESERVED: ["Varattu"],
-    UNALLOCATED: ["Ei jaettu"],
+    UNALLOCATED: ["Vastaanotettu"],
   },
   TimeSlotStatusCell: {
     declined: ["Hylätty"],


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- application section status enum translation not matching the documentation

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

-

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3388](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3388)


[TILA-3388]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ