### PR TITLE
fix: add default values to base64encodes

### DIFF
--- a/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
+++ b/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
@@ -168,7 +168,7 @@ const MyUnitRecurringReservationForm = ({ reservationUnits }: Props) => {
   const selectedReservationUnit = watch("reservationUnit");
 
   const reservationUnitPk = selectedReservationUnit?.value;
-  const id = base64encode(`ReservationUnitNode:${reservationUnitPk}`);
+  const id = base64encode(`ReservationUnitNode:${reservationUnitPk ?? 0}`);
   const isValid = reservationUnitPk > 0;
   const { data: queryData } = useReservationUnitQuery({
     variables: { id },

--- a/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
+++ b/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
@@ -363,7 +363,7 @@ function CreateReservationModal({
   const { t } = useTranslation();
 
   const isPkValid = pk > 0;
-  const id = base64encode(`ReservationUnitNode:${pk}`);
+  const id = base64encode(`ReservationUnitNode:${pk ?? 0}`);
   const { data, loading } = useReservationUnitQuery({
     variables: { id },
     skip: !isPkValid,

--- a/apps/ui/pages/reservations/[id]/edit.tsx
+++ b/apps/ui/pages/reservations/[id]/edit.tsx
@@ -51,7 +51,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
     const resUnitPk = reservation?.reservationUnit?.[0]?.pk;
     const id = resUnitPk
-      ? base64encode(`ReservationUnitNode:${resUnitPk}`)
+      ? base64encode(`ReservationUnitNode:${resUnitPk ?? 0}`)
       : "";
     const { data: reservationUnitData } = await client.query<
       ReservationUnitPageQuery,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Sometimes the front attempts a query with `ReservationUnitNode:undefined`. This attempts to fix that issue, by adding fallbacks to `pk` when attempting to `base64encode()` the query name (using `0` as fallback).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- This is hard to test, as it's not known exactly what causes the bug to appear. Now the code _shouldn't_ be able to ever attempt to base64encode `ReservationUnitNode:undefined`, as all references now default to `ReservationUnitNode:0`.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3346
