### PR TITLE
fix: redirect instead of returning 404 on error

### DIFF
--- a/apps/ui/pages/reservations/[id]/cancel.tsx
+++ b/apps/ui/pages/reservations/[id]/cancel.tsx
@@ -14,6 +14,7 @@ import { getCommonServerSideProps } from "@/modules/serverUtils";
 import { createApolloClient } from "@/modules/apolloClient";
 import { base64encode, filterNonNullable } from "common/src/helpers";
 import { canUserCancelReservation } from "@/modules/reservation";
+import { reservationsPrefix } from "@/modules/const";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 type PropsNarrowed = Exclude<Props, { notFound: boolean }>;
@@ -61,6 +62,16 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
           ...(await serverSideTranslations(locale ?? "fi")),
           reservation: reservation ?? null,
           reasons,
+        },
+      };
+    } else if (reservation != null) {
+      return {
+        redirect: {
+          permanent: true,
+          destination: `${reservationsPrefix}/${reservation.pk}`,
+        },
+        props: {
+          notFound: true, // for prop narrowing
         },
       };
     }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Bugfix for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1227
- Fix: redirect to reservation instead of returning 404 if it can't be cancelled. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: `reservation/[id]/cancel` should give 404 when the `id` is invalid, normal page if it can be cancelled, redirect to main reservation page if it can't.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
