### PR TITLE
Fix admin table cache issues

### DIFF
--- a/apps/admin-ui/src/component/Table.tsx
+++ b/apps/admin-ui/src/component/Table.tsx
@@ -56,6 +56,9 @@ type Props = TableProps & {
 // TODO overlay and spinner for loading would be preferable over colour switching
 export const CustomTable = ({ isLoading, ...props }: Props): JSX.Element => (
   <StyledTable
+    // NOTE have to unmount on data changes because there is a bug in the Table component
+    // removing this and using sort leaves ghost elements in the table.
+    key={JSON.stringify(props.rows)}
     $headingBackground={
       isLoading ? "var(--color-black-20)" : "var(--color-black-10)"
     }

--- a/apps/admin-ui/src/component/Unit/UnitsDataLoader.tsx
+++ b/apps/admin-ui/src/component/Unit/UnitsDataLoader.tsx
@@ -79,10 +79,10 @@ function transformSortString(orderBy: string | null): UnitOrderingChoices[] {
       return [UnitOrderingChoices.NameFiAsc];
     case "-nameFi":
       return [UnitOrderingChoices.NameFiDesc];
-    case "typeFi":
-      return [UnitOrderingChoices.ReservationCountAsc];
-    case "-typeFi":
-      return [UnitOrderingChoices.ReservationCountDesc];
+    case "reservationUnitCount":
+      return [UnitOrderingChoices.ReservationUnitsCountAsc];
+    case "-reservationUnitCount":
+      return [UnitOrderingChoices.ReservationUnitsCountDesc];
     case "unitGroup":
       return [UnitOrderingChoices.UnitGroupNameAsc];
     case "-unitGroup":

--- a/apps/admin-ui/src/component/Unit/UnitsTable.tsx
+++ b/apps/admin-ui/src/component/Unit/UnitsTable.tsx
@@ -42,10 +42,10 @@ function getColConfig(t: TFunction, isMyUnits?: boolean): ColumnType[] {
     },
     {
       headerName: t("Units.headings.reservationUnitCount"),
-      key: "typeFi",
+      key: "reservationUnitCount",
       isSortable: true,
       transform: (unit: UnitType) => (
-        <> {unit?.reservationunitSet?.length ?? 0} </>
+        <>{unit?.reservationunitSet?.length ?? 0}</>
       ),
       width: "25%",
     },
@@ -56,7 +56,7 @@ function getColConfig(t: TFunction, isMyUnits?: boolean): ColumnType[] {
       transform: (unit: UnitType) =>
         (unit?.unitGroups || [])
           .map((unitGroup) => unitGroup?.nameFi)
-          .join(","),
+          .join(", "),
       width: "25%",
     },
   ];


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Bugfix: https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1194
- Fix: tables (especially units / my-units, but others as well like reservation-units) had ghost elements left when sort was changed.
- Fix: more descriptive sort key name.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: same as the original.
- Manual testing: as well test the other admin tables: all should reset cache on data change, i.e. no ghost elements from previous data.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
