### PR TITLE
Add onlyWithPermissions-filter to application rounds query

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -15436,7 +15436,7 @@ export type AllocatedTimeSlotsQueryResult = Apollo.QueryResult<
 >;
 export const ApplicationRoundsDocument = gql`
   query ApplicationRounds {
-    applicationRounds {
+    applicationRounds(onlyWithPermissions: true) {
       edges {
         node {
           ...ApplicationRoundBase

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
@@ -14,7 +14,7 @@ const APPLICATION_ROUND_BASE_FRAGMENT = gql`
 export const APPLICATION_ROUNDS_QUERY = gql`
   ${APPLICATION_ROUND_BASE_FRAGMENT}
   query ApplicationRounds {
-    applicationRounds {
+    applicationRounds(onlyWithPermissions: true) {
       edges {
         node {
           ...ApplicationRoundBase


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- uses `onlyWithPermissions`-filter in the application round query, so that the user is only shown the application rounds to which they have proper permissions.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that the "Hakukierrokset" listing only shows appropriate application rounds. Probably best done by checking the application round listing as two users with differing permissions.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3196
