### PR TITLE
Add rejected occurrences tab

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -621,9 +621,10 @@ export enum ApplicationSectionOrderingChoices {
 
 /** An enumeration. */
 export enum ApplicationSectionStatusChoice {
+  Failed = "FAILED",
   Handled = "HANDLED",
   InAllocation = "IN_ALLOCATION",
-  Rejected = "REJECTED",
+  Reserved = "RESERVED",
   Unallocated = "UNALLOCATED",
 }
 
@@ -8557,6 +8558,68 @@ export type ApplicationRoundCriteriaQuery = {
   } | null;
 };
 
+export type RejectedOccurrencesQueryVariables = Exact<{
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
+  unit?: InputMaybe<Scalars["Int"]["input"]>;
+  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<
+    | Array<InputMaybe<RejectedOccurrenceOrderingChoices>>
+    | InputMaybe<RejectedOccurrenceOrderingChoices>
+  >;
+  textSearch?: InputMaybe<Scalars["String"]["input"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  first?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type RejectedOccurrencesQuery = {
+  rejectedOccurrences?: {
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null };
+    edges: Array<{
+      node?: {
+        id: string;
+        pk?: number | null;
+        beginDatetime: string;
+        endDatetime: string;
+        rejectionReason: RejectionReadinessChoice;
+        recurringReservation: {
+          id: string;
+          allocatedTimeSlot?: {
+            id: string;
+            pk?: number | null;
+            dayOfTheWeek: Weekday;
+            beginTime: string;
+            endTime: string;
+            reservationUnitOption: {
+              id: string;
+              applicationSection: {
+                id: string;
+                name: string;
+                application: {
+                  id: string;
+                  pk?: number | null;
+                  applicantType?: ApplicantTypeChoice | null;
+                  contactPerson?: {
+                    id: string;
+                    firstName: string;
+                    lastName: string;
+                  } | null;
+                };
+              };
+              reservationUnit: {
+                id: string;
+                nameFi?: string | null;
+                pk?: number | null;
+                unit?: { id: string; nameFi?: string | null } | null;
+              };
+            };
+          } | null;
+          reservations: Array<{ id: string; pk?: number | null }>;
+        };
+      } | null;
+    } | null>;
+  } | null;
+};
+
 export type EndAllocationMutationVariables = Exact<{
   pk: Scalars["Int"]["input"];
 }>;
@@ -15371,6 +15434,153 @@ export type ApplicationRoundCriteriaSuspenseQueryHookResult = ReturnType<
 export type ApplicationRoundCriteriaQueryResult = Apollo.QueryResult<
   ApplicationRoundCriteriaQuery,
   ApplicationRoundCriteriaQueryVariables
+>;
+export const RejectedOccurrencesDocument = gql`
+  query RejectedOccurrences(
+    $applicationRound: Int
+    $unit: Int
+    $reservationUnit: Int
+    $orderBy: [RejectedOccurrenceOrderingChoices]
+    $textSearch: String
+    $after: String
+    $first: Int
+  ) {
+    rejectedOccurrences(
+      applicationRound: $applicationRound
+      unit: $unit
+      reservationUnit: $reservationUnit
+      orderBy: $orderBy
+      textSearch: $textSearch
+      after: $after
+      first: $first
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          id
+          pk
+          beginDatetime
+          endDatetime
+          rejectionReason
+          recurringReservation {
+            id
+            allocatedTimeSlot {
+              id
+              pk
+              dayOfTheWeek
+              beginTime
+              endTime
+              reservationUnitOption {
+                id
+                applicationSection {
+                  id
+                  name
+                  application {
+                    id
+                    pk
+                    applicantType
+                    contactPerson {
+                      id
+                      firstName
+                      lastName
+                    }
+                  }
+                }
+                reservationUnit {
+                  id
+                  nameFi
+                  pk
+                  unit {
+                    id
+                    nameFi
+                  }
+                }
+              }
+            }
+            reservations {
+              id
+              pk
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useRejectedOccurrencesQuery__
+ *
+ * To run a query within a React component, call `useRejectedOccurrencesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRejectedOccurrencesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useRejectedOccurrencesQuery({
+ *   variables: {
+ *      applicationRound: // value for 'applicationRound'
+ *      unit: // value for 'unit'
+ *      reservationUnit: // value for 'reservationUnit'
+ *      orderBy: // value for 'orderBy'
+ *      textSearch: // value for 'textSearch'
+ *      after: // value for 'after'
+ *      first: // value for 'first'
+ *   },
+ * });
+ */
+export function useRejectedOccurrencesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    RejectedOccurrencesQuery,
+    RejectedOccurrencesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    RejectedOccurrencesQuery,
+    RejectedOccurrencesQueryVariables
+  >(RejectedOccurrencesDocument, options);
+}
+export function useRejectedOccurrencesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    RejectedOccurrencesQuery,
+    RejectedOccurrencesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    RejectedOccurrencesQuery,
+    RejectedOccurrencesQueryVariables
+  >(RejectedOccurrencesDocument, options);
+}
+export function useRejectedOccurrencesSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    RejectedOccurrencesQuery,
+    RejectedOccurrencesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    RejectedOccurrencesQuery,
+    RejectedOccurrencesQueryVariables
+  >(RejectedOccurrencesDocument, options);
+}
+export type RejectedOccurrencesQueryHookResult = ReturnType<
+  typeof useRejectedOccurrencesQuery
+>;
+export type RejectedOccurrencesLazyQueryHookResult = ReturnType<
+  typeof useRejectedOccurrencesLazyQuery
+>;
+export type RejectedOccurrencesSuspenseQueryHookResult = ReturnType<
+  typeof useRejectedOccurrencesSuspenseQuery
+>;
+export type RejectedOccurrencesQueryResult = Apollo.QueryResult<
+  RejectedOccurrencesQuery,
+  RejectedOccurrencesQueryVariables
 >;
 export const EndAllocationDocument = gql`
   mutation EndAllocation($pk: Int!) {

--- a/apps/admin-ui/src/helpers/index.ts
+++ b/apps/admin-ui/src/helpers/index.ts
@@ -127,7 +127,7 @@ export function getApplicationSectiontatusColor(
       return "var(--color-alert-dark)";
     case ApplicationSectionStatusChoice.Handled:
       return "var(--color-success)";
-    case ApplicationSectionStatusChoice.Rejected:
+    case ApplicationSectionStatusChoice.Failed:
     default:
       return "var(--color-error)";
   }

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -564,6 +564,7 @@ const translations: ITranslations = {
     appliedReservations: ["Haetut vuorot"],
     madeReservations: ["Varatut vuorot"],
     allocatedReservations: ["Jaetut vuorot"],
+    rejectedOccurrences: ["Hylätyt ajankohdat"],
     applications: ["Hakemukset"],
     roundCriteria: ["Kierroksen kriteerit"],
     // TODO this is used in Criteria page
@@ -603,6 +604,8 @@ const translations: ITranslations = {
       reservationUnit: ["Varausyksikkö"],
       eventName: ["Varauksen nimi"],
       time: ["Vuoro"],
+      occurrenceTime: ["Aika"],
+      reason: ["Syy"],
     },
   },
   ApplicationSectionStatusChoice: {
@@ -652,6 +655,7 @@ const translations: ITranslations = {
       customer: ["Hakija"],
       name: ["Varauksen nimi"],
       unit: ["Toimipiste"],
+      reason: ["Syy"],
       stats: ["Haettu"],
       phase: ["Vaihe"],
     },

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Filters.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Filters.tsx
@@ -18,6 +18,7 @@ type UnitPkName = {
 type Props = {
   units: UnitPkName[];
   statusOption?: "application" | "event" | "eventShort";
+  enableApplicant?: boolean;
   enableWeekday?: boolean;
   enableReservationUnit?: boolean;
   reservationUnits?: UnitPkName[];
@@ -26,6 +27,7 @@ type Props = {
 export function Filters({
   units,
   statusOption = "application",
+  enableApplicant = false,
   enableWeekday = false,
   enableReservationUnit = false,
   reservationUnits = [],
@@ -110,7 +112,9 @@ export function Filters({
       ) : (
         <MultiSelectFilter name="status" options={statusOptions} />
       )}
-      <MultiSelectFilter name="applicant" options={applicantOptions} />
+      {enableApplicant && (
+        <MultiSelectFilter name="applicant" options={applicantOptions} />
+      )}
       {enableWeekday && (
         <MultiSelectFilter name="weekday" options={weekdayOptions} />
       )}

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
@@ -37,6 +37,7 @@ function RejectedOccurrencesDataLoader({
         unit: unitFilter.map(Number).filter(Number.isFinite)[0],
         reservationUnit: reservationUnitFilter
           .map(Number)
+          // TODO: remove the [0], as this should be the entire array instead of single value
           .filter(Number.isFinite)[0],
         orderBy: transformOrderBy(orderBy),
         textSearch: nameFilter,
@@ -125,6 +126,7 @@ function transformOrderBy(
 
 export default RejectedOccurrencesDataLoader;
 
+// TODO: $reservationUnit: Int should be $reservationUnit: [Int] - fix once the API is updated
 export const REJECTED_OCCURRENCES_QUERY = gql`
   query RejectedOccurrences(
     $applicationRound: Int

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
@@ -1,0 +1,202 @@
+import { useNotification } from "@/context/NotificationContext";
+import { useSort } from "@/hooks/useSort";
+import {
+  RejectedOccurrencesTable,
+  SORT_KEYS,
+} from "./RejectedOccurrencesTable";
+import { useSearchParams } from "react-router-dom";
+import { type ApolloError, gql } from "@apollo/client";
+import {
+  RejectedOccurrenceOrderingChoices,
+  useRejectedOccurrencesQuery,
+} from "@gql/gql-types";
+import { More } from "@/component/More";
+import React from "react";
+import Loader from "@/component/Loader";
+import { filterNonNullable } from "common/src/helpers";
+
+type Props = {
+  applicationRoundPk: number;
+};
+
+function RejectedOccurrencesDataLoader({
+  applicationRoundPk,
+}: Props): JSX.Element {
+  const { notifyError } = useNotification();
+
+  const [orderBy, handleSortChanged] = useSort(SORT_KEYS);
+  const [searchParams] = useSearchParams();
+  const unitFilter = searchParams.getAll("unit");
+  const reservationUnitFilter = searchParams.getAll("reservationUnit");
+  const nameFilter = searchParams.get("search");
+
+  const { data, previousData, loading, fetchMore } =
+    useRejectedOccurrencesQuery({
+      variables: {
+        applicationRound: applicationRoundPk,
+        unit: unitFilter.map(Number).filter(Number.isFinite)[0],
+        reservationUnit: reservationUnitFilter
+          .map(Number)
+          .filter(Number.isFinite)[0],
+        orderBy: transformOrderBy(orderBy),
+        textSearch: nameFilter,
+      },
+      onError: (err: ApolloError) => {
+        notifyError(err.message);
+      },
+      fetchPolicy: "cache-and-network",
+      // TODO enable or no?
+      nextFetchPolicy: "cache-first",
+    });
+
+  const dataToUse = data ?? previousData;
+
+  if (loading && !dataToUse) {
+    return <Loader />;
+  }
+
+  const totalCount = dataToUse?.rejectedOccurrences?.edges.length ?? 0;
+  const rejectedOccurrences = filterNonNullable(
+    dataToUse?.rejectedOccurrences?.edges.map((edge) => edge?.node)
+  );
+
+  return (
+    <>
+      <RejectedOccurrencesTable
+        rejectedOccurrences={rejectedOccurrences}
+        isLoading={loading}
+        sort={orderBy}
+        sortChanged={handleSortChanged}
+      />
+      <More
+        totalCount={totalCount}
+        count={rejectedOccurrences.length}
+        pageInfo={dataToUse?.rejectedOccurrences?.pageInfo}
+        fetchMore={(after) => fetchMore({ variables: { after } })}
+      />
+    </>
+  );
+}
+
+function transformOrderBy(
+  orderBy: string | null
+): RejectedOccurrenceOrderingChoices[] {
+  if (orderBy == null) {
+    return [];
+  }
+  const desc = orderBy.startsWith("-");
+  const rest = desc ? orderBy.slice(1) : orderBy;
+  switch (rest) {
+    case "application_id,application_event_id":
+    case "application_id,-application_event_id":
+      return desc
+        ? [
+            RejectedOccurrenceOrderingChoices.ApplicationPkDesc,
+            RejectedOccurrenceOrderingChoices.PkDesc,
+          ]
+        : [
+            RejectedOccurrenceOrderingChoices.ApplicationPkAsc,
+            RejectedOccurrenceOrderingChoices.PkAsc,
+          ];
+    case "applicant":
+      return desc
+        ? [RejectedOccurrenceOrderingChoices.ApplicantDesc]
+        : [RejectedOccurrenceOrderingChoices.ApplicantAsc];
+    case "rejected_event_name_fi":
+      return desc
+        ? [RejectedOccurrenceOrderingChoices.ApplicationSectionNameDesc]
+        : [RejectedOccurrenceOrderingChoices.ApplicationSectionNameAsc];
+    case "rejected_reservation_unit_name_fi":
+      return desc
+        ? [RejectedOccurrenceOrderingChoices.ReservationUnitPkDesc]
+        : [RejectedOccurrenceOrderingChoices.ReservationUnitPkAsc];
+    case "time_of_occurrence":
+      return desc
+        ? [RejectedOccurrenceOrderingChoices.BeginDatetimeDesc]
+        : [RejectedOccurrenceOrderingChoices.BeginDatetimeAsc];
+    case "rejection_reason":
+      return desc
+        ? [RejectedOccurrenceOrderingChoices.RejectionReasonDesc]
+        : [RejectedOccurrenceOrderingChoices.RejectionReasonAsc];
+    default:
+      return [];
+  }
+}
+
+export default RejectedOccurrencesDataLoader;
+
+export const REJECTED_OCCURRENCES_QUERY = gql`
+  query RejectedOccurrences(
+    $applicationRound: Int
+    $unit: Int
+    $reservationUnit: Int
+    $orderBy: [RejectedOccurrenceOrderingChoices]
+    $textSearch: String
+    $after: String
+    $first: Int
+  ) {
+    rejectedOccurrences(
+      applicationRound: $applicationRound
+      unit: $unit
+      reservationUnit: $reservationUnit
+      orderBy: $orderBy
+      textSearch: $textSearch
+      after: $after
+      first: $first
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          id
+          pk
+          beginDatetime
+          endDatetime
+          rejectionReason
+          recurringReservation {
+            id
+            allocatedTimeSlot {
+              id
+              pk
+              dayOfTheWeek
+              beginTime
+              endTime
+              reservationUnitOption {
+                id
+                applicationSection {
+                  id
+                  name
+                  application {
+                    id
+                    pk
+                    applicantType
+                    contactPerson {
+                      id
+                      firstName
+                      lastName
+                    }
+                  }
+                }
+                reservationUnit {
+                  id
+                  nameFi
+                  pk
+                  unit {
+                    id
+                    nameFi
+                  }
+                }
+              }
+            }
+            reservations {
+              id
+              pk
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/RejectedOccurrencesTable.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/RejectedOccurrencesTable.tsx
@@ -1,0 +1,192 @@
+import React from "react";
+import { CustomTable, ExternalTableLink } from "@/component/Table";
+import { getApplicationUrl, getReservationUrl } from "@/common/urls";
+import type { RejectedOccurrencesQuery } from "@gql/gql-types";
+import { truncate } from "common/src/helpers";
+import { IconLinkExternal } from "hds-react";
+import { memoize } from "lodash";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import { getApplicantName } from "@/helpers";
+import { toUIDate } from "common/src/common/util";
+import { formatTime } from "@/common/util";
+
+const unitsTruncateLen = 23;
+const applicantTruncateLen = 20;
+
+type QueryData = NonNullable<RejectedOccurrencesQuery["rejectedOccurrences"]>;
+type Edge = NonNullable<QueryData["edges"]>[0];
+type Node = NonNullable<NonNullable<Edge>["node"]>;
+type Props = {
+  sort: string | null;
+  sortChanged: (field: string) => void;
+  rejectedOccurrences: Node[];
+  isLoading?: boolean;
+};
+
+type RejectedOccurrencesView = {
+  key: string;
+  applicationPk?: number;
+  pk?: number;
+  applicantName?: string;
+  name: string;
+  unitName?: string;
+  allocatedReservationUnitName?: string;
+  time: string;
+  reason: string;
+  link: string;
+};
+
+function timeSlotMapper(t: TFunction, slot: Node): RejectedOccurrencesView {
+  const allocatedSlot = slot.recurringReservation?.allocatedTimeSlot;
+  const allocatedReservationUnit =
+    allocatedSlot?.reservationUnitOption.reservationUnit;
+  const allocatedReservationUnitName = allocatedReservationUnit?.nameFi ?? "-";
+  const allocatedUnit = allocatedReservationUnit?.unit?.nameFi ?? "-";
+
+  const application =
+    allocatedSlot?.reservationUnitOption.applicationSection?.application;
+  const applicantName = getApplicantName(application);
+
+  const date = toUIDate(new Date(slot?.beginDatetime));
+  const begin = formatTime(slot?.beginDatetime);
+  const end = formatTime(slot?.endDatetime);
+  const timeString = `${date} ${begin}–${end}`;
+  const name =
+    allocatedSlot?.reservationUnitOption.applicationSection.name ?? "-";
+
+  const applicationPk = application?.pk ?? 0;
+  const reservationPk = slot.recurringReservation?.reservations[0]?.pk ?? null;
+  const link = getReservationUrl(reservationPk);
+
+  const reason =
+    t(
+      `MyUnits.RecurringReservation.Confirmation.RejectionReadinessChoice.${slot.rejectionReason}`
+    ) ?? "-";
+  return {
+    key: `${applicationPk}-${slot.pk}`,
+    applicationPk,
+    pk: slot.pk ?? 0,
+    applicantName,
+    name,
+    unitName: allocatedUnit,
+    allocatedReservationUnitName,
+    time: timeString,
+    link,
+    reason,
+  };
+}
+
+const COLS = [
+  {
+    headerTKey: "ApplicationEvent.headings.id",
+    isSortable: true,
+    key: "application_id,application_event_id",
+    transform: ({ pk, applicationPk }: RejectedOccurrencesView) =>
+      `${applicationPk}-${pk}`,
+  },
+  {
+    headerTKey: "ApplicationEvent.headings.customer",
+    isSortable: true,
+    key: "applicant",
+    transform: ({
+      applicantName,
+      applicationPk,
+      pk,
+    }: RejectedOccurrencesView) => (
+      <ExternalTableLink
+        href={getApplicationUrl(applicationPk, pk)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {truncate(applicantName ?? "-", applicantTruncateLen)}
+        <IconLinkExternal size="xs" aria-hidden />
+      </ExternalTableLink>
+    ),
+  },
+  {
+    headerTKey: "ApplicationEventSchedules.headings.eventName",
+    isSortable: true,
+    key: "rejected_event_name_fi",
+    transform: ({ name }: RejectedOccurrencesView) => {
+      return <span>{truncate(name ?? "-", unitsTruncateLen)}</span>;
+    },
+  },
+  {
+    headerTKey: "ApplicationEvent.headings.unit",
+    isSortable: true,
+    key: "rejected_unit_name_fi",
+    transform: ({ unitName }: RejectedOccurrencesView) => {
+      return <span>{truncate(unitName ?? "-", unitsTruncateLen)}</span>;
+    },
+  },
+  {
+    headerTKey: "ApplicationEventSchedules.headings.reservationUnit",
+    isSortable: true,
+    key: "rejected_reservation_unit_name_fi",
+    transform: ({ allocatedReservationUnitName }: RejectedOccurrencesView) => {
+      return (
+        <span>
+          {truncate(allocatedReservationUnitName ?? "-", unitsTruncateLen)}
+        </span>
+      );
+    },
+  },
+  {
+    headerTKey: "ApplicationEventSchedules.headings.occurrenceTime",
+    isSortable: true,
+    key: "time_of_occurrence",
+    transform: ({ time, link }: RejectedOccurrencesView) => {
+      if (link !== "") {
+        return <ExternalTableLink href={link}>{time}</ExternalTableLink>;
+      }
+      return <span>{time}</span>;
+    },
+  },
+  {
+    headerTKey: "ApplicationEventSchedules.headings.reason",
+    isSortable: true,
+    key: "rejection_reason",
+    transform: ({ reason }: RejectedOccurrencesView) => <span>{reason}</span>,
+  },
+];
+
+const getColConfig = (t: TFunction) =>
+  COLS.map(({ headerTKey, ...col }) => ({
+    ...col,
+    headerName: t(headerTKey),
+  }));
+
+export const SORT_KEYS = COLS.filter((c) => c.isSortable).map((c) => c.key);
+
+export function RejectedOccurrencesTable({
+  rejectedOccurrences,
+  isLoading,
+  sort,
+  sortChanged: onSortChanged,
+}: Props) {
+  const { t } = useTranslation();
+
+  const rows = rejectedOccurrences.map((ro) => timeSlotMapper(t, ro));
+  const cols = memoize(() => getColConfig(t))();
+
+  if (rows.length === 0) {
+    const name = t("ApplicationEvent.emptyFilterPageName");
+    return <div>{t("common.noFilteredResults", { name })}</div>;
+  }
+
+  const sortField = sort?.replaceAll("-", "") ?? "";
+  const sortDirection = sort?.startsWith("-") ? "desc" : "asc";
+  return (
+    <CustomTable
+      disableKey
+      setSort={onSortChanged}
+      indexKey="pk"
+      isLoading={isLoading}
+      rows={rows}
+      cols={cols}
+      initialSortingColumnKey={sortField}
+      initialSortingOrder={sortDirection}
+    />
+  );
+}

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
@@ -365,7 +365,7 @@ export function Review({
                 <Filters
                   units={unitPks}
                   reservationUnits={reservationUnitOptions}
-                  enableReservationUnit
+                  // enableReservationUnit TODO: enable this when the API is updated
                   statusOption="eventShort"
                 />
                 <RejectedOccurrencesDataLoader

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
@@ -30,6 +30,7 @@ import usePermission from "@/hooks/usePermission";
 import { Permission } from "@/modules/permissionHelper";
 import { isApplicationRoundInProgress } from "@/helpers";
 import { breakpoints } from "common";
+import RejectedOccurrencesDataLoader from "./RejectedOccurrencesDataLoader";
 
 const HeadingContainer = styled.div`
   display: flex;
@@ -260,7 +261,7 @@ export function Review({
   const activeTabIndex =
     selectedTab === "events" ? 1 : selectedTab === "allocated" ? 2 : 0;
 
-  const reseevationUnitOptions = filterNonNullable(
+  const reservationUnitOptions = filterNonNullable(
     resUnits.map((x) => toOption(x))
   );
 
@@ -321,10 +322,15 @@ export function Review({
                 ? t("ApplicationRound.madeReservations")
                 : t("ApplicationRound.allocatedReservations")}
             </Tabs.Tab>
+            {isApplicationRoundEnded && (
+              <Tabs.Tab onClick={() => handleTabChange("rejected")}>
+                {t("ApplicationRound.rejectedOccurrences")}
+              </Tabs.Tab>
+            )}
           </Tabs.TabList>
           <Tabs.TabPanel>
             <TabContent>
-              <Filters units={unitPks} />
+              <Filters units={unitPks} enableApplicant />
               <ApplicationDataLoader
                 applicationRoundPk={applicationRound.pk ?? 0}
               />
@@ -332,7 +338,7 @@ export function Review({
           </Tabs.TabPanel>
           <Tabs.TabPanel>
             <TabContent>
-              <Filters units={unitPks} statusOption="event" />
+              <Filters units={unitPks} statusOption="event" enableApplicant />
               <ApplicationEventDataLoader
                 applicationRoundPk={applicationRound.pk ?? 0}
               />
@@ -342,7 +348,8 @@ export function Review({
             <TabContent>
               <Filters
                 units={unitPks}
-                reservationUnits={reseevationUnitOptions}
+                reservationUnits={reservationUnitOptions}
+                enableApplicant
                 enableWeekday
                 enableReservationUnit
                 statusOption="eventShort"
@@ -352,6 +359,21 @@ export function Review({
               />
             </TabContent>
           </Tabs.TabPanel>
+          {isApplicationRoundEnded && (
+            <Tabs.TabPanel>
+              <TabContent>
+                <Filters
+                  units={unitPks}
+                  reservationUnits={reservationUnitOptions}
+                  enableReservationUnit
+                  statusOption="eventShort"
+                />
+                <RejectedOccurrencesDataLoader
+                  applicationRoundPk={applicationRound.pk ?? 0}
+                />
+              </TabContent>
+            </Tabs.TabPanel>
+          )}
         </Tabs>
       </TabWrapper>
     </Container>

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/utils.ts
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/utils.ts
@@ -22,8 +22,10 @@ export function transformApplicationSectionStatus(
           return ApplicationSectionStatusChoice.Unallocated;
         case ApplicationSectionStatusChoice.InAllocation:
           return ApplicationSectionStatusChoice.InAllocation;
-        case ApplicationSectionStatusChoice.Rejected:
-          return ApplicationSectionStatusChoice.Rejected;
+        case ApplicationSectionStatusChoice.Reserved:
+          return ApplicationSectionStatusChoice.Reserved;
+        case ApplicationSectionStatusChoice.Failed:
+          return ApplicationSectionStatusChoice.Failed;
         default:
           return undefined;
       }

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -621,9 +621,10 @@ export enum ApplicationSectionOrderingChoices {
 
 /** An enumeration. */
 export enum ApplicationSectionStatusChoice {
+  Failed = "FAILED",
   Handled = "HANDLED",
   InAllocation = "IN_ALLOCATION",
-  Rejected = "REJECTED",
+  Reserved = "RESERVED",
   Unallocated = "UNALLOCATED",
 }
 

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -621,9 +621,10 @@ export enum ApplicationSectionOrderingChoices {
 
 /** An enumeration. */
 export enum ApplicationSectionStatusChoice {
+  Failed = "FAILED",
   Handled = "HANDLED",
   InAllocation = "IN_ALLOCATION",
-  Rejected = "REJECTED",
+  Reserved = "RESERVED",
   Unallocated = "UNALLOCATED",
 }
 

--- a/packages/eslint-config-custom/react.js
+++ b/packages/eslint-config-custom/react.js
@@ -28,6 +28,7 @@ module.exports = defineConfig({
      },
       rules: {
         "@graphql-eslint/no-deprecated": "warn",
+        "@graphql-eslint/selection-set-depth": ["error", { maxDepth: 10 }],
       },
     },
   ],

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -674,9 +674,10 @@ enum ApplicationSectionOrderingChoices {
 An enumeration.
 """
 enum ApplicationSectionStatusChoice {
+  FAILED
   HANDLED
   IN_ALLOCATION
-  REJECTED
+  RESERVED
   UNALLOCATED
 }
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds a new tab for rejected occurrences to the application round review view 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- End an application round which results in rejected occurrences for an application, and go view that application
- There should be a "Hylätyt ajankohdat" tab as the last tab on the application review page, next to "Varatut vuorot"
- The table contents (along with links and sortability) should work as specified by the ticket
- The "Hylätyt ajankohdat" tab should be visible for all ended application rounds, and shouldn't be shown otherwise. Hence, viewing an application for an open application round should never show the tab

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3370
