### PR TITLE
Fix reservation funnel error handling

### DIFF
--- a/apps/ui/components/common/ControlledDateInput.tsx
+++ b/apps/ui/components/common/ControlledDateInput.tsx
@@ -6,7 +6,7 @@ import {
   type UseControllerProps,
   useController,
 } from "react-hook-form";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 interface ControllerProps<T extends FieldValues> extends UseControllerProps<T> {
   error?: string;

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/modules/util";
 import { reservationUnitPath } from "@/modules/const";
 import { getImageSource } from "common/src/helpers";
+import ClientOnly from "common/src/ClientOnly";
 
 type Type = "pending" | "confirmed" | "complete";
 
@@ -180,47 +181,50 @@ export function ReservationInfoCard({
     ? reservationUnitPath(reservationUnit.pk)
     : "";
 
+  // Have to make client only because date formatting doesn't work on server side
   return (
-    <Wrapper $type={type}>
-      <MainImage src={imgSrc} alt={name} />
-      <Content data-testid="reservation__reservation-info-card__content">
-        <Heading>
-          <StyledLink
-            data-testid="reservation__reservation-info-card__reservationUnit"
-            href={link}
-          >
-            {name}
-          </StyledLink>
-        </Heading>
-        {["confirmed", "complete"].includes(type) && (
+    <ClientOnly>
+      <Wrapper $type={type}>
+        <MainImage src={imgSrc} alt={name} />
+        <Content data-testid="reservation__reservation-info-card__content">
+          <Heading>
+            <StyledLink
+              data-testid="reservation__reservation-info-card__reservationUnit"
+              href={link}
+            >
+              {name}
+            </StyledLink>
+          </Heading>
+          {["confirmed", "complete"].includes(type) && (
+            <Subheading>
+              {t("reservations:reservationNumber")}:{" "}
+              <span data-testid="reservation__reservation-info-card__reservationNumber">
+                {reservation.pk ?? "-"}
+              </span>
+            </Subheading>
+          )}
           <Subheading>
-            {t("reservations:reservationNumber")}:{" "}
-            <span data-testid="reservation__reservation-info-card__reservationNumber">
-              {reservation.pk ?? "-"}
-            </span>
+            {reservationUnit.unit != null
+              ? getTranslation(reservationUnit.unit, "name")
+              : "-"}
           </Subheading>
-        )}
-        <Subheading>
-          {reservationUnit.unit != null
-            ? getTranslation(reservationUnit.unit, "name")
-            : "-"}
-        </Subheading>
-        <Value data-testid="reservation__reservation-info-card__duration">
-          <Strong>
-            {capitalize(timeString)}, {formatDuration(duration, t)}
-          </Strong>
-        </Value>
-        <Value data-testid="reservation__reservation-info-card__price">
-          {t("reservationUnit:price")}: <Strong>{price}</Strong>{" "}
-          {taxPercentageValue &&
-            shouldDisplayTaxPercentage &&
-            `(${t("common:inclTax", {
-              taxPercentage: formatters.strippedDecimal.format(
-                parseFloat(taxPercentageValue)
-              ),
-            })})`}
-        </Value>
-      </Content>
-    </Wrapper>
+          <Value data-testid="reservation__reservation-info-card__duration">
+            <Strong>
+              {capitalize(timeString)}, {formatDuration(duration, t)}
+            </Strong>
+          </Value>
+          <Value data-testid="reservation__reservation-info-card__price">
+            {t("reservationUnit:price")}: <Strong>{price}</Strong>{" "}
+            {taxPercentageValue &&
+              shouldDisplayTaxPercentage &&
+              `(${t("common:inclTax", {
+                taxPercentage: formatters.strippedDecimal.format(
+                  parseFloat(taxPercentageValue)
+                ),
+              })})`}
+          </Value>
+        </Content>
+      </Wrapper>
+    </ClientOnly>
   );
 }

--- a/packages/common/src/components/form/ControlledNumberInput.tsx
+++ b/packages/common/src/components/form/ControlledNumberInput.tsx
@@ -5,7 +5,7 @@ import {
   Controller,
   UseControllerProps,
 } from "react-hook-form";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 interface ControllerProps<T extends FieldValues> extends UseControllerProps<T> {
   min?: number;

--- a/packages/common/src/components/form/DateTimeInput.tsx
+++ b/packages/common/src/components/form/DateTimeInput.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DateInput } from "hds-react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import {
   useController,

--- a/packages/common/src/reservation-form/MetaFields.tsx
+++ b/packages/common/src/reservation-form/MetaFields.tsx
@@ -12,7 +12,7 @@ import { IconGroup, IconUser } from "hds-react";
 import React, { Fragment } from "react";
 import styled from "styled-components";
 import { Controller, useFormContext } from "react-hook-form";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { camelCase } from "lodash";
 import { CustomerTypeChoice, MetadataSetsFragment } from "../../gql/gql-types";
 import ReservationFormField from "./ReservationFormField";

--- a/packages/common/src/reservation-form/ReservationFormField.tsx
+++ b/packages/common/src/reservation-form/ReservationFormField.tsx
@@ -7,7 +7,7 @@ import {
   FieldValues,
   useFormContext,
 } from "react-hook-form";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { fontMedium, fontRegular, Strongish } from "../common/typography";
 import { CustomerTypeChoice } from "../../gql/gql-types";


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: navigating to the reservation funnel when reservation is not new returned a 400 error breaking things like "back" button.
- Existing reservations are redirected to the reservation page instead (including `WaitingForPayment`).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: try to break the reservation funnel.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3414](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3414)


[TILA-3414]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ