### PR TITLE
refactor: Remove service sector

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -16026,7 +16026,7 @@ export type AllocatedTimeSlotsQueryResult = Apollo.QueryResult<
 >;
 export const ApplicationRoundsDocument = gql`
   query ApplicationRounds {
-    applicationRounds {
+    applicationRounds(onlyWithPermissions: true) {
       edges {
         node {
           ...ApplicationRoundBase

--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -5816,6 +5816,9 @@ export type ApplicationQuery = {
     additionalInformation?: string | null;
     applicationRound: {
       id: string;
+      notesWhenApplyingFi?: string | null;
+      notesWhenApplyingEn?: string | null;
+      notesWhenApplyingSv?: string | null;
       pk?: number | null;
       nameFi?: string | null;
       nameSv?: string | null;
@@ -9777,6 +9780,9 @@ export const ApplicationDocument = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields

--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -5626,11 +5626,6 @@ export type ApplicationRoundFragment = {
   applicationsCount?: number | null;
   reservationUnitCount?: number | null;
   statusTimestamp?: string | null;
-  serviceSector?: {
-    id: string;
-    pk?: number | null;
-    nameFi?: string | null;
-  } | null;
   reservationUnits: Array<{
     id: string;
     pk?: number | null;
@@ -5678,11 +5673,6 @@ export type ApplicationCommonFragment = {
     applicationsCount?: number | null;
     reservationUnitCount?: number | null;
     statusTimestamp?: string | null;
-    serviceSector?: {
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-    } | null;
     reservationUnits: Array<{
       id: string;
       pk?: number | null;
@@ -5848,11 +5838,6 @@ export type ApplicationQuery = {
         textFi?: string | null;
         textEn?: string | null;
         textSv?: string | null;
-      } | null;
-      serviceSector?: {
-        id: string;
-        pk?: number | null;
-        nameFi?: string | null;
       } | null;
       reservationUnits: Array<{
         id: string;
@@ -6172,11 +6157,6 @@ export type UnitNameFieldsFragment = {
   id: string;
   pk?: number | null;
   nameFi?: string | null;
-  serviceSectors: Array<{
-    id: string;
-    pk?: number | null;
-    nameFi?: string | null;
-  }>;
 };
 
 export type ApplicationSectionFragment = {
@@ -6865,11 +6845,6 @@ export type UnitViewQuery = {
       nameFi?: string | null;
       spaces: Array<{ id: string; pk?: number | null }>;
     }>;
-    serviceSectors: Array<{
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-    }>;
   } | null;
 };
 
@@ -6920,11 +6895,7 @@ export type ReservationUnitsByUnitQuery = {
           nameFi?: string | null;
           bufferTimeBefore: number;
           bufferTimeAfter: number;
-          unit?: {
-            id: string;
-            pk?: number | null;
-            serviceSectors: Array<{ id: string; pk?: number | null }>;
-          } | null;
+          unit?: { id: string; pk?: number | null } | null;
         }>;
         user?: {
           id: string;
@@ -6960,11 +6931,7 @@ export type ReservationUnitsByUnitQuery = {
       nameFi?: string | null;
       bufferTimeBefore: number;
       bufferTimeAfter: number;
-      unit?: {
-        id: string;
-        pk?: number | null;
-        serviceSectors: Array<{ id: string; pk?: number | null }>;
-      } | null;
+      unit?: { id: string; pk?: number | null } | null;
     }>;
     user?: {
       id: string;
@@ -6993,16 +6960,7 @@ export type ReservationUnitQuery = {
     authentication: Authentication;
     termsOfUseFi?: string | null;
     minPersons?: number | null;
-    unit?: {
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-      serviceSectors: Array<{
-        id: string;
-        pk?: number | null;
-        nameFi?: string | null;
-      }>;
-    } | null;
+    unit?: { id: string; pk?: number | null; nameFi?: string | null } | null;
     cancellationTerms?: {
       id: string;
       textFi?: string | null;
@@ -7089,11 +7047,7 @@ export type ReservationUnitCalendarQuery = {
         nameFi?: string | null;
         bufferTimeBefore: number;
         bufferTimeAfter: number;
-        unit?: {
-          id: string;
-          pk?: number | null;
-          serviceSectors: Array<{ id: string; pk?: number | null }>;
-        } | null;
+        unit?: { id: string; pk?: number | null } | null;
       }>;
       user?: {
         id: string;
@@ -7128,11 +7082,7 @@ export type ReservationUnitCalendarQuery = {
       nameFi?: string | null;
       bufferTimeBefore: number;
       bufferTimeAfter: number;
-      unit?: {
-        id: string;
-        pk?: number | null;
-        serviceSectors: Array<{ id: string; pk?: number | null }>;
-      } | null;
+      unit?: { id: string; pk?: number | null } | null;
     }>;
     user?: {
       id: string;
@@ -7266,16 +7216,7 @@ export type ReservationUnitFragment = {
   authentication: Authentication;
   termsOfUseFi?: string | null;
   minPersons?: number | null;
-  unit?: {
-    id: string;
-    pk?: number | null;
-    nameFi?: string | null;
-    serviceSectors: Array<{
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-    }>;
-  } | null;
+  unit?: { id: string; pk?: number | null; nameFi?: string | null } | null;
   cancellationTerms?: {
     id: string;
     textFi?: string | null;
@@ -7355,11 +7296,7 @@ export type ReservationUnitReservationsFragment = {
     nameFi?: string | null;
     bufferTimeBefore: number;
     bufferTimeAfter: number;
-    unit?: {
-      id: string;
-      pk?: number | null;
-      serviceSectors: Array<{ id: string; pk?: number | null }>;
-    } | null;
+    unit?: { id: string; pk?: number | null } | null;
   }>;
   user?: {
     id: string;
@@ -7669,16 +7606,7 @@ export type ReservationQuery = {
       authentication: Authentication;
       termsOfUseFi?: string | null;
       minPersons?: number | null;
-      unit?: {
-        id: string;
-        pk?: number | null;
-        nameFi?: string | null;
-        serviceSectors: Array<{
-          id: string;
-          pk?: number | null;
-          nameFi?: string | null;
-        }>;
-      } | null;
+      unit?: { id: string; pk?: number | null; nameFi?: string | null } | null;
       cancellationTerms?: {
         id: string;
         textFi?: string | null;
@@ -7872,18 +7800,6 @@ export type CurrentUserQuery = {
           nameFi?: string | null;
         }>;
       }>;
-    }>;
-    serviceSectorRoles: Array<{
-      id: string;
-      pk?: number | null;
-      serviceSector: { id: string; pk?: number | null; nameFi?: string | null };
-      role: {
-        id: string;
-        permissions?: Array<{
-          id: string;
-          permission?: ServiceSectorPermissionsChoices | null;
-        }> | null;
-      };
     }>;
     generalRoles: Array<{
       id: string;
@@ -9063,11 +8979,6 @@ export const ApplicationRoundFragmentDoc = gql`
     nameFi
     nameSv
     nameEn
-    serviceSector {
-      id
-      pk
-      nameFi
-    }
     reservationUnits {
       id
       pk
@@ -9434,11 +9345,6 @@ export const UnitNameFieldsFragmentDoc = gql`
     id
     pk
     nameFi
-    serviceSectors {
-      id
-      pk
-      nameFi
-    }
   }
 `;
 export const MetadataSetsFragmentDoc = gql`
@@ -9551,10 +9457,6 @@ export const ReservationUnitReservationsFragmentDoc = gql`
       unit {
         id
         pk
-        serviceSectors {
-          id
-          pk
-        }
       }
     }
     user {
@@ -13602,22 +13504,6 @@ export const CurrentUserDocument = gql`
             id
             pk
             nameFi
-          }
-        }
-      }
-      serviceSectorRoles {
-        id
-        pk
-        serviceSector {
-          id
-          pk
-          nameFi
-        }
-        role {
-          id
-          permissions {
-            id
-            permission
           }
         }
       }

--- a/apps/admin-ui/src/common/fragments.tsx
+++ b/apps/admin-ui/src/common/fragments.tsx
@@ -73,11 +73,6 @@ export const UNIT_NAME_FRAGMENT = gql`
     id
     pk
     nameFi
-    serviceSectors {
-      id
-      pk
-      nameFi
-    }
   }
 `;
 

--- a/apps/admin-ui/src/common/queries.tsx
+++ b/apps/admin-ui/src/common/queries.tsx
@@ -129,7 +129,7 @@ export const HANDLING_COUNT_QUERY = gql`
     reservations(
       state: $state
       beginDate: $beginDate
-      onlyWithPermission: true
+      onlyWithHandlingPermission: true
     ) {
       edges {
         node {

--- a/apps/admin-ui/src/component/reservations/EditPage.test.tsx
+++ b/apps/admin-ui/src/component/reservations/EditPage.test.tsx
@@ -47,12 +47,8 @@ const extendedReservation = {
       unit: {
         pk: 101,
         nameFi: "unitName",
-        serviceSectors: [
-          {
-            pk: 201,
-          },
-        ],
       },
+      serviceSectors: [],
       reservationStartInterval: "INTERVAL_15_MINS",
       metadataSet: {
         name: "metadata",

--- a/apps/admin-ui/src/component/reservations/fragments.tsx
+++ b/apps/admin-ui/src/component/reservations/fragments.tsx
@@ -94,7 +94,6 @@ export const RESERVATION_COMMON_FRAGMENT = gql`
 // TODO ReservationCommon has extra fields: [order, createdAt]
 // TODO do we still need the user here?
 // TODO what is the reservation name vs. reserveeName?
-// TODO why do we need the pk of the unit and serviceSector
 export const RESERVATIONUNIT_RESERVATIONS_FRAGMENT = gql`
   ${RESERVATION_COMMON_FRAGMENT}
   fragment ReservationUnitReservations on ReservationNode {
@@ -111,10 +110,6 @@ export const RESERVATIONUNIT_RESERVATIONS_FRAGMENT = gql`
       unit {
         id
         pk
-        serviceSectors {
-          id
-          pk
-        }
       }
     }
     user {

--- a/apps/admin-ui/src/context/queries.tsx
+++ b/apps/admin-ui/src/context/queries.tsx
@@ -36,22 +36,6 @@ export const CURRENT_USER = gql`
           }
         }
       }
-      serviceSectorRoles {
-        id
-        pk
-        serviceSector {
-          id
-          pk
-          nameFi
-        }
-        role {
-          id
-          permissions {
-            id
-            permission
-          }
-        }
-      }
       generalRoles {
         id
         pk

--- a/apps/admin-ui/src/hooks/usePermission.ts
+++ b/apps/admin-ui/src/hooks/usePermission.ts
@@ -15,7 +15,6 @@ import { filterNonNullable } from "common/src/helpers";
 export type UnitPermissionFragment =
   | {
       pk?: number | null | undefined;
-      serviceSectors?: { pk?: number | null | undefined }[] | null | undefined;
     }
   | null
   | undefined;
@@ -29,16 +28,7 @@ const hasUnitPermission = (
     return false;
   }
 
-  const serviceSectorPks =
-    unit?.serviceSectors
-      ?.map((x) => x?.pk)
-      ?.filter((x): x is number => x != null) ?? [];
-
-  const permission = baseHasPermission(user)(
-    permissionName,
-    unit.pk,
-    serviceSectorPks
-  );
+  const permission = baseHasPermission(user)(permissionName, unit.pk);
 
   return permission;
 };
@@ -50,10 +40,6 @@ export type ReservationPermissionType = {
         unit?:
           | {
               pk?: number | undefined | null;
-              serviceSectors?:
-                | { pk?: number | undefined | null }[]
-                | null
-                | undefined;
             }
           | undefined
           | null;
@@ -74,24 +60,17 @@ const hasPermission = (
   }
 
   const { unit } = reservation?.reservationUnit?.[0] ?? {};
-  const serviceSectorPks = filterNonNullable(
-    unit?.serviceSectors?.map((x) => x?.pk)
-  );
 
   const unitPk = unit?.pk ?? undefined;
 
   const permissionCheck = baseHasPermission(user);
-  const permission = permissionCheck(permissionName, unitPk, serviceSectorPks);
+  const permission = permissionCheck(permissionName, unitPk);
 
   const isUsersOwnReservation = reservation?.user?.pk === user?.pk;
 
   const ownPermissions =
     includeOwn && isUsersOwnReservation
-      ? permissionCheck(
-          Permission.CAN_CREATE_STAFF_RESERVATIONS,
-          unitPk,
-          serviceSectorPks
-        )
+      ? permissionCheck(Permission.CAN_CREATE_STAFF_RESERVATIONS, unitPk)
       : false;
 
   return permission || ownPermissions;

--- a/apps/admin-ui/src/modules/permissionHelper.test.ts
+++ b/apps/admin-ui/src/modules/permissionHelper.test.ts
@@ -17,7 +17,6 @@ const userCommon = {
   isSuperuser: false,
   unitRoles: [],
   generalRoles: [],
-  serviceSectorRoles: [],
 };
 
 const unitRole: UnitRoleNode = {
@@ -45,8 +44,9 @@ const unitRole: UnitRoleNode = {
       description: "",
       shortDescription: "",
       reservationunitSet: [],
-      serviceSectors: [],
       spaces: [],
+      serviceSectors: [],
+      unitGroups: [],
     } as UnitNode,
   ],
 };

--- a/apps/admin-ui/src/spa/applications/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/applications/[id]/index.tsx
@@ -17,7 +17,10 @@ import { type TFunction } from "i18next";
 import { H2, H4, H5, Strong } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import { base64encode, filterNonNullable } from "common/src/helpers";
-import { getValidationErrors } from "common/src/apolloUtils";
+import {
+  getPermissionErrors,
+  getValidationErrors,
+} from "common/src/apolloUtils";
 import {
   ApplicationStatusChoice,
   ApplicantTypeChoice,
@@ -379,7 +382,9 @@ function RejectOptionButton({
       refetch();
     } catch (err) {
       const mutationErrors = getValidationErrors(err);
-      if (mutationErrors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (mutationErrors.length > 0) {
         // TODO handle other codes also
         const isInvalidState = mutationErrors.find(
           (e) => e.code === "invalid" && e.field === "rejected"
@@ -393,6 +398,7 @@ function RejectOptionButton({
           notifyError(t("errors.formValidationError", { message }));
         }
       } else {
+        // TODO this translation is missing
         notifyError(t("errors.errorRejectingOption"));
       }
     }
@@ -477,7 +483,9 @@ function RejectAllOptionsButton({
       refetch();
     } catch (err) {
       const mutationErrors = getValidationErrors(err);
-      if (mutationErrors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (mutationErrors.length > 0) {
         // TODO handle other codes also
         const isInvalidState = mutationErrors.find(
           (e) => e.code === "CANNOT_REJECT_SECTION_OPTIONS"
@@ -491,6 +499,7 @@ function RejectAllOptionsButton({
           notifyError(t("errors.formValidationError", { message }));
         }
       } else {
+        // TODO this translation is missing
         notifyError(t("errors.errorRejectingOption"));
       }
     }
@@ -732,7 +741,9 @@ function RejectApplicationButton({
       refetch();
     } catch (err) {
       const mutationErrors = getValidationErrors(err);
-      if (mutationErrors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (mutationErrors.length > 0) {
         // TODO handle other codes also
         const isInvalidState = mutationErrors.find(
           (e) => e.code === "CANNOT_REJECT_APPLICATION_OPTIONS"

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
@@ -25,7 +25,10 @@ import { ApplicationEventDataLoader } from "./ApplicationEventDataLoader";
 import { TimeSlotDataLoader } from "./AllocatedEventDataLoader";
 import { ApolloQueryResult, gql } from "@apollo/client";
 import { useNotification } from "@/context/NotificationContext";
-import { getValidationErrors } from "common/src/apolloUtils";
+import {
+  getPermissionErrors,
+  getValidationErrors,
+} from "common/src/apolloUtils";
 import usePermission from "@/hooks/usePermission";
 import { Permission } from "@/modules/permissionHelper";
 import { isApplicationRoundInProgress } from "@/helpers";
@@ -127,7 +130,9 @@ function EndAllocation({
       }
     } catch (err) {
       const errors = getValidationErrors(err);
-      if (errors.length > 0) {
+      if (getPermissionErrors(err).length > 0) {
+        notifyError(t("errors.noPermission"));
+      } else if (errors.length > 0) {
         const unhandledCode = "APPLICATION_ROUND_HAS_UNHANDLED_APPLICATIONS";
         const notInAllocationCode = "APPLICATION_ROUND_NOT_IN_ALLOCATION";
         if (errors.some((e) => e.code === unhandledCode)) {

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/index.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/index.tsx
@@ -34,6 +34,10 @@ const StyledAccordion = styled(Accordion)`
   & > div > div {
     display: grid;
   }
+  {/* This is to give more space to the name-column in the previous rounds table */}
+  &.previous-rounds td:first-child {
+    width: 50%;
+  }
 `;
 
 type ApplicationRoundListType = NonNullable<
@@ -172,6 +176,7 @@ function AllApplicationRounds(): JSX.Element | null {
         />
         <StyledAccordion
           heading={t("ApplicationRound.groupLabel.previousRounds")}
+          className="previous-rounds"
         >
           <StyledHDSTable
             ariaLabelSortButtonAscending="Sorted in ascending order"
@@ -188,17 +193,11 @@ function AllApplicationRounds(): JSX.Element | null {
                     href={applicationRoundUrl(Number(applicationRound.pk))}
                   >
                     <span title={applicationRound.nameFi ?? ""}>
-                      {truncate(applicationRound.nameFi ?? "", 20)}
+                      {truncate(applicationRound.nameFi ?? "", 50)}
                     </span>
                   </TableLink>
                 ),
                 key: "nameFi",
-              },
-              {
-                headerName: t("ApplicationRound.headings.service"),
-                transform: (applicationRound: ApplicationRoundNode) =>
-                  applicationRound.serviceSector?.nameFi ?? "",
-                key: "serviceSectorName",
               },
               {
                 isSortable: true,

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/queries.tsx
@@ -14,7 +14,7 @@ const APPLICATION_ROUND_BASE_FRAGMENT = gql`
 export const APPLICATION_ROUNDS_QUERY = gql`
   ${APPLICATION_ROUND_BASE_FRAGMENT}
   query ApplicationRounds {
-    applicationRounds {
+    applicationRounds(onlyWithPermissions: true) {
       edges {
         node {
           ...ApplicationRoundBase

--- a/apps/ui/components/application/ApplicationPage.tsx
+++ b/apps/ui/components/application/ApplicationPage.tsx
@@ -11,16 +11,7 @@ import {
 import { useRouter } from "next/router";
 import Head from "./Head";
 import Stepper, { StepperProps } from "./Stepper";
-
-type Node = NonNullable<ApplicationQuery["application"]>;
-type ApplicationPageProps = {
-  application: Node;
-  translationKeyPrefix: string;
-  overrideText?: string;
-  isDirty?: boolean;
-  children?: React.ReactNode;
-  headContent?: React.ReactNode;
-};
+import NotesWhenApplying from "@/components/application/NotesWhenApplying";
 
 const StyledContainer = styled(Container)`
   background-color: var(--color-white);
@@ -44,8 +35,12 @@ const Main = styled.div`
   margin-top: var(--spacing-s);
 
   @media (max-width: ${breakpoints.s}) {
-    width: calc (100vw - 3 * var(--spacing-xs));
+    width: calc(100vw - 3 * var(--spacing-xs));
   }
+`;
+
+const NotesWrapper = styled.div`
+  margin-bottom: var(--spacing-m);
 `;
 
 // TODO this should have more complete checks (but we are thinking of splitting the form anyway)
@@ -87,6 +82,16 @@ function calculateCompletedStep(values: Node): 0 | 1 | 2 | 3 | 4 {
   return 0;
 }
 
+type Node = NonNullable<ApplicationQuery["application"]>;
+type ApplicationPageProps = {
+  application: Node;
+  translationKeyPrefix: string;
+  overrideText?: string;
+  isDirty?: boolean;
+  children?: React.ReactNode;
+  headContent?: React.ReactNode;
+};
+
 export function ApplicationPageWrapper({
   application,
   translationKeyPrefix,
@@ -118,7 +123,14 @@ export function ApplicationPageWrapper({
       <StyledContainer>
         <InnerContainer $hideStepper={hideStepper}>
           {hideStepper ? <div /> : <Stepper {...steps} />}
-          <Main>{children}</Main>
+          <Main>
+            <NotesWrapper>
+              <NotesWhenApplying
+                applicationRound={application?.applicationRound ?? null}
+              />
+            </NotesWrapper>
+            {children}
+          </Main>
         </InnerContainer>
       </StyledContainer>
     </>

--- a/apps/ui/components/application/NotesWhenApplying.tsx
+++ b/apps/ui/components/application/NotesWhenApplying.tsx
@@ -28,7 +28,10 @@ const NotesBoxHeading = styled.h3`
 `;
 
 type NotesWhenApplyingProps = {
-  applicationRound: ApplicationRoundNode | null;
+  applicationRound: Pick<
+    ApplicationRoundNode,
+    "notesWhenApplyingFi" | "notesWhenApplyingSv" | "notesWhenApplyingEn"
+  > | null;
 };
 
 const NotesWhenApplying = ({ applicationRound }: NotesWhenApplyingProps) => {

--- a/apps/ui/components/application/NotesWhenApplying.tsx
+++ b/apps/ui/components/application/NotesWhenApplying.tsx
@@ -1,0 +1,60 @@
+import { ApplicationRoundNode } from "@gql/gql-types";
+import { useTranslation } from "next-i18next";
+import styled from "styled-components";
+import { getTranslationSafe } from "common/src/common/util";
+import { getLocalizationLang } from "common/src/helpers";
+import Sanitize from "@/components/common/Sanitize";
+import { breakpoints, fontMedium } from "common";
+
+const NotesBox = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--spacing-m);
+  box-sizing: border-box;
+  padding: var(--spacing-l);
+  background-color: var(--color-gold-light);
+  > h3 {
+    margin: 0;
+  }
+  @media (min-width: ${breakpoints.m}) {
+    width: 23em;
+  }
+`;
+
+const NotesBoxHeading = styled.h3`
+  font-size: var(--fontsize-heading-s);
+  ${fontMedium};
+  margin-top: 0;
+`;
+
+type NotesWhenApplyingProps = {
+  applicationRound: ApplicationRoundNode | null;
+};
+
+const NotesWhenApplying = ({ applicationRound }: NotesWhenApplyingProps) => {
+  const { t, i18n } = useTranslation();
+
+  if (!applicationRound) {
+    return null;
+  }
+  const translatedNotes = getTranslationSafe(
+    applicationRound,
+    "notesWhenApplying",
+    getLocalizationLang(i18n.language)
+  );
+
+  if (translatedNotes === "") {
+    return null;
+  }
+
+  return (
+    <NotesBox>
+      <NotesBoxHeading>
+        {t("applicationRound:notesWhenApplying")}
+      </NotesBoxHeading>
+      <Sanitize html={translatedNotes} />
+    </NotesBox>
+  );
+};
+
+export default NotesWhenApplying;

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -7261,11 +7261,6 @@ export type ApplicationRoundFragment = {
   applicationsCount?: number | null;
   reservationUnitCount?: number | null;
   statusTimestamp?: string | null;
-  serviceSector?: {
-    id: string;
-    pk?: number | null;
-    nameFi?: string | null;
-  } | null;
   reservationUnits: Array<{
     id: string;
     pk?: number | null;
@@ -7313,11 +7308,6 @@ export type ApplicationCommonFragment = {
     applicationsCount?: number | null;
     reservationUnitCount?: number | null;
     statusTimestamp?: string | null;
-    serviceSector?: {
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-    } | null;
     reservationUnits: Array<{
       id: string;
       pk?: number | null;
@@ -7483,11 +7473,6 @@ export type ApplicationQuery = {
         textFi?: string | null;
         textEn?: string | null;
         textSv?: string | null;
-      } | null;
-      serviceSector?: {
-        id: string;
-        pk?: number | null;
-        nameFi?: string | null;
       } | null;
       reservationUnits: Array<{
         id: string;
@@ -8229,11 +8214,6 @@ export const ApplicationRoundFragmentDoc = gql`
     nameFi
     nameSv
     nameEn
-    serviceSector {
-      id
-      pk
-      nameFi
-    }
     reservationUnits {
       id
       pk

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5581,6 +5581,9 @@ export type ApplicationsQuery = {
           criteriaFi?: string | null;
           criteriaEn?: string | null;
           criteriaSv?: string | null;
+          notesWhenApplyingFi?: string | null;
+          notesWhenApplyingEn?: string | null;
+          notesWhenApplyingSv?: string | null;
           reservationUnits: Array<{
             id: string;
             pk?: number | null;
@@ -5651,6 +5654,9 @@ export type ApplicationRoundFieldsFragment = {
   criteriaFi?: string | null;
   criteriaEn?: string | null;
   criteriaSv?: string | null;
+  notesWhenApplyingFi?: string | null;
+  notesWhenApplyingEn?: string | null;
+  notesWhenApplyingSv?: string | null;
   reservationUnits: Array<{
     id: string;
     pk?: number | null;
@@ -5704,6 +5710,9 @@ export type ApplicationRoundsUiQuery = {
         criteriaFi?: string | null;
         criteriaEn?: string | null;
         criteriaSv?: string | null;
+        notesWhenApplyingFi?: string | null;
+        notesWhenApplyingEn?: string | null;
+        notesWhenApplyingSv?: string | null;
         reservationUnits: Array<{
           id: string;
           pk?: number | null;
@@ -7451,6 +7460,9 @@ export type ApplicationQuery = {
     additionalInformation?: string | null;
     applicationRound: {
       id: string;
+      notesWhenApplyingFi?: string | null;
+      notesWhenApplyingEn?: string | null;
+      notesWhenApplyingSv?: string | null;
       pk?: number | null;
       nameFi?: string | null;
       nameSv?: string | null;
@@ -7820,6 +7832,9 @@ export const ApplicationRoundFieldsFragmentDoc = gql`
     criteriaFi
     criteriaEn
     criteriaSv
+    notesWhenApplyingFi
+    notesWhenApplyingEn
+    notesWhenApplyingSv
     reservationUnits {
       id
       pk
@@ -10580,6 +10595,9 @@ export const ApplicationDocument = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields

--- a/apps/ui/modules/queries/applicationRound.tsx
+++ b/apps/ui/modules/queries/applicationRound.tsx
@@ -17,6 +17,9 @@ export const APPLICATION_ROUND_FRAGMENT = gql`
     criteriaFi
     criteriaEn
     criteriaSv
+    notesWhenApplyingFi
+    notesWhenApplyingEn
+    notesWhenApplyingSv
     reservationUnits {
       id
       pk

--- a/apps/ui/pages/criteria/[id].tsx
+++ b/apps/ui/pages/criteria/[id].tsx
@@ -8,7 +8,7 @@ import {
   type ApplicationRoundsUiQuery,
   type ApplicationRoundsUiQueryVariables,
 } from "@gql/gql-types";
-import { Container } from "common";
+import { breakpoints, Container } from "common";
 import { createApolloClient } from "@/modules/apolloClient";
 import Sanitize from "@/components/common/Sanitize";
 import KorosDefault from "@/components/common/KorosDefault";
@@ -16,6 +16,7 @@ import { getTranslation } from "@/modules/util";
 import BreadcrumbWrapper from "@/components/common/BreadcrumbWrapper";
 import { getApplicationRoundName } from "@/modules/applicationRound";
 import { getCommonServerSideProps } from "@/modules/serverUtils";
+import NotesWhenApplying from "@/components/application/NotesWhenApplying";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 
@@ -64,10 +65,22 @@ const H1 = styled.h1`
   font-size: var(--fontsize-heading-l);
 `;
 
+const ContentWrapper = styled.div`
+  display: flex;
+  gap: var(--spacing-m);
+  @media (max-width: ${breakpoints.m}) {
+    flex-flow: column-reverse;
+  }
+`;
+
 const Content = styled.div`
   max-width: var(--container-width-l);
   font-family: var(--font-regular);
   font-size: var(--fontsize-body-l);
+`;
+
+const NotesWrapper = styled.div`
+  flex-grow: 1;
 `;
 
 const Criteria = ({ applicationRound }: Props): JSX.Element | null => {
@@ -91,9 +104,16 @@ const Criteria = ({ applicationRound }: Props): JSX.Element | null => {
         <KorosDefault />
       </Head>
       <Container>
-        <Content>
-          <Sanitize html={getTranslation(applicationRound, "criteria") || ""} />
-        </Content>
+        <ContentWrapper>
+          <Content>
+            <Sanitize
+              html={getTranslation(applicationRound, "criteria") || ""}
+            />
+          </Content>
+          <NotesWrapper>
+            <NotesWhenApplying applicationRound={applicationRound} />
+          </NotesWrapper>
+        </ContentWrapper>
       </Container>
     </>
   );

--- a/apps/ui/public/locales/en/applicationRound.json
+++ b/apps/ui/public/locales/en/applicationRound.json
@@ -8,5 +8,6 @@
     "past": "Application round closed {{closingDate, d.M.yyyy',' H.mm}}",
     "reservationPeriod": "Spaces can be booked for the period {{reservationPeriodBegin, d.M.yyyy}} - {{reservationPeriodEnd, d.M.yyyy}}"
   },
-  "criteria": "application criteria"
+  "criteria": "application criteria",
+  "notesWhenApplying": "Please note when applying"
 }

--- a/apps/ui/public/locales/en/reservations.json
+++ b/apps/ui/public/locales/en/reservations.json
@@ -71,7 +71,7 @@
   "contactEmail": "Contact person’s e-mail address",
   "saveToCalendar": "Save to calendar",
   "downloadReceipt": "Download receipt",
-  "reservationInfoBoxHeading": "Please note before booking",
+  "reservationInfoBoxHeading": "Please note when booking",
   "steps": {
     "1": "Booking details",
     "2": "Review",

--- a/apps/ui/public/locales/fi/applicationRound.json
+++ b/apps/ui/public/locales/fi/applicationRound.json
@@ -8,5 +8,6 @@
     "past": "Haku sulkeutui {{closingDate, d.M.yyyy 'klo' H.mm}}",
     "reservationPeriod": "Tilat varattavissa ajalle {{reservationPeriodBegin, d.M.yyyy}} - {{reservationPeriodEnd, d.M.yyyy}}"
   },
-  "criteria": "hakuehdot"
+  "criteria": "hakuehdot",
+  "notesWhenApplying": "Huomioi hakiessa"
 }

--- a/apps/ui/public/locales/sv/applicationRound.json
+++ b/apps/ui/public/locales/sv/applicationRound.json
@@ -8,5 +8,6 @@
     "past": "Ansökningsperioden stängdes {{closingDate, d.M.yyyy 'kl' H.mm}}",
     "reservationPeriod": "Lokaler kan bokas för perioden {{reservationPeriodBegin, d.M.yyyy}} - {{reservationPeriodEnd, d.M.yyyy}}"
   },
-  "criteria": "ansökningsvillkor"
+  "criteria": "ansökningsvillkor",
+  "notesWhenApplying": "Observera när du ansöker"
 }

--- a/apps/ui/public/locales/sv/reservations.json
+++ b/apps/ui/public/locales/sv/reservations.json
@@ -69,7 +69,7 @@
   "contactEmail": "Kontaktpersonens e-post",
   "saveToCalendar": "Spara i kalender",
   "downloadReceipt": "Ladda ner kvitto",
-  "reservationInfoBoxHeading": "Observera innan du bokar",
+  "reservationInfoBoxHeading": "Observera när du bokar",
   "steps": {
     "1": "Bokningsuppgifter",
     "2": "Granskning",

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -5816,6 +5816,9 @@ export type ApplicationQuery = {
     additionalInformation?: string | null;
     applicationRound: {
       id: string;
+      notesWhenApplyingFi?: string | null;
+      notesWhenApplyingEn?: string | null;
+      notesWhenApplyingSv?: string | null;
       pk?: number | null;
       nameFi?: string | null;
       nameSv?: string | null;
@@ -6591,6 +6594,9 @@ export const ApplicationDocument = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -5626,11 +5626,6 @@ export type ApplicationRoundFragment = {
   applicationsCount?: number | null;
   reservationUnitCount?: number | null;
   statusTimestamp?: string | null;
-  serviceSector?: {
-    id: string;
-    pk?: number | null;
-    nameFi?: string | null;
-  } | null;
   reservationUnits: Array<{
     id: string;
     pk?: number | null;
@@ -5678,11 +5673,6 @@ export type ApplicationCommonFragment = {
     applicationsCount?: number | null;
     reservationUnitCount?: number | null;
     statusTimestamp?: string | null;
-    serviceSector?: {
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-    } | null;
     reservationUnits: Array<{
       id: string;
       pk?: number | null;
@@ -5848,11 +5838,6 @@ export type ApplicationQuery = {
         textFi?: string | null;
         textEn?: string | null;
         textSv?: string | null;
-      } | null;
-      serviceSector?: {
-        id: string;
-        pk?: number | null;
-        nameFi?: string | null;
       } | null;
       reservationUnits: Array<{
         id: string;
@@ -6200,11 +6185,6 @@ export const ApplicationRoundFragmentDoc = gql`
     nameFi
     nameSv
     nameEn
-    serviceSector {
-      id
-      pk
-      nameFi
-    }
     reservationUnits {
       id
       pk

--- a/packages/common/src/apolloUtils.ts
+++ b/packages/common/src/apolloUtils.ts
@@ -2,14 +2,15 @@ import { ApolloError } from "@apollo/client";
 import { type GraphQLErrors } from "@apollo/client/errors";
 
 type ValidationError = {
-  message: string;
+  message: string | null;
   code: string;
-  field: string;
+  field: string | null;
 };
 
-function mapGQLErrors(gqlError: GraphQLErrors[0]) {
+function mapGQLErrors(gqlError: GraphQLErrors[0]): ValidationError[] {
   const { extensions } = gqlError;
   if ("errors" in extensions && Array.isArray(extensions.errors)) {
+    // field errors
     const { errors } = extensions;
     const errs = errors.map((err: unknown) => {
       if (typeof err !== "object" || err == null) {
@@ -17,18 +18,60 @@ function mapGQLErrors(gqlError: GraphQLErrors[0]) {
       }
       if ("message" in err && "code" in err && "field" in err) {
         const { message, code, field } = err ?? {};
-        if (
-          typeof message !== "string" ||
-          typeof code !== "string" ||
-          typeof field !== "string"
-        ) {
+        if (typeof code !== "string") {
           return null;
         }
-        return { message, code, field };
+        return {
+          code,
+          message: typeof message !== "string" ? null : message,
+          field: typeof field !== "string" ? null : field,
+        };
       }
       return null;
     });
     return errs.filter((e): e is ValidationError => e != null);
+  } else if ("code" in extensions) {
+    // permission errors (non field errors)
+    const { code } = extensions;
+    if (typeof code !== "string") {
+      return [];
+    }
+    return [
+      {
+        code,
+        message: null,
+        field: null,
+      },
+    ];
+  }
+  return [];
+}
+
+const PERMISSION_ERROR_CODES = [
+  "UPDATE_PERMISSION_DENIED",
+  "CREATE_PERMISSION_DENIED",
+  "DELETE_PERMISSION_DENIED",
+  "MUTATION_PERMISSION_DENIED",
+  "NODE_PERMISSION_DENIED",
+];
+export function getPermissionErrors(error: unknown): ValidationError[] {
+  if (error == null) {
+    return [];
+  }
+
+  if (error instanceof ApolloError) {
+    const { graphQLErrors } = error;
+    if (graphQLErrors.length > 0) {
+      const hasExtension = (e: (typeof graphQLErrors)[0]) => {
+        if (e.extensions == null) {
+          return false;
+        }
+        return (
+          PERMISSION_ERROR_CODES.find((x) => x === e.extensions.code) != null
+        );
+      };
+      return graphQLErrors.filter(hasExtension).flatMap(mapGQLErrors);
+    }
   }
   return [];
 }

--- a/packages/common/src/queries/application.tsx
+++ b/packages/common/src/queries/application.tsx
@@ -157,11 +157,6 @@ const APPLICATION_ROUND_FRAGMENT = gql`
     nameFi
     nameSv
     nameEn
-    serviceSector {
-      id
-      pk
-      nameFi
-    }
     reservationUnits {
       id
       pk

--- a/packages/common/src/queries/application.tsx
+++ b/packages/common/src/queries/application.tsx
@@ -215,6 +215,9 @@ export const APPLICATION_QUERY = gql`
       ...ApplicationCommon
       applicationRound {
         id
+        notesWhenApplyingFi
+        notesWhenApplyingEn
+        notesWhenApplyingSv
         termsOfUse {
           id
           ...TermsOfUseFields


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Removes all traces of service sector (and derivatives) from the tilavarauspalvelu-ui codebase.
- Once service sector is removed from the back end, we need to do run `codegen` to remove the references in the auto-generated gql files.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Do a search for any reference to "serviceSector" in the codebase, and note that all results are from generated files (`tilavaraus.graphql` and various `gql-types.ts`)

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3389
- TILA-3390
