### PR TITLE
fix: application section statuses updated

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -344,6 +344,7 @@ export type ApplicationRoundNode = Node & {
   handledDate?: Maybe<Scalars["DateTime"]["output"]>;
   /** The ID of the object */
   id: Scalars["ID"]["output"];
+  isSettingHandledAllowed?: Maybe<Scalars["Boolean"]["output"]>;
   name: Scalars["String"]["output"];
   nameEn?: Maybe<Scalars["String"]["output"]>;
   nameFi?: Maybe<Scalars["String"]["output"]>;
@@ -356,6 +357,7 @@ export type ApplicationRoundNode = Node & {
   publicDisplayBegin: Scalars["DateTime"]["output"];
   publicDisplayEnd: Scalars["DateTime"]["output"];
   purposes: Array<ReservationPurposeNode>;
+  reservationCreationStatus?: Maybe<ApplicationRoundReservationCreationStatusChoice>;
   reservationPeriodBegin: Scalars["Date"]["output"];
   reservationPeriodEnd: Scalars["Date"]["output"];
   reservationUnitCount?: Maybe<Scalars["Int"]["output"]>;
@@ -449,6 +451,13 @@ export type ApplicationRoundNodeEdge = {
 export enum ApplicationRoundOrderingChoices {
   PkAsc = "pkAsc",
   PkDesc = "pkDesc",
+}
+
+/** An enumeration. */
+export enum ApplicationRoundReservationCreationStatusChoice {
+  Completed = "COMPLETED",
+  Failed = "FAILED",
+  NotCompleted = "NOT_COMPLETED",
 }
 
 /** An enumeration. */
@@ -612,10 +621,9 @@ export enum ApplicationSectionOrderingChoices {
 
 /** An enumeration. */
 export enum ApplicationSectionStatusChoice {
-  Failed = "FAILED",
   Handled = "HANDLED",
   InAllocation = "IN_ALLOCATION",
-  Reserved = "RESERVED",
+  Rejected = "REJECTED",
   Unallocated = "UNALLOCATED",
 }
 
@@ -1751,7 +1759,6 @@ export type PurposeNode = Node & {
   nameFi?: Maybe<Scalars["String"]["output"]>;
   nameSv?: Maybe<Scalars["String"]["output"]>;
   pk?: Maybe<Scalars["Int"]["output"]>;
-  /** Järjestysnumero, jota käytetään rajapinnan järjestämisessä. */
   rank?: Maybe<Scalars["Int"]["output"]>;
   smallUrl?: Maybe<Scalars["String"]["output"]>;
 };
@@ -1863,6 +1870,8 @@ export type Query = {
   qualifiers?: Maybe<QualifierNodeConnection>;
   recurringReservation?: Maybe<RecurringReservationNode>;
   recurringReservations?: Maybe<RecurringReservationNodeConnection>;
+  rejectedOccurrence?: Maybe<RejectedOccurrenceNode>;
+  rejectedOccurrences?: Maybe<RejectedOccurrenceNodeConnection>;
   reservation?: Maybe<ReservationNode>;
   reservationCancelReasons?: Maybe<ReservationCancelReasonNodeConnection>;
   reservationDenyReasons?: Maybe<ReservationDenyReasonNodeConnection>;
@@ -1880,6 +1889,7 @@ export type Query = {
   taxPercentages?: Maybe<TaxPercentageNodeConnection>;
   termsOfUse?: Maybe<TermsOfUseNodeConnection>;
   unit?: Maybe<UnitNode>;
+  unitGroups?: Maybe<UnitGroupNodeConnection>;
   units?: Maybe<UnitNodeConnection>;
   user?: Maybe<UserNode>;
 };
@@ -2185,6 +2195,25 @@ export type QueryRecurringReservationsArgs = {
   user?: InputMaybe<Scalars["ID"]["input"]>;
 };
 
+export type QueryRejectedOccurrenceArgs = {
+  id: Scalars["ID"]["input"];
+};
+
+export type QueryRejectedOccurrencesArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<InputMaybe<RejectedOccurrenceOrderingChoices>>>;
+  pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  recurringReservation?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
+  textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  unit?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
 export type QueryReservationArgs = {
   id: Scalars["ID"]["input"];
 };
@@ -2431,6 +2460,14 @@ export type QueryUnitArgs = {
   id: Scalars["ID"]["input"];
 };
 
+export type QueryUnitGroupsArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
 export type QueryUnitsArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>;
   before?: InputMaybe<Scalars["String"]["input"]>;
@@ -2493,6 +2530,7 @@ export type RecurringReservationCreateMutationPayload = {
 export type RecurringReservationNode = Node & {
   abilityGroup?: Maybe<AbilityGroupNode>;
   ageGroup?: Maybe<AgeGroupNode>;
+  allocatedTimeSlot?: Maybe<AllocatedTimeSlotNode>;
   beginDate?: Maybe<Scalars["Date"]["output"]>;
   beginTime?: Maybe<Scalars["Time"]["output"]>;
   created: Scalars["DateTime"]["output"];
@@ -2504,10 +2542,21 @@ export type RecurringReservationNode = Node & {
   name: Scalars["String"]["output"];
   pk?: Maybe<Scalars["Int"]["output"]>;
   recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
+  rejectedOccurrences: Array<RejectedOccurrenceNode>;
   reservationUnit: ReservationUnitNode;
   reservations: Array<ReservationNode>;
   user?: Maybe<UserNode>;
   weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
+};
+
+export type RecurringReservationNodeRejectedOccurrencesArgs = {
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<InputMaybe<RejectedOccurrenceOrderingChoices>>>;
+  pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  recurringReservation?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
+  textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  unit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RecurringReservationNodeReservationsArgs = {
@@ -2637,6 +2686,67 @@ export type RejectAllSectionOptionsMutationInput = {
 export type RejectAllSectionOptionsMutationPayload = {
   pk?: Maybe<Scalars["Int"]["output"]>;
 };
+
+export type RejectedOccurrenceNode = Node & {
+  beginDatetime: Scalars["DateTime"]["output"];
+  createdAt: Scalars["DateTime"]["output"];
+  endDatetime: Scalars["DateTime"]["output"];
+  /** The ID of the object */
+  id: Scalars["ID"]["output"];
+  pk?: Maybe<Scalars["Int"]["output"]>;
+  recurringReservation: RecurringReservationNode;
+  rejectionReason: RejectionReadinessChoice;
+};
+
+export type RejectedOccurrenceNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<RejectedOccurrenceNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `RejectedOccurrenceNode` and its cursor. */
+export type RejectedOccurrenceNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<RejectedOccurrenceNode>;
+};
+
+/** Ordering fields for the 'RejectedOccurrence' model. */
+export enum RejectedOccurrenceOrderingChoices {
+  ApplicantAsc = "applicantAsc",
+  ApplicantDesc = "applicantDesc",
+  ApplicationPkAsc = "applicationPkAsc",
+  ApplicationPkDesc = "applicationPkDesc",
+  ApplicationSectionNameAsc = "applicationSectionNameAsc",
+  ApplicationSectionNameDesc = "applicationSectionNameDesc",
+  ApplicationSectionPkAsc = "applicationSectionPkAsc",
+  ApplicationSectionPkDesc = "applicationSectionPkDesc",
+  BeginDatetimeAsc = "beginDatetimeAsc",
+  BeginDatetimeDesc = "beginDatetimeDesc",
+  EndDatetimeAsc = "endDatetimeAsc",
+  EndDatetimeDesc = "endDatetimeDesc",
+  PkAsc = "pkAsc",
+  PkDesc = "pkDesc",
+  RejectionReasonAsc = "rejectionReasonAsc",
+  RejectionReasonDesc = "rejectionReasonDesc",
+  ReservationUnitPkAsc = "reservationUnitPkAsc",
+  ReservationUnitPkDesc = "reservationUnitPkDesc",
+  UnitPkAsc = "unitPkAsc",
+  UnitPkDesc = "unitPkDesc",
+}
+
+/** An enumeration. */
+export enum RejectionReadinessChoice {
+  /** Aloitusaika ei sallittu */
+  IntervalNotAllowed = "INTERVAL_NOT_ALLOWED",
+  /** Päällekkäisiä varauksia */
+  OverlappingReservations = "OVERLAPPING_RESERVATIONS",
+  /** Varausyksikkö suljettu */
+  ReservationUnitClosed = "RESERVATION_UNIT_CLOSED",
+}
 
 export type ReservableTimeSpanType = {
   endDatetime?: Maybe<Scalars["DateTime"]["output"]>;
@@ -2973,13 +3083,16 @@ export type ReservationNode = Node & {
   isHandled?: Maybe<Scalars["Boolean"]["output"]>;
   name?: Maybe<Scalars["String"]["output"]>;
   numPersons?: Maybe<Scalars["Int"]["output"]>;
+  /** @deprecated Please use to 'paymentOrder' instead. */
   order?: Maybe<PaymentOrderNode>;
+  /** Reservation this order is based on */
+  paymentOrder: Array<PaymentOrderNode>;
   pk?: Maybe<Scalars["Int"]["output"]>;
   price?: Maybe<Scalars["Decimal"]["output"]>;
   priceNet?: Maybe<Scalars["Decimal"]["output"]>;
   purpose?: Maybe<ReservationPurposeNode>;
   recurringReservation?: Maybe<RecurringReservationNode>;
-  reservationUnit?: Maybe<Array<ReservationUnitNode>>;
+  reservationUnit: Array<ReservationUnitNode>;
   reserveeAddressCity?: Maybe<Scalars["String"]["output"]>;
   reserveeAddressStreet?: Maybe<Scalars["String"]["output"]>;
   reserveeAddressZip?: Maybe<Scalars["String"]["output"]>;
@@ -2992,7 +3105,7 @@ export type ReservationNode = Node & {
   reserveeOrganisationName?: Maybe<Scalars["String"]["output"]>;
   reserveePhone?: Maybe<Scalars["String"]["output"]>;
   reserveeType?: Maybe<CustomerTypeChoice>;
-  /** @deprecated Please refer to type. */
+  /** @deprecated Please use to 'type' instead. */
   staffEvent?: Maybe<Scalars["Boolean"]["output"]>;
   state: State;
   taxPercentageValue?: Maybe<Scalars["Decimal"]["output"]>;
@@ -4907,6 +5020,22 @@ export type UnitGroupNodeUnitsArgs = {
   serviceSector?: InputMaybe<Scalars["Decimal"]["input"]>;
 };
 
+export type UnitGroupNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<UnitGroupNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `UnitGroupNode` and its cursor. */
+export type UnitGroupNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<UnitGroupNode>;
+};
+
 export type UnitNode = Node & {
   description: Scalars["String"]["output"];
   descriptionEn?: Maybe<Scalars["String"]["output"]>;
@@ -4931,6 +5060,7 @@ export type UnitNode = Node & {
   shortDescriptionSv?: Maybe<Scalars["String"]["output"]>;
   spaces: Array<SpaceNode>;
   tprekId?: Maybe<Scalars["String"]["output"]>;
+  unitGroups: Array<UnitGroupNode>;
   webPage: Scalars["String"]["output"];
 };
 
@@ -5032,6 +5162,10 @@ export enum UnitOrderingChoices {
   RankDesc = "rankDesc",
   ReservationCountAsc = "reservationCountAsc",
   ReservationCountDesc = "reservationCountDesc",
+  ReservationUnitsCountAsc = "reservationUnitsCountAsc",
+  ReservationUnitsCountDesc = "reservationUnitsCountDesc",
+  UnitGroupNameAsc = "unitGroupNameAsc",
+  UnitGroupNameDesc = "unitGroupNameDesc",
 }
 
 /** An enumeration. */
@@ -6819,7 +6953,7 @@ export type ReservationUnitsByUnitQuery = {
         reserveeName?: string | null;
         bufferTimeBefore: number;
         bufferTimeAfter: number;
-        reservationUnit?: Array<{
+        reservationUnit: Array<{
           id: string;
           pk?: number | null;
           nameFi?: string | null;
@@ -6830,7 +6964,7 @@ export type ReservationUnitsByUnitQuery = {
             pk?: number | null;
             serviceSectors: Array<{ id: string; pk?: number | null }>;
           } | null;
-        }> | null;
+        }>;
         user?: {
           id: string;
           firstName: string;
@@ -6859,7 +6993,7 @@ export type ReservationUnitsByUnitQuery = {
     reserveeName?: string | null;
     bufferTimeBefore: number;
     bufferTimeAfter: number;
-    reservationUnit?: Array<{
+    reservationUnit: Array<{
       id: string;
       pk?: number | null;
       nameFi?: string | null;
@@ -6870,7 +7004,7 @@ export type ReservationUnitsByUnitQuery = {
         pk?: number | null;
         serviceSectors: Array<{ id: string; pk?: number | null }>;
       } | null;
-    }> | null;
+    }>;
     user?: {
       id: string;
       firstName: string;
@@ -6988,7 +7122,7 @@ export type ReservationUnitCalendarQuery = {
       reserveeName?: string | null;
       bufferTimeBefore: number;
       bufferTimeAfter: number;
-      reservationUnit?: Array<{
+      reservationUnit: Array<{
         id: string;
         pk?: number | null;
         nameFi?: string | null;
@@ -6999,7 +7133,7 @@ export type ReservationUnitCalendarQuery = {
           pk?: number | null;
           serviceSectors: Array<{ id: string; pk?: number | null }>;
         } | null;
-      }> | null;
+      }>;
       user?: {
         id: string;
         firstName: string;
@@ -7027,7 +7161,7 @@ export type ReservationUnitCalendarQuery = {
     reserveeName?: string | null;
     bufferTimeBefore: number;
     bufferTimeAfter: number;
-    reservationUnit?: Array<{
+    reservationUnit: Array<{
       id: string;
       pk?: number | null;
       nameFi?: string | null;
@@ -7038,7 +7172,7 @@ export type ReservationUnitCalendarQuery = {
         pk?: number | null;
         serviceSectors: Array<{ id: string; pk?: number | null }>;
       } | null;
-    }> | null;
+    }>;
     user?: {
       id: string;
       firstName: string;
@@ -7255,7 +7389,7 @@ export type ReservationUnitReservationsFragment = {
   reserveeName?: string | null;
   bufferTimeBefore: number;
   bufferTimeAfter: number;
-  reservationUnit?: Array<{
+  reservationUnit: Array<{
     id: string;
     pk?: number | null;
     nameFi?: string | null;
@@ -7266,7 +7400,7 @@ export type ReservationUnitReservationsFragment = {
       pk?: number | null;
       serviceSectors: Array<{ id: string; pk?: number | null }>;
     } | null;
-  }> | null;
+  }>;
   user?: {
     id: string;
     firstName: string;
@@ -7347,11 +7481,11 @@ export type ReservationsQuery = {
         reserveeName?: string | null;
         bufferTimeBefore: number;
         bufferTimeAfter: number;
-        reservationUnit?: Array<{
+        reservationUnit: Array<{
           id: string;
           nameFi?: string | null;
           unit?: { id: string; nameFi?: string | null } | null;
-        }> | null;
+        }>;
         order?: { id: string; status?: OrderStatus | null } | null;
         user?: { id: string; firstName: string; lastName: string } | null;
       } | null;
@@ -7535,7 +7669,7 @@ export type ReservationQuery = {
     billingAddressStreet?: string | null;
     billingAddressCity?: string | null;
     billingAddressZip?: string | null;
-    reservationUnit?: Array<{
+    reservationUnit: Array<{
       id: string;
       pk?: number | null;
       nameFi?: string | null;
@@ -7591,7 +7725,7 @@ export type ReservationQuery = {
         requiredFields: Array<{ id: string; fieldName: string }>;
         supportedFields: Array<{ id: string; fieldName: string }>;
       } | null;
-    }> | null;
+    }>;
     order?: {
       id: string;
       status?: OrderStatus | null;
@@ -7648,7 +7782,7 @@ export type RecurringReservationQuery = {
       begin: string;
       end: string;
       state: State;
-      reservationUnit?: Array<{ id: string; pk?: number | null }> | null;
+      reservationUnit: Array<{ id: string; pk?: number | null }>;
     }>;
   } | null;
 };

--- a/apps/admin-ui/src/helpers/index.ts
+++ b/apps/admin-ui/src/helpers/index.ts
@@ -118,13 +118,12 @@ export function getApplicationSectiontatusColor(
   status: ApplicationSectionStatusChoice
 ): string {
   switch (status) {
-    case ApplicationSectionStatusChoice.Reserved:
     case ApplicationSectionStatusChoice.Unallocated:
     case ApplicationSectionStatusChoice.InAllocation:
       return "var(--color-alert-dark)";
     case ApplicationSectionStatusChoice.Handled:
       return "var(--color-success)";
-    case ApplicationSectionStatusChoice.Failed:
+    case ApplicationSectionStatusChoice.Rejected:
     default:
       return "var(--color-error)";
   }

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -563,11 +563,10 @@ const translations: ITranslations = {
     },
   },
   ApplicationSectionStatusChoice: {
-    FAILED: ["Epäonnistunut"],
     HANDLED: ["Hyväksytty"],
     IN_ALLOCATION: ["Käsittelyssä"],
-    RESERVED: ["Varattu"],
     UNALLOCATED: ["Vastaanotettu"],
+    REJECTED: ["Hylätty"],
   },
   TimeSlotStatusCell: {
     declined: ["Hylätty"],

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -344,6 +344,7 @@ export type ApplicationRoundNode = Node & {
   handledDate?: Maybe<Scalars["DateTime"]["output"]>;
   /** The ID of the object */
   id: Scalars["ID"]["output"];
+  isSettingHandledAllowed?: Maybe<Scalars["Boolean"]["output"]>;
   name: Scalars["String"]["output"];
   nameEn?: Maybe<Scalars["String"]["output"]>;
   nameFi?: Maybe<Scalars["String"]["output"]>;
@@ -356,6 +357,7 @@ export type ApplicationRoundNode = Node & {
   publicDisplayBegin: Scalars["DateTime"]["output"];
   publicDisplayEnd: Scalars["DateTime"]["output"];
   purposes: Array<ReservationPurposeNode>;
+  reservationCreationStatus?: Maybe<ApplicationRoundReservationCreationStatusChoice>;
   reservationPeriodBegin: Scalars["Date"]["output"];
   reservationPeriodEnd: Scalars["Date"]["output"];
   reservationUnitCount?: Maybe<Scalars["Int"]["output"]>;
@@ -449,6 +451,13 @@ export type ApplicationRoundNodeEdge = {
 export enum ApplicationRoundOrderingChoices {
   PkAsc = "pkAsc",
   PkDesc = "pkDesc",
+}
+
+/** An enumeration. */
+export enum ApplicationRoundReservationCreationStatusChoice {
+  Completed = "COMPLETED",
+  Failed = "FAILED",
+  NotCompleted = "NOT_COMPLETED",
 }
 
 /** An enumeration. */
@@ -612,10 +621,9 @@ export enum ApplicationSectionOrderingChoices {
 
 /** An enumeration. */
 export enum ApplicationSectionStatusChoice {
-  Failed = "FAILED",
   Handled = "HANDLED",
   InAllocation = "IN_ALLOCATION",
-  Reserved = "RESERVED",
+  Rejected = "REJECTED",
   Unallocated = "UNALLOCATED",
 }
 
@@ -1751,7 +1759,6 @@ export type PurposeNode = Node & {
   nameFi?: Maybe<Scalars["String"]["output"]>;
   nameSv?: Maybe<Scalars["String"]["output"]>;
   pk?: Maybe<Scalars["Int"]["output"]>;
-  /** Järjestysnumero, jota käytetään rajapinnan järjestämisessä. */
   rank?: Maybe<Scalars["Int"]["output"]>;
   smallUrl?: Maybe<Scalars["String"]["output"]>;
 };
@@ -1863,6 +1870,8 @@ export type Query = {
   qualifiers?: Maybe<QualifierNodeConnection>;
   recurringReservation?: Maybe<RecurringReservationNode>;
   recurringReservations?: Maybe<RecurringReservationNodeConnection>;
+  rejectedOccurrence?: Maybe<RejectedOccurrenceNode>;
+  rejectedOccurrences?: Maybe<RejectedOccurrenceNodeConnection>;
   reservation?: Maybe<ReservationNode>;
   reservationCancelReasons?: Maybe<ReservationCancelReasonNodeConnection>;
   reservationDenyReasons?: Maybe<ReservationDenyReasonNodeConnection>;
@@ -1880,6 +1889,7 @@ export type Query = {
   taxPercentages?: Maybe<TaxPercentageNodeConnection>;
   termsOfUse?: Maybe<TermsOfUseNodeConnection>;
   unit?: Maybe<UnitNode>;
+  unitGroups?: Maybe<UnitGroupNodeConnection>;
   units?: Maybe<UnitNodeConnection>;
   user?: Maybe<UserNode>;
 };
@@ -2185,6 +2195,25 @@ export type QueryRecurringReservationsArgs = {
   user?: InputMaybe<Scalars["ID"]["input"]>;
 };
 
+export type QueryRejectedOccurrenceArgs = {
+  id: Scalars["ID"]["input"];
+};
+
+export type QueryRejectedOccurrencesArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<InputMaybe<RejectedOccurrenceOrderingChoices>>>;
+  pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  recurringReservation?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
+  textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  unit?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
 export type QueryReservationArgs = {
   id: Scalars["ID"]["input"];
 };
@@ -2431,6 +2460,14 @@ export type QueryUnitArgs = {
   id: Scalars["ID"]["input"];
 };
 
+export type QueryUnitGroupsArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
 export type QueryUnitsArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>;
   before?: InputMaybe<Scalars["String"]["input"]>;
@@ -2493,6 +2530,7 @@ export type RecurringReservationCreateMutationPayload = {
 export type RecurringReservationNode = Node & {
   abilityGroup?: Maybe<AbilityGroupNode>;
   ageGroup?: Maybe<AgeGroupNode>;
+  allocatedTimeSlot?: Maybe<AllocatedTimeSlotNode>;
   beginDate?: Maybe<Scalars["Date"]["output"]>;
   beginTime?: Maybe<Scalars["Time"]["output"]>;
   created: Scalars["DateTime"]["output"];
@@ -2504,10 +2542,21 @@ export type RecurringReservationNode = Node & {
   name: Scalars["String"]["output"];
   pk?: Maybe<Scalars["Int"]["output"]>;
   recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
+  rejectedOccurrences: Array<RejectedOccurrenceNode>;
   reservationUnit: ReservationUnitNode;
   reservations: Array<ReservationNode>;
   user?: Maybe<UserNode>;
   weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
+};
+
+export type RecurringReservationNodeRejectedOccurrencesArgs = {
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<InputMaybe<RejectedOccurrenceOrderingChoices>>>;
+  pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  recurringReservation?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
+  textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  unit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RecurringReservationNodeReservationsArgs = {
@@ -2637,6 +2686,67 @@ export type RejectAllSectionOptionsMutationInput = {
 export type RejectAllSectionOptionsMutationPayload = {
   pk?: Maybe<Scalars["Int"]["output"]>;
 };
+
+export type RejectedOccurrenceNode = Node & {
+  beginDatetime: Scalars["DateTime"]["output"];
+  createdAt: Scalars["DateTime"]["output"];
+  endDatetime: Scalars["DateTime"]["output"];
+  /** The ID of the object */
+  id: Scalars["ID"]["output"];
+  pk?: Maybe<Scalars["Int"]["output"]>;
+  recurringReservation: RecurringReservationNode;
+  rejectionReason: RejectionReadinessChoice;
+};
+
+export type RejectedOccurrenceNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<RejectedOccurrenceNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `RejectedOccurrenceNode` and its cursor. */
+export type RejectedOccurrenceNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<RejectedOccurrenceNode>;
+};
+
+/** Ordering fields for the 'RejectedOccurrence' model. */
+export enum RejectedOccurrenceOrderingChoices {
+  ApplicantAsc = "applicantAsc",
+  ApplicantDesc = "applicantDesc",
+  ApplicationPkAsc = "applicationPkAsc",
+  ApplicationPkDesc = "applicationPkDesc",
+  ApplicationSectionNameAsc = "applicationSectionNameAsc",
+  ApplicationSectionNameDesc = "applicationSectionNameDesc",
+  ApplicationSectionPkAsc = "applicationSectionPkAsc",
+  ApplicationSectionPkDesc = "applicationSectionPkDesc",
+  BeginDatetimeAsc = "beginDatetimeAsc",
+  BeginDatetimeDesc = "beginDatetimeDesc",
+  EndDatetimeAsc = "endDatetimeAsc",
+  EndDatetimeDesc = "endDatetimeDesc",
+  PkAsc = "pkAsc",
+  PkDesc = "pkDesc",
+  RejectionReasonAsc = "rejectionReasonAsc",
+  RejectionReasonDesc = "rejectionReasonDesc",
+  ReservationUnitPkAsc = "reservationUnitPkAsc",
+  ReservationUnitPkDesc = "reservationUnitPkDesc",
+  UnitPkAsc = "unitPkAsc",
+  UnitPkDesc = "unitPkDesc",
+}
+
+/** An enumeration. */
+export enum RejectionReadinessChoice {
+  /** Aloitusaika ei sallittu */
+  IntervalNotAllowed = "INTERVAL_NOT_ALLOWED",
+  /** Päällekkäisiä varauksia */
+  OverlappingReservations = "OVERLAPPING_RESERVATIONS",
+  /** Varausyksikkö suljettu */
+  ReservationUnitClosed = "RESERVATION_UNIT_CLOSED",
+}
 
 export type ReservableTimeSpanType = {
   endDatetime?: Maybe<Scalars["DateTime"]["output"]>;
@@ -2973,13 +3083,16 @@ export type ReservationNode = Node & {
   isHandled?: Maybe<Scalars["Boolean"]["output"]>;
   name?: Maybe<Scalars["String"]["output"]>;
   numPersons?: Maybe<Scalars["Int"]["output"]>;
+  /** @deprecated Please use to 'paymentOrder' instead. */
   order?: Maybe<PaymentOrderNode>;
+  /** Reservation this order is based on */
+  paymentOrder: Array<PaymentOrderNode>;
   pk?: Maybe<Scalars["Int"]["output"]>;
   price?: Maybe<Scalars["Decimal"]["output"]>;
   priceNet?: Maybe<Scalars["Decimal"]["output"]>;
   purpose?: Maybe<ReservationPurposeNode>;
   recurringReservation?: Maybe<RecurringReservationNode>;
-  reservationUnit?: Maybe<Array<ReservationUnitNode>>;
+  reservationUnit: Array<ReservationUnitNode>;
   reserveeAddressCity?: Maybe<Scalars["String"]["output"]>;
   reserveeAddressStreet?: Maybe<Scalars["String"]["output"]>;
   reserveeAddressZip?: Maybe<Scalars["String"]["output"]>;
@@ -2992,7 +3105,7 @@ export type ReservationNode = Node & {
   reserveeOrganisationName?: Maybe<Scalars["String"]["output"]>;
   reserveePhone?: Maybe<Scalars["String"]["output"]>;
   reserveeType?: Maybe<CustomerTypeChoice>;
-  /** @deprecated Please refer to type. */
+  /** @deprecated Please use to 'type' instead. */
   staffEvent?: Maybe<Scalars["Boolean"]["output"]>;
   state: State;
   taxPercentageValue?: Maybe<Scalars["Decimal"]["output"]>;
@@ -4907,6 +5020,22 @@ export type UnitGroupNodeUnitsArgs = {
   serviceSector?: InputMaybe<Scalars["Decimal"]["input"]>;
 };
 
+export type UnitGroupNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<UnitGroupNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `UnitGroupNode` and its cursor. */
+export type UnitGroupNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<UnitGroupNode>;
+};
+
 export type UnitNode = Node & {
   description: Scalars["String"]["output"];
   descriptionEn?: Maybe<Scalars["String"]["output"]>;
@@ -4931,6 +5060,7 @@ export type UnitNode = Node & {
   shortDescriptionSv?: Maybe<Scalars["String"]["output"]>;
   spaces: Array<SpaceNode>;
   tprekId?: Maybe<Scalars["String"]["output"]>;
+  unitGroups: Array<UnitGroupNode>;
   webPage: Scalars["String"]["output"];
 };
 
@@ -5032,6 +5162,10 @@ export enum UnitOrderingChoices {
   RankDesc = "rankDesc",
   ReservationCountAsc = "reservationCountAsc",
   ReservationCountDesc = "reservationCountDesc",
+  ReservationUnitsCountAsc = "reservationUnitsCountAsc",
+  ReservationUnitsCountDesc = "reservationUnitsCountDesc",
+  UnitGroupNameAsc = "unitGroupNameAsc",
+  UnitGroupNameDesc = "unitGroupNameDesc",
 }
 
 /** An enumeration. */
@@ -5306,7 +5440,7 @@ export type ReservationInfoCardFragment = {
   end: string;
   state: State;
   price?: string | null;
-  reservationUnit?: Array<{
+  reservationUnit: Array<{
     id: string;
     pk?: number | null;
     nameFi?: string | null;
@@ -5338,7 +5472,7 @@ export type ReservationInfoCardFragment = {
       status: Status;
       taxPercentage: { id: string; pk?: number | null; value: string };
     }>;
-  }> | null;
+  }>;
 };
 
 export type OptionsQueryVariables = Exact<{ [key: string]: never }>;
@@ -5847,7 +5981,7 @@ export type ListReservationsQuery = {
           expiresInMinutes?: number | null;
           status?: OrderStatus | null;
         } | null;
-        reservationUnit?: Array<{
+        reservationUnit: Array<{
           id: string;
           pk?: number | null;
           nameFi?: string | null;
@@ -5884,7 +6018,7 @@ export type ListReservationsQuery = {
             status: Status;
             taxPercentage: { id: string; pk?: number | null; value: string };
           }>;
-        }> | null;
+        }>;
       } | null;
     } | null>;
   } | null;
@@ -5956,7 +6090,7 @@ export type ReservationQuery = {
       orderUuid?: string | null;
       status?: OrderStatus | null;
     } | null;
-    reservationUnit?: Array<{
+    reservationUnit: Array<{
       id: string;
       canApplyFreeOfCharge: boolean;
       pk?: number | null;
@@ -6053,7 +6187,7 @@ export type ReservationQuery = {
         requiredFields: Array<{ id: string; fieldName: string }>;
         supportedFields: Array<{ id: string; fieldName: string }>;
       } | null;
-    }> | null;
+    }>;
     purpose?: {
       id: string;
       pk?: number | null;

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -344,6 +344,7 @@ export type ApplicationRoundNode = Node & {
   handledDate?: Maybe<Scalars["DateTime"]["output"]>;
   /** The ID of the object */
   id: Scalars["ID"]["output"];
+  isSettingHandledAllowed?: Maybe<Scalars["Boolean"]["output"]>;
   name: Scalars["String"]["output"];
   nameEn?: Maybe<Scalars["String"]["output"]>;
   nameFi?: Maybe<Scalars["String"]["output"]>;
@@ -356,6 +357,7 @@ export type ApplicationRoundNode = Node & {
   publicDisplayBegin: Scalars["DateTime"]["output"];
   publicDisplayEnd: Scalars["DateTime"]["output"];
   purposes: Array<ReservationPurposeNode>;
+  reservationCreationStatus?: Maybe<ApplicationRoundReservationCreationStatusChoice>;
   reservationPeriodBegin: Scalars["Date"]["output"];
   reservationPeriodEnd: Scalars["Date"]["output"];
   reservationUnitCount?: Maybe<Scalars["Int"]["output"]>;
@@ -449,6 +451,13 @@ export type ApplicationRoundNodeEdge = {
 export enum ApplicationRoundOrderingChoices {
   PkAsc = "pkAsc",
   PkDesc = "pkDesc",
+}
+
+/** An enumeration. */
+export enum ApplicationRoundReservationCreationStatusChoice {
+  Completed = "COMPLETED",
+  Failed = "FAILED",
+  NotCompleted = "NOT_COMPLETED",
 }
 
 /** An enumeration. */
@@ -612,10 +621,9 @@ export enum ApplicationSectionOrderingChoices {
 
 /** An enumeration. */
 export enum ApplicationSectionStatusChoice {
-  Failed = "FAILED",
   Handled = "HANDLED",
   InAllocation = "IN_ALLOCATION",
-  Reserved = "RESERVED",
+  Rejected = "REJECTED",
   Unallocated = "UNALLOCATED",
 }
 
@@ -1751,7 +1759,6 @@ export type PurposeNode = Node & {
   nameFi?: Maybe<Scalars["String"]["output"]>;
   nameSv?: Maybe<Scalars["String"]["output"]>;
   pk?: Maybe<Scalars["Int"]["output"]>;
-  /** Järjestysnumero, jota käytetään rajapinnan järjestämisessä. */
   rank?: Maybe<Scalars["Int"]["output"]>;
   smallUrl?: Maybe<Scalars["String"]["output"]>;
 };
@@ -1863,6 +1870,8 @@ export type Query = {
   qualifiers?: Maybe<QualifierNodeConnection>;
   recurringReservation?: Maybe<RecurringReservationNode>;
   recurringReservations?: Maybe<RecurringReservationNodeConnection>;
+  rejectedOccurrence?: Maybe<RejectedOccurrenceNode>;
+  rejectedOccurrences?: Maybe<RejectedOccurrenceNodeConnection>;
   reservation?: Maybe<ReservationNode>;
   reservationCancelReasons?: Maybe<ReservationCancelReasonNodeConnection>;
   reservationDenyReasons?: Maybe<ReservationDenyReasonNodeConnection>;
@@ -1880,6 +1889,7 @@ export type Query = {
   taxPercentages?: Maybe<TaxPercentageNodeConnection>;
   termsOfUse?: Maybe<TermsOfUseNodeConnection>;
   unit?: Maybe<UnitNode>;
+  unitGroups?: Maybe<UnitGroupNodeConnection>;
   units?: Maybe<UnitNodeConnection>;
   user?: Maybe<UserNode>;
 };
@@ -2185,6 +2195,25 @@ export type QueryRecurringReservationsArgs = {
   user?: InputMaybe<Scalars["ID"]["input"]>;
 };
 
+export type QueryRejectedOccurrenceArgs = {
+  id: Scalars["ID"]["input"];
+};
+
+export type QueryRejectedOccurrencesArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<InputMaybe<RejectedOccurrenceOrderingChoices>>>;
+  pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  recurringReservation?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
+  textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  unit?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
 export type QueryReservationArgs = {
   id: Scalars["ID"]["input"];
 };
@@ -2431,6 +2460,14 @@ export type QueryUnitArgs = {
   id: Scalars["ID"]["input"];
 };
 
+export type QueryUnitGroupsArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  before?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+  last?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
 export type QueryUnitsArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>;
   before?: InputMaybe<Scalars["String"]["input"]>;
@@ -2493,6 +2530,7 @@ export type RecurringReservationCreateMutationPayload = {
 export type RecurringReservationNode = Node & {
   abilityGroup?: Maybe<AbilityGroupNode>;
   ageGroup?: Maybe<AgeGroupNode>;
+  allocatedTimeSlot?: Maybe<AllocatedTimeSlotNode>;
   beginDate?: Maybe<Scalars["Date"]["output"]>;
   beginTime?: Maybe<Scalars["Time"]["output"]>;
   created: Scalars["DateTime"]["output"];
@@ -2504,10 +2542,21 @@ export type RecurringReservationNode = Node & {
   name: Scalars["String"]["output"];
   pk?: Maybe<Scalars["Int"]["output"]>;
   recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
+  rejectedOccurrences: Array<RejectedOccurrenceNode>;
   reservationUnit: ReservationUnitNode;
   reservations: Array<ReservationNode>;
   user?: Maybe<UserNode>;
   weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
+};
+
+export type RecurringReservationNodeRejectedOccurrencesArgs = {
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<InputMaybe<RejectedOccurrenceOrderingChoices>>>;
+  pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  recurringReservation?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
+  textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  unit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type RecurringReservationNodeReservationsArgs = {
@@ -2637,6 +2686,67 @@ export type RejectAllSectionOptionsMutationInput = {
 export type RejectAllSectionOptionsMutationPayload = {
   pk?: Maybe<Scalars["Int"]["output"]>;
 };
+
+export type RejectedOccurrenceNode = Node & {
+  beginDatetime: Scalars["DateTime"]["output"];
+  createdAt: Scalars["DateTime"]["output"];
+  endDatetime: Scalars["DateTime"]["output"];
+  /** The ID of the object */
+  id: Scalars["ID"]["output"];
+  pk?: Maybe<Scalars["Int"]["output"]>;
+  recurringReservation: RecurringReservationNode;
+  rejectionReason: RejectionReadinessChoice;
+};
+
+export type RejectedOccurrenceNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<RejectedOccurrenceNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `RejectedOccurrenceNode` and its cursor. */
+export type RejectedOccurrenceNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<RejectedOccurrenceNode>;
+};
+
+/** Ordering fields for the 'RejectedOccurrence' model. */
+export enum RejectedOccurrenceOrderingChoices {
+  ApplicantAsc = "applicantAsc",
+  ApplicantDesc = "applicantDesc",
+  ApplicationPkAsc = "applicationPkAsc",
+  ApplicationPkDesc = "applicationPkDesc",
+  ApplicationSectionNameAsc = "applicationSectionNameAsc",
+  ApplicationSectionNameDesc = "applicationSectionNameDesc",
+  ApplicationSectionPkAsc = "applicationSectionPkAsc",
+  ApplicationSectionPkDesc = "applicationSectionPkDesc",
+  BeginDatetimeAsc = "beginDatetimeAsc",
+  BeginDatetimeDesc = "beginDatetimeDesc",
+  EndDatetimeAsc = "endDatetimeAsc",
+  EndDatetimeDesc = "endDatetimeDesc",
+  PkAsc = "pkAsc",
+  PkDesc = "pkDesc",
+  RejectionReasonAsc = "rejectionReasonAsc",
+  RejectionReasonDesc = "rejectionReasonDesc",
+  ReservationUnitPkAsc = "reservationUnitPkAsc",
+  ReservationUnitPkDesc = "reservationUnitPkDesc",
+  UnitPkAsc = "unitPkAsc",
+  UnitPkDesc = "unitPkDesc",
+}
+
+/** An enumeration. */
+export enum RejectionReadinessChoice {
+  /** Aloitusaika ei sallittu */
+  IntervalNotAllowed = "INTERVAL_NOT_ALLOWED",
+  /** Päällekkäisiä varauksia */
+  OverlappingReservations = "OVERLAPPING_RESERVATIONS",
+  /** Varausyksikkö suljettu */
+  ReservationUnitClosed = "RESERVATION_UNIT_CLOSED",
+}
 
 export type ReservableTimeSpanType = {
   endDatetime?: Maybe<Scalars["DateTime"]["output"]>;
@@ -2973,13 +3083,16 @@ export type ReservationNode = Node & {
   isHandled?: Maybe<Scalars["Boolean"]["output"]>;
   name?: Maybe<Scalars["String"]["output"]>;
   numPersons?: Maybe<Scalars["Int"]["output"]>;
+  /** @deprecated Please use to 'paymentOrder' instead. */
   order?: Maybe<PaymentOrderNode>;
+  /** Reservation this order is based on */
+  paymentOrder: Array<PaymentOrderNode>;
   pk?: Maybe<Scalars["Int"]["output"]>;
   price?: Maybe<Scalars["Decimal"]["output"]>;
   priceNet?: Maybe<Scalars["Decimal"]["output"]>;
   purpose?: Maybe<ReservationPurposeNode>;
   recurringReservation?: Maybe<RecurringReservationNode>;
-  reservationUnit?: Maybe<Array<ReservationUnitNode>>;
+  reservationUnit: Array<ReservationUnitNode>;
   reserveeAddressCity?: Maybe<Scalars["String"]["output"]>;
   reserveeAddressStreet?: Maybe<Scalars["String"]["output"]>;
   reserveeAddressZip?: Maybe<Scalars["String"]["output"]>;
@@ -2992,7 +3105,7 @@ export type ReservationNode = Node & {
   reserveeOrganisationName?: Maybe<Scalars["String"]["output"]>;
   reserveePhone?: Maybe<Scalars["String"]["output"]>;
   reserveeType?: Maybe<CustomerTypeChoice>;
-  /** @deprecated Please refer to type. */
+  /** @deprecated Please use to 'type' instead. */
   staffEvent?: Maybe<Scalars["Boolean"]["output"]>;
   state: State;
   taxPercentageValue?: Maybe<Scalars["Decimal"]["output"]>;
@@ -4907,6 +5020,22 @@ export type UnitGroupNodeUnitsArgs = {
   serviceSector?: InputMaybe<Scalars["Decimal"]["input"]>;
 };
 
+export type UnitGroupNodeConnection = {
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<UnitGroupNodeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** A Relay edge containing a `UnitGroupNode` and its cursor. */
+export type UnitGroupNodeEdge = {
+  /** A cursor for use in pagination */
+  cursor: Scalars["String"]["output"];
+  /** The item at the end of the edge */
+  node?: Maybe<UnitGroupNode>;
+};
+
 export type UnitNode = Node & {
   description: Scalars["String"]["output"];
   descriptionEn?: Maybe<Scalars["String"]["output"]>;
@@ -4931,6 +5060,7 @@ export type UnitNode = Node & {
   shortDescriptionSv?: Maybe<Scalars["String"]["output"]>;
   spaces: Array<SpaceNode>;
   tprekId?: Maybe<Scalars["String"]["output"]>;
+  unitGroups: Array<UnitGroupNode>;
   webPage: Scalars["String"]["output"];
 };
 
@@ -5032,6 +5162,10 @@ export enum UnitOrderingChoices {
   RankDesc = "rankDesc",
   ReservationCountAsc = "reservationCountAsc",
   ReservationCountDesc = "reservationCountDesc",
+  ReservationUnitsCountAsc = "reservationUnitsCountAsc",
+  ReservationUnitsCountDesc = "reservationUnitsCountDesc",
+  UnitGroupNameAsc = "unitGroupNameAsc",
+  UnitGroupNameDesc = "unitGroupNameDesc",
 }
 
 /** An enumeration. */

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -363,6 +363,7 @@ type ApplicationRoundNode implements Node {
   The ID of the object
   """
   id: ID!
+  isSettingHandledAllowed: Boolean
   name: String!
   nameEn: String
   nameFi: String
@@ -384,6 +385,7 @@ type ApplicationRoundNode implements Node {
     orderBy: [ReservationPurposeOrderingChoices]
     pk: [Int]
   ): [ReservationPurposeNode!]!
+  reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice
   reservationPeriodBegin: Date!
   reservationPeriodEnd: Date!
   reservationUnitCount: Int
@@ -482,6 +484,15 @@ Ordering fields for the 'ApplicationRound' model.
 enum ApplicationRoundOrderingChoices {
   pkAsc
   pkDesc
+}
+
+"""
+An enumeration.
+"""
+enum ApplicationRoundReservationCreationStatusChoice {
+  COMPLETED
+  FAILED
+  NOT_COMPLETED
 }
 
 """
@@ -663,10 +674,9 @@ enum ApplicationSectionOrderingChoices {
 An enumeration.
 """
 enum ApplicationSectionStatusChoice {
-  FAILED
   HANDLED
   IN_ALLOCATION
-  RESERVED
+  REJECTED
   UNALLOCATED
 }
 
@@ -1922,9 +1932,6 @@ type PurposeNode implements Node {
   nameFi: String
   nameSv: String
   pk: Int
-  """
-  Järjestysnumero, jota käytetään rajapinnan järjestämisessä.
-  """
   rank: Int
   smallUrl: String
 }
@@ -2377,6 +2384,29 @@ type Query {
     unit: [ID]
     user: ID
   ): RecurringReservationNodeConnection
+  rejectedOccurrence(
+    """
+    The ID of the object
+    """
+    id: ID!
+  ): RejectedOccurrenceNode
+  rejectedOccurrences(
+    after: String
+    applicationRound: Int
+    before: String
+    first: Int
+    last: Int
+    offset: Int
+    """
+    Järjestä
+    """
+    orderBy: [RejectedOccurrenceOrderingChoices]
+    pk: [Int]
+    recurringReservation: Int
+    reservationUnit: Int
+    textSearch: String
+    unit: Int
+  ): RejectedOccurrenceNodeConnection
   reservation(
     """
     The ID of the object
@@ -2655,6 +2685,13 @@ type Query {
     """
     id: ID!
   ): UnitNode
+  unitGroups(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    offset: Int
+  ): UnitGroupNodeConnection
   units(
     after: String
     before: String
@@ -2723,6 +2760,7 @@ type RecurringReservationCreateMutationPayload {
 type RecurringReservationNode implements Node {
   abilityGroup: AbilityGroupNode
   ageGroup: AgeGroupNode
+  allocatedTimeSlot: AllocatedTimeSlotNode
   beginDate: Date
   beginTime: Time
   created: DateTime!
@@ -2736,6 +2774,18 @@ type RecurringReservationNode implements Node {
   name: String!
   pk: Int
   recurrenceInDays: Int
+  rejectedOccurrences(
+    applicationRound: Int
+    """
+    Järjestä
+    """
+    orderBy: [RejectedOccurrenceOrderingChoices]
+    pk: [Int]
+    recurringReservation: Int
+    reservationUnit: Int
+    textSearch: String
+    unit: Int
+  ): [RejectedOccurrenceNode!]!
   reservationUnit: ReservationUnitNode!
   reservations(
     begin: DateTime
@@ -2884,6 +2934,89 @@ input RejectAllSectionOptionsMutationInput {
 
 type RejectAllSectionOptionsMutationPayload {
   pk: Int
+}
+
+type RejectedOccurrenceNode implements Node {
+  beginDatetime: DateTime!
+  createdAt: DateTime!
+  endDatetime: DateTime!
+  """
+  The ID of the object
+  """
+  id: ID!
+  pk: Int
+  recurringReservation: RecurringReservationNode!
+  rejectionReason: RejectionReadinessChoice!
+}
+
+type RejectedOccurrenceNodeConnection {
+  """
+  Contains the nodes in this connection.
+  """
+  edges: [RejectedOccurrenceNodeEdge]!
+  """
+  Pagination data for this connection.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+"""
+A Relay edge containing a `RejectedOccurrenceNode` and its cursor.
+"""
+type RejectedOccurrenceNodeEdge {
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+  """
+  The item at the end of the edge
+  """
+  node: RejectedOccurrenceNode
+}
+
+"""
+Ordering fields for the 'RejectedOccurrence' model.
+"""
+enum RejectedOccurrenceOrderingChoices {
+  applicantAsc
+  applicantDesc
+  applicationPkAsc
+  applicationPkDesc
+  applicationSectionNameAsc
+  applicationSectionNameDesc
+  applicationSectionPkAsc
+  applicationSectionPkDesc
+  beginDatetimeAsc
+  beginDatetimeDesc
+  endDatetimeAsc
+  endDatetimeDesc
+  pkAsc
+  pkDesc
+  rejectionReasonAsc
+  rejectionReasonDesc
+  reservationUnitPkAsc
+  reservationUnitPkDesc
+  unitPkAsc
+  unitPkDesc
+}
+
+"""
+An enumeration.
+"""
+enum RejectionReadinessChoice {
+  """
+  Aloitusaika ei sallittu
+  """
+  INTERVAL_NOT_ALLOWED
+  """
+  Päällekkäisiä varauksia
+  """
+  OVERLAPPING_RESERVATIONS
+  """
+  Varausyksikkö suljettu
+  """
+  RESERVATION_UNIT_CLOSED
 }
 
 type ReservableTimeSpanType {
@@ -3278,6 +3411,11 @@ type ReservationNode implements Node {
   name: String
   numPersons: Int
   order: PaymentOrderNode
+    @deprecated(reason: "Please use to 'paymentOrder' instead.")
+  """
+  Reservation this order is based on
+  """
+  paymentOrder: [PaymentOrderNode!]!
   pk: Int
   price: Decimal
   priceNet: Decimal
@@ -3337,7 +3475,7 @@ type ReservationNode implements Node {
     typeRankGte: Decimal
     typeRankLte: Decimal
     unit: [Int]
-  ): [ReservationUnitNode!]
+  ): [ReservationUnitNode!]!
   reserveeAddressCity: String
   reserveeAddressStreet: String
   reserveeAddressZip: String
@@ -3350,7 +3488,7 @@ type ReservationNode implements Node {
   reserveeOrganisationName: String
   reserveePhone: String
   reserveeType: CustomerTypeChoice
-  staffEvent: Boolean @deprecated(reason: "Please refer to type.")
+  staffEvent: Boolean @deprecated(reason: "Please use to 'type' instead.")
   state: State!
   taxPercentageValue: Decimal
   type: ReservationTypeChoice
@@ -5552,6 +5690,32 @@ type UnitGroupNode implements Node {
   ): [UnitNode!]!
 }
 
+type UnitGroupNodeConnection {
+  """
+  Contains the nodes in this connection.
+  """
+  edges: [UnitGroupNodeEdge]!
+  """
+  Pagination data for this connection.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+"""
+A Relay edge containing a `UnitGroupNode` and its cursor.
+"""
+type UnitGroupNodeEdge {
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+  """
+  The item at the end of the edge
+  """
+  node: UnitGroupNode
+}
+
 type UnitNode implements Node {
   description: String!
   descriptionEn: String
@@ -5648,6 +5812,7 @@ type UnitNode implements Node {
     pk: [Int]
   ): [SpaceNode!]!
   tprekId: String
+  unitGroups: [UnitGroupNode!]!
   webPage: String!
 }
 
@@ -5693,6 +5858,10 @@ enum UnitOrderingChoices {
   rankDesc
   reservationCountAsc
   reservationCountDesc
+  reservationUnitsCountAsc
+  reservationUnitsCountDesc
+  unitGroupNameAsc
+  unitGroupNameDesc
 }
 
 """


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Updates the front to the new application section statuses (removes `FAILED` and `RESERVED`, adds `REJECTED`)
- This code is written using the `application-section-reject-status` branch as backend, and requires it to be merged main in order to function properly: https://github.com/City-of-Helsinki/tilavarauspalvelu-core/pull/1236
- TODO: run codegen to fix merge conflicts, once the backend is up to date (== has merged the PR mentioned above)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to "Haetut vuorot" tab in the application round review view, and note that the status filter is missing the "Epäonnistunut" and "Varattu" options, and has the "Hylätty" option instead.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3381
