### PR TITLE
fix: show correct amount of applications in main menu

### DIFF
--- a/apps/admin-ui/src/common/queries.tsx
+++ b/apps/admin-ui/src/common/queries.tsx
@@ -129,7 +129,7 @@ export const HANDLING_COUNT_QUERY = gql`
     reservations(
       state: "REQUIRES_HANDLING"
       beginDate: $beginDate
-      onlyWithPermission: true
+      onlyWithHandlingPermission: true
     ) {
       edges {
         node {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- use onlyWithHandlingPermission instead of onlyWithPermission, when determining the application count shown in the orange dot in the main menu, next to "Varaustoiveet"

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- The number should now correspond to the correct amount, as specified in the Jira-ticket (TILA-3351)

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3351
