### PR TITLE
fix: double anchor in breadcrumb

### DIFF
--- a/apps/ui/components/common/BreadcrumbWrapper.tsx
+++ b/apps/ui/components/common/BreadcrumbWrapper.tsx
@@ -25,9 +25,7 @@ const Wrapper = styled.div`
 
 // Breadcrumbs are shared with admin ui which uses react-router which requires an anchor elem
 const LinkWrapper = (props: LinkProps & { children?: React.ReactNode }) => (
-  <Link legacyBehavior {...props}>
-    {props.children}
-  </Link>
+  <Link {...props}>{props.children}</Link>
 );
 
 const BreadcrumbWrapper = ({

--- a/packages/common/src/breadcrumb/Breadcrumb.tsx
+++ b/packages/common/src/breadcrumb/Breadcrumb.tsx
@@ -52,7 +52,7 @@ const Item = styled.div`
   max-width: 100%;
 `;
 
-const Anchor = styled.a<{ $current?: boolean; $isMobile?: boolean }>`
+const Anchor = styled.span<{ $current?: boolean; $isMobile?: boolean }>`
   &&& {
     ${({ $current }) => {
       switch ($current) {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: Admin remove double `<a>` from the breadcrumb links. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: breadcrumb links work in both apps.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
