### PR TITLE
fix: missing free of charge reason in summary

### DIFF
--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5919,6 +5919,7 @@ export type ReservationQuery = {
     pk?: number | null;
     name?: string | null;
     applyingForFreeOfCharge?: boolean | null;
+    freeOfChargeReason?: string | null;
     bufferTimeBefore: number;
     bufferTimeAfter: number;
     begin: string;
@@ -9382,6 +9383,7 @@ export const ReservationDocument = gql`
       ...ReserveeBillingFields
       ...ReservationInfo
       applyingForFreeOfCharge
+      freeOfChargeReason
       bufferTimeBefore
       bufferTimeAfter
       begin

--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -162,6 +162,7 @@ export const GET_RESERVATION = gql`
       ...ReserveeBillingFields
       ...ReservationInfo
       applyingForFreeOfCharge
+      freeOfChargeReason
       bufferTimeBefore
       bufferTimeAfter
       begin


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: Reservation summary page (step2) didn't show the reason user added when applying for a free of charge (only that the user applied for it).
- The field was missing in GQL query, and it's not caught with the type checker because metafields are dynamically constructed from strings and retrieved from the Record, not directly addressed from the query object.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: summary page should now include the reason user inputted (and should not if none was applied for).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
