### PR TITLE
add: notes-when-applying component

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -5685,6 +5685,9 @@ export type ApplicationQuery = {
     additionalInformation?: string | null;
     applicationRound: {
       id: string;
+      notesWhenApplyingFi?: string | null;
+      notesWhenApplyingEn?: string | null;
+      notesWhenApplyingSv?: string | null;
       pk?: number | null;
       nameFi?: string | null;
       nameSv?: string | null;
@@ -9524,6 +9527,9 @@ export const ApplicationDocument = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields

--- a/apps/ui/components/application/ApplicationPage.tsx
+++ b/apps/ui/components/application/ApplicationPage.tsx
@@ -11,16 +11,7 @@ import {
 import { useRouter } from "next/router";
 import Head from "./Head";
 import Stepper, { StepperProps } from "./Stepper";
-
-type Node = NonNullable<ApplicationQuery["application"]>;
-type ApplicationPageProps = {
-  application: Node;
-  translationKeyPrefix: string;
-  overrideText?: string;
-  isDirty?: boolean;
-  children?: React.ReactNode;
-  headContent?: React.ReactNode;
-};
+import NotesWhenApplying from "@/components/application/NotesWhenApplying";
 
 const StyledContainer = styled(Container)`
   background-color: var(--color-white);
@@ -44,8 +35,12 @@ const Main = styled.div`
   margin-top: var(--spacing-s);
 
   @media (max-width: ${breakpoints.s}) {
-    width: calc (100vw - 3 * var(--spacing-xs));
+    width: calc(100vw - 3 * var(--spacing-xs));
   }
+`;
+
+const NotesWrapper = styled.div`
+  margin-bottom: var(--spacing-m);
 `;
 
 // TODO this should have more complete checks (but we are thinking of splitting the form anyway)
@@ -87,6 +82,16 @@ function calculateCompletedStep(values: Node): 0 | 1 | 2 | 3 | 4 {
   return 0;
 }
 
+type Node = NonNullable<ApplicationQuery["application"]>;
+type ApplicationPageProps = {
+  application: Node;
+  translationKeyPrefix: string;
+  overrideText?: string;
+  isDirty?: boolean;
+  children?: React.ReactNode;
+  headContent?: React.ReactNode;
+};
+
 export function ApplicationPageWrapper({
   application,
   translationKeyPrefix,
@@ -118,7 +123,14 @@ export function ApplicationPageWrapper({
       <StyledContainer>
         <InnerContainer $hideStepper={hideStepper}>
           {hideStepper ? <div /> : <Stepper {...steps} />}
-          <Main>{children}</Main>
+          <Main>
+            <NotesWrapper>
+              <NotesWhenApplying
+                applicationRound={application?.applicationRound ?? null}
+              />
+            </NotesWrapper>
+            {children}
+          </Main>
         </InnerContainer>
       </StyledContainer>
     </>

--- a/apps/ui/components/application/NotesWhenApplying.tsx
+++ b/apps/ui/components/application/NotesWhenApplying.tsx
@@ -28,7 +28,10 @@ const NotesBoxHeading = styled.h3`
 `;
 
 type NotesWhenApplyingProps = {
-  applicationRound: ApplicationRoundNode | null;
+  applicationRound: Pick<
+    ApplicationRoundNode,
+    "notesWhenApplyingFi" | "notesWhenApplyingSv" | "notesWhenApplyingEn"
+  > | null;
 };
 
 const NotesWhenApplying = ({ applicationRound }: NotesWhenApplyingProps) => {

--- a/apps/ui/components/application/NotesWhenApplying.tsx
+++ b/apps/ui/components/application/NotesWhenApplying.tsx
@@ -1,0 +1,60 @@
+import { ApplicationRoundNode } from "@gql/gql-types";
+import { useTranslation } from "next-i18next";
+import styled from "styled-components";
+import { getTranslationSafe } from "common/src/common/util";
+import { getLocalizationLang } from "common/src/helpers";
+import Sanitize from "@/components/common/Sanitize";
+import { breakpoints, fontMedium } from "common";
+
+const NotesBox = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--spacing-m);
+  box-sizing: border-box;
+  padding: var(--spacing-l);
+  background-color: var(--color-gold-light);
+  > h3 {
+    margin: 0;
+  }
+  @media (min-width: ${breakpoints.m}) {
+    width: 23em;
+  }
+`;
+
+const NotesBoxHeading = styled.h3`
+  font-size: var(--fontsize-heading-s);
+  ${fontMedium};
+  margin-top: 0;
+`;
+
+type NotesWhenApplyingProps = {
+  applicationRound: ApplicationRoundNode | null;
+};
+
+const NotesWhenApplying = ({ applicationRound }: NotesWhenApplyingProps) => {
+  const { t, i18n } = useTranslation();
+
+  if (!applicationRound) {
+    return null;
+  }
+  const translatedNotes = getTranslationSafe(
+    applicationRound,
+    "notesWhenApplying",
+    getLocalizationLang(i18n.language)
+  );
+
+  if (translatedNotes === "") {
+    return null;
+  }
+
+  return (
+    <NotesBox>
+      <NotesBoxHeading>
+        {t("applicationRound:notesWhenApplying")}
+      </NotesBoxHeading>
+      <Sanitize html={translatedNotes} />
+    </NotesBox>
+  );
+};
+
+export default NotesWhenApplying;

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5447,6 +5447,9 @@ export type ApplicationsQuery = {
           criteriaFi?: string | null;
           criteriaEn?: string | null;
           criteriaSv?: string | null;
+          notesWhenApplyingFi?: string | null;
+          notesWhenApplyingEn?: string | null;
+          notesWhenApplyingSv?: string | null;
           reservationUnits: Array<{
             id: string;
             pk?: number | null;
@@ -5517,6 +5520,9 @@ export type ApplicationRoundFieldsFragment = {
   criteriaFi?: string | null;
   criteriaEn?: string | null;
   criteriaSv?: string | null;
+  notesWhenApplyingFi?: string | null;
+  notesWhenApplyingEn?: string | null;
+  notesWhenApplyingSv?: string | null;
   reservationUnits: Array<{
     id: string;
     pk?: number | null;
@@ -5570,6 +5576,9 @@ export type ApplicationRoundsUiQuery = {
         criteriaFi?: string | null;
         criteriaEn?: string | null;
         criteriaSv?: string | null;
+        notesWhenApplyingFi?: string | null;
+        notesWhenApplyingEn?: string | null;
+        notesWhenApplyingSv?: string | null;
         reservationUnits: Array<{
           id: string;
           pk?: number | null;
@@ -7301,6 +7310,9 @@ export type ApplicationQuery = {
     additionalInformation?: string | null;
     applicationRound: {
       id: string;
+      notesWhenApplyingFi?: string | null;
+      notesWhenApplyingEn?: string | null;
+      notesWhenApplyingSv?: string | null;
       pk?: number | null;
       nameFi?: string | null;
       nameSv?: string | null;
@@ -7675,6 +7687,9 @@ export const ApplicationRoundFieldsFragmentDoc = gql`
     criteriaFi
     criteriaEn
     criteriaSv
+    notesWhenApplyingFi
+    notesWhenApplyingEn
+    notesWhenApplyingSv
     reservationUnits {
       id
       pk
@@ -10350,6 +10365,9 @@ export const ApplicationDocument = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields

--- a/apps/ui/modules/queries/applicationRound.tsx
+++ b/apps/ui/modules/queries/applicationRound.tsx
@@ -17,6 +17,9 @@ export const APPLICATION_ROUND_FRAGMENT = gql`
     criteriaFi
     criteriaEn
     criteriaSv
+    notesWhenApplyingFi
+    notesWhenApplyingEn
+    notesWhenApplyingSv
     reservationUnits {
       id
       pk

--- a/apps/ui/pages/criteria/[id].tsx
+++ b/apps/ui/pages/criteria/[id].tsx
@@ -8,7 +8,7 @@ import {
   type ApplicationRoundsUiQuery,
   type ApplicationRoundsUiQueryVariables,
 } from "@gql/gql-types";
-import { Container } from "common";
+import { breakpoints, Container } from "common";
 import { createApolloClient } from "@/modules/apolloClient";
 import Sanitize from "@/components/common/Sanitize";
 import KorosDefault from "@/components/common/KorosDefault";
@@ -16,6 +16,7 @@ import { getTranslation } from "@/modules/util";
 import BreadcrumbWrapper from "@/components/common/BreadcrumbWrapper";
 import { getApplicationRoundName } from "@/modules/applicationRound";
 import { getCommonServerSideProps } from "@/modules/serverUtils";
+import NotesWhenApplying from "@/components/application/NotesWhenApplying";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 
@@ -64,10 +65,22 @@ const H1 = styled.h1`
   font-size: var(--fontsize-heading-l);
 `;
 
+const ContentWrapper = styled.div`
+  display: flex;
+  gap: var(--spacing-m);
+  @media (max-width: ${breakpoints.m}) {
+    flex-flow: column-reverse;
+  }
+`;
+
 const Content = styled.div`
   max-width: var(--container-width-l);
   font-family: var(--font-regular);
   font-size: var(--fontsize-body-l);
+`;
+
+const NotesWrapper = styled.div`
+  flex-grow: 1;
 `;
 
 const Criteria = ({ applicationRound }: Props): JSX.Element | null => {
@@ -91,9 +104,16 @@ const Criteria = ({ applicationRound }: Props): JSX.Element | null => {
         <KorosDefault />
       </Head>
       <Container>
-        <Content>
-          <Sanitize html={getTranslation(applicationRound, "criteria") || ""} />
-        </Content>
+        <ContentWrapper>
+          <Content>
+            <Sanitize
+              html={getTranslation(applicationRound, "criteria") || ""}
+            />
+          </Content>
+          <NotesWrapper>
+            <NotesWhenApplying applicationRound={applicationRound} />
+          </NotesWrapper>
+        </ContentWrapper>
       </Container>
     </>
   );

--- a/apps/ui/public/locales/en/applicationRound.json
+++ b/apps/ui/public/locales/en/applicationRound.json
@@ -8,5 +8,6 @@
     "past": "Application round closed {{closingDate, d.M.yyyy',' H.mm}}",
     "reservationPeriod": "Spaces can be booked for the period {{reservationPeriodBegin, d.M.yyyy}} - {{reservationPeriodEnd, d.M.yyyy}}"
   },
-  "criteria": "application criteria"
+  "criteria": "application criteria",
+  "notesWhenApplying": "Please note when applying"
 }

--- a/apps/ui/public/locales/en/reservations.json
+++ b/apps/ui/public/locales/en/reservations.json
@@ -71,7 +71,7 @@
   "contactEmail": "Contact person’s e-mail address",
   "saveToCalendar": "Save to calendar",
   "downloadReceipt": "Download receipt",
-  "reservationInfoBoxHeading": "Please note before booking",
+  "reservationInfoBoxHeading": "Please note when booking",
   "steps": {
     "1": "Booking details",
     "2": "Review",

--- a/apps/ui/public/locales/fi/applicationRound.json
+++ b/apps/ui/public/locales/fi/applicationRound.json
@@ -8,5 +8,6 @@
     "past": "Haku sulkeutui {{closingDate, d.M.yyyy 'klo' H.mm}}",
     "reservationPeriod": "Tilat varattavissa ajalle {{reservationPeriodBegin, d.M.yyyy}} - {{reservationPeriodEnd, d.M.yyyy}}"
   },
-  "criteria": "hakuehdot"
+  "criteria": "hakuehdot",
+  "notesWhenApplying": "Huomioi hakiessa"
 }

--- a/apps/ui/public/locales/sv/applicationRound.json
+++ b/apps/ui/public/locales/sv/applicationRound.json
@@ -8,5 +8,6 @@
     "past": "Ansökningsperioden stängdes {{closingDate, d.M.yyyy 'kl' H.mm}}",
     "reservationPeriod": "Lokaler kan bokas för perioden {{reservationPeriodBegin, d.M.yyyy}} - {{reservationPeriodEnd, d.M.yyyy}}"
   },
-  "criteria": "ansökningsvillkor"
+  "criteria": "ansökningsvillkor",
+  "notesWhenApplying": "Observera när du ansöker"
 }

--- a/apps/ui/public/locales/sv/reservations.json
+++ b/apps/ui/public/locales/sv/reservations.json
@@ -69,7 +69,7 @@
   "contactEmail": "Kontaktpersonens e-post",
   "saveToCalendar": "Spara i kalender",
   "downloadReceipt": "Ladda ner kvitto",
-  "reservationInfoBoxHeading": "Observera innan du bokar",
+  "reservationInfoBoxHeading": "Observera när du bokar",
   "steps": {
     "1": "Bokningsuppgifter",
     "2": "Granskning",

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -5685,6 +5685,9 @@ export type ApplicationQuery = {
     additionalInformation?: string | null;
     applicationRound: {
       id: string;
+      notesWhenApplyingFi?: string | null;
+      notesWhenApplyingEn?: string | null;
+      notesWhenApplyingSv?: string | null;
       pk?: number | null;
       nameFi?: string | null;
       nameSv?: string | null;
@@ -6400,6 +6403,9 @@ export const ApplicationDocument = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields

--- a/packages/common/src/queries/application.tsx
+++ b/packages/common/src/queries/application.tsx
@@ -220,6 +220,9 @@ export const APPLICATION_QUERY = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds a component which displays the `notesWhenApplying`, translated (defaulting to Finnish), if it's set. If an application round doesn't have any `notesWhenApplying`, nothing is shown.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Log in to Django (`notesWhenApplying` can't be set elsewhere)
- For an application round (which is open for application), set `notesWhenApplyingFi` and `notesWhenApplyingEn` while leaving `notesWhenApplyingSv` empty.
- Go to "Kausivaraus"
- For the application round in question, behind the "Tutustu hakuohjeisiin"-link there should be a "Huomioi hakiessa" box as per the design.
- Make an application for that same application round, and go view the application you just made ("Omat hakemukset" in the profile menu). It should also feature the "Huomioi hakiessa" box.
- Switching the language to English should be reflected in said box. As long as `notesWhenApplyingSv` was left empty switching the language to Swedish should show the Finnish translation as fallback (the box heading is always translated).
- For an application round where none of the translations are set in Django, there shouldn't be any extra boxes.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3285
