### PR TITLE
fix: preview reservation unit link disabled

### DIFF
--- a/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
@@ -1565,7 +1565,7 @@ function OpeningHoursSection({
 
   const previewUrl = `${previewUrlPrefix}/${reservationUnit?.pk}?ru=${reservationUnit?.uuid}#calendar`;
   const previewDisabled =
-    previewUrlPrefix !== "" || !reservationUnit?.pk || !reservationUnit?.uuid;
+    previewUrlPrefix === "" || !reservationUnit?.pk || !reservationUnit?.uuid;
 
   // TODO refactor this to inner wrapper (so we don't have a ternary in the middle)
   return (
@@ -2095,8 +2095,9 @@ function ReservationUnitEditor({
   const previewDisabled =
     isSaving ||
     !reservationUnit?.pk ||
-    !reservationUnit?.uuid ||
-    previewUrlPrefix !== "";
+    !reservationUnit.uuid ||
+    previewUrlPrefix === "";
+
   const draftEnabled = hasChanges || !watch("isDraft");
   const publishEnabled = hasChanges || watch("isDraft");
   const archiveEnabled = watch("pk") !== 0 && !watch("isArchived");
@@ -2288,6 +2289,8 @@ function EditorWrapper({ previewUrlPrefix }: { previewUrlPrefix: string }) {
   ];
   const backLink = reservationUnitPk == null ? `/unit/${unitPk}` : undefined;
 
+  const cleanPreviewUrlPrefix = previewUrlPrefix.replace(/\/$/, "");
+
   return (
     <Wrapper>
       <BreadcrumbWrapper route={route} backLink={backLink} />
@@ -2296,7 +2299,7 @@ function EditorWrapper({ previewUrlPrefix }: { previewUrlPrefix: string }) {
         form={form}
         unitPk={unitPk}
         refetch={refetch}
-        previewUrlPrefix={previewUrlPrefix}
+        previewUrlPrefix={cleanPreviewUrlPrefix}
       />
     </Wrapper>
   );


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: incorrect condition in disabling preview reservation unit on admin edit page.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: preview button (next to save) should be enabled for all created reservation units (drafts, published etc.) and should go to the public web page (with a query param that bypasses visibility checks).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3429](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3429)

[TILA-3429]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ