### PR TITLE
Fix permission check deny buttons

### DIFF
--- a/apps/admin-ui/src/spa/applications/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/applications/[id]/index.tsx
@@ -17,7 +17,10 @@ import { type TFunction } from "i18next";
 import { H2, H4, H5, Strong } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import { base64encode, filterNonNullable } from "common/src/helpers";
-import { getValidationErrors } from "common/src/apolloUtils";
+import {
+  getPermissionErrors,
+  getValidationErrors,
+} from "common/src/apolloUtils";
 import {
   ApplicationStatusChoice,
   ApplicantTypeChoice,
@@ -379,7 +382,9 @@ function RejectOptionButton({
       refetch();
     } catch (err) {
       const mutationErrors = getValidationErrors(err);
-      if (mutationErrors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (mutationErrors.length > 0) {
         // TODO handle other codes also
         const isInvalidState = mutationErrors.find(
           (e) => e.code === "invalid" && e.field === "rejected"
@@ -393,6 +398,7 @@ function RejectOptionButton({
           notifyError(t("errors.formValidationError", { message }));
         }
       } else {
+        // TODO this translation is missing
         notifyError(t("errors.errorRejectingOption"));
       }
     }
@@ -477,7 +483,9 @@ function RejectAllOptionsButton({
       refetch();
     } catch (err) {
       const mutationErrors = getValidationErrors(err);
-      if (mutationErrors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (mutationErrors.length > 0) {
         // TODO handle other codes also
         const isInvalidState = mutationErrors.find(
           (e) => e.code === "CANNOT_REJECT_SECTION_OPTIONS"
@@ -491,6 +499,7 @@ function RejectAllOptionsButton({
           notifyError(t("errors.formValidationError", { message }));
         }
       } else {
+        // TODO this translation is missing
         notifyError(t("errors.errorRejectingOption"));
       }
     }
@@ -732,7 +741,9 @@ function RejectApplicationButton({
       refetch();
     } catch (err) {
       const mutationErrors = getValidationErrors(err);
-      if (mutationErrors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (mutationErrors.length > 0) {
         // TODO handle other codes also
         const isInvalidState = mutationErrors.find(
           (e) => e.code === "CANNOT_REJECT_APPLICATION_OPTIONS"

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
@@ -25,7 +25,10 @@ import { ApplicationEventDataLoader } from "./ApplicationEventDataLoader";
 import { TimeSlotDataLoader } from "./AllocatedEventDataLoader";
 import { ApolloQueryResult, gql } from "@apollo/client";
 import { useNotification } from "@/context/NotificationContext";
-import { getValidationErrors } from "common/src/apolloUtils";
+import {
+  getPermissionErrors,
+  getValidationErrors,
+} from "common/src/apolloUtils";
 import usePermission from "@/hooks/usePermission";
 import { Permission } from "@/modules/permissionHelper";
 import { isApplicationRoundInProgress } from "@/helpers";
@@ -127,7 +130,9 @@ function EndAllocation({
       }
     } catch (err) {
       const errors = getValidationErrors(err);
-      if (errors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (errors.length > 0) {
         const unhandledCode = "APPLICATION_ROUND_HAS_UNHANDLED_APPLICATIONS";
         const notInAllocationCode = "APPLICATION_ROUND_NOT_IN_ALLOCATION";
         if (errors.some((e) => e.code === unhandledCode)) {

--- a/packages/common/src/apolloUtils.ts
+++ b/packages/common/src/apolloUtils.ts
@@ -2,14 +2,15 @@ import { ApolloError } from "@apollo/client";
 import { type GraphQLErrors } from "@apollo/client/errors";
 
 type ValidationError = {
-  message: string;
+  message: string | null;
   code: string;
-  field: string;
+  field: string | null;
 };
 
-function mapGQLErrors(gqlError: GraphQLErrors[0]) {
+function mapGQLErrors(gqlError: GraphQLErrors[0]): ValidationError[] {
   const { extensions } = gqlError;
   if ("errors" in extensions && Array.isArray(extensions.errors)) {
+    // field errors
     const { errors } = extensions;
     const errs = errors.map((err: unknown) => {
       if (typeof err !== "object" || err == null) {
@@ -17,18 +18,60 @@ function mapGQLErrors(gqlError: GraphQLErrors[0]) {
       }
       if ("message" in err && "code" in err && "field" in err) {
         const { message, code, field } = err ?? {};
-        if (
-          typeof message !== "string" ||
-          typeof code !== "string" ||
-          typeof field !== "string"
-        ) {
+        if (typeof code !== "string") {
           return null;
         }
-        return { message, code, field };
+        return {
+          code,
+          message: typeof message !== "string" ? null : message,
+          field: typeof field !== "string" ? null : field,
+        };
       }
       return null;
     });
     return errs.filter((e): e is ValidationError => e != null);
+  } else if ("code" in extensions) {
+    // permission errors (non field errors)
+    const { code } = extensions;
+    if (typeof code !== "string") {
+      return [];
+    }
+    return [
+      {
+        code,
+        message: null,
+        field: null,
+      },
+    ];
+  }
+  return [];
+}
+
+const PERMISSION_ERROR_CODES = [
+  "UPDATE_PERMISSION_DENIED",
+  "CREATE_PERMISSION_DENIED",
+  "DELETE_PERMISSION_DENIED",
+  "MUTATION_PERMISSION_DENIED",
+  "NODE_PERMISSION_DENIED",
+];
+export function getPermissionErrors(error: unknown): ValidationError[] {
+  if (error == null) {
+    return [];
+  }
+
+  if (error instanceof ApolloError) {
+    const { graphQLErrors } = error;
+    if (graphQLErrors.length > 0) {
+      const hasExtension = (e: (typeof graphQLErrors)[0]) => {
+        if (e.extensions == null) {
+          return false;
+        }
+        return (
+          PERMISSION_ERROR_CODES.find((x) => x === e.extensions.code) != null
+        );
+      };
+      return graphQLErrors.filter(hasExtension).flatMap(mapGQLErrors);
+    }
   }
   return [];
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: if the user has no permission to approve a reservation unit included in the application hide the reject buttons on application page.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3328](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3328)


[TILA-3328]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ