### PR TITLE
fix: deprecated order field in graphql api

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -6984,7 +6984,7 @@ export type ReservationUnitsByUnitQuery = {
           email: string;
           pk?: number | null;
         } | null;
-        order?: { id: string; status?: OrderStatus | null } | null;
+        paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
       }> | null;
     }>;
   } | null;
@@ -7024,7 +7024,7 @@ export type ReservationUnitsByUnitQuery = {
       email: string;
       pk?: number | null;
     } | null;
-    order?: { id: string; status?: OrderStatus | null } | null;
+    paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
   }> | null;
 };
 
@@ -7153,7 +7153,7 @@ export type ReservationUnitCalendarQuery = {
         email: string;
         pk?: number | null;
       } | null;
-      order?: { id: string; status?: OrderStatus | null } | null;
+      paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
     }> | null;
   } | null;
   affectingReservations?: Array<{
@@ -7192,7 +7192,7 @@ export type ReservationUnitCalendarQuery = {
       email: string;
       pk?: number | null;
     } | null;
-    order?: { id: string; status?: OrderStatus | null } | null;
+    paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
   }> | null;
 };
 
@@ -7380,7 +7380,7 @@ export type ReservationCommonFragment = {
   reserveeName?: string | null;
   bufferTimeBefore: number;
   bufferTimeAfter: number;
-  order?: { id: string; status?: OrderStatus | null } | null;
+  paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
   user?: { id: string; firstName: string; lastName: string } | null;
 };
 
@@ -7420,7 +7420,7 @@ export type ReservationUnitReservationsFragment = {
     email: string;
     pk?: number | null;
   } | null;
-  order?: { id: string; status?: OrderStatus | null } | null;
+  paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
 };
 
 export type UpdateStaffReservationMutationVariables = Exact<{
@@ -7498,7 +7498,7 @@ export type ReservationsQuery = {
           nameFi?: string | null;
           unit?: { id: string; nameFi?: string | null } | null;
         }>;
-        order?: { id: string; status?: OrderStatus | null } | null;
+        paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
         user?: { id: string; firstName: string; lastName: string } | null;
       } | null;
     } | null>;
@@ -7643,11 +7643,11 @@ export type ReservationSpecialisationFragment = {
   handlingDetails?: string | null;
   bufferTimeBefore: number;
   bufferTimeAfter: number;
-  order?: {
+  paymentOrder: Array<{
     id: string;
     orderUuid?: string | null;
     refundUuid?: string | null;
-  } | null;
+  }>;
   cancelReason?: { id: string; reasonFi?: string | null } | null;
   denyReason?: { id: string; reasonFi?: string | null } | null;
   user?: {
@@ -7761,12 +7761,12 @@ export type ReservationQuery = {
         supportedFields: Array<{ id: string; fieldName: string }>;
       } | null;
     }>;
-    order?: {
+    paymentOrder: Array<{
       id: string;
       status?: OrderStatus | null;
       orderUuid?: string | null;
       refundUuid?: string | null;
-    } | null;
+    }>;
     user?: {
       id: string;
       firstName: string;
@@ -7823,6 +7823,7 @@ export type RecurringReservationQuery = {
       begin: string;
       end: string;
       state: State;
+      paymentOrder: Array<{ id: string; status?: OrderStatus | null }>;
       reservationUnit: Array<{ id: string; pk?: number | null }>;
     }>;
   } | null;
@@ -9507,7 +9508,7 @@ export const ReservationCommonFragmentDoc = gql`
     isBlocked
     workingMemo
     reserveeName
-    order {
+    paymentOrder {
       id
       status
     }
@@ -9632,7 +9633,7 @@ export const ReservationSpecialisationFragmentDoc = gql`
     calendarUrl
     price
     taxPercentageValue
-    order {
+    paymentOrder {
       id
       orderUuid
       refundUuid
@@ -13428,6 +13429,10 @@ export const RecurringReservationDocument = gql`
         begin
         end
         state
+        paymentOrder {
+          id
+          status
+        }
         reservationUnit {
           id
           pk

--- a/apps/admin-ui/src/component/reservations/ReservationsTable.tsx
+++ b/apps/admin-ui/src/component/reservations/ReservationsTable.tsx
@@ -83,8 +83,13 @@ const getColConfig = (t: TFunction): ReservationTableColumn[] => [
     headerName: t("Reservations.headings.paymentStatus"),
     key: "orderStatus",
     isSortable: true,
-    transform: ({ order }: ReservationType) =>
-      order?.status == null ? "-" : t(`Payment.status.${order.status}`),
+    transform: ({ paymentOrder }: ReservationType) => {
+      const order = paymentOrder?.[0];
+      if (!order) {
+        return "-";
+      }
+      return t(`Payment.status.${order.status}`);
+    },
   },
   {
     headerName: t("Reservations.headings.state"),

--- a/apps/admin-ui/src/component/reservations/fragments.tsx
+++ b/apps/admin-ui/src/component/reservations/fragments.tsx
@@ -78,7 +78,7 @@ export const RESERVATION_COMMON_FRAGMENT = gql`
     isBlocked
     workingMemo
     reserveeName
-    order {
+    paymentOrder {
       id
       status
     }

--- a/apps/admin-ui/src/component/reservations/requested/DenyDialog.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/DenyDialog.tsx
@@ -31,7 +31,7 @@ const ActionButtons = styled(Dialog.ActionButtons)`
 // TODO use a fragment
 type ReservationType = Pick<
   NonNullable<ReservationQuery["reservation"]>,
-  "pk" | "handlingDetails" | "price" | "order"
+  "pk" | "handlingDetails" | "price" | "paymentOrder"
 >;
 
 type ReturnAllowedState =
@@ -71,12 +71,15 @@ function convertToReturnState(
   reservations: ReservationType[]
 ): ReturnAllowedState {
   const payed = reservations
-    .map(({ price, order }) => ({
-      price: price ? Number(price) : 0,
-      orderStatus: order?.status ?? null,
-      orderUuid: order?.orderUuid ?? null,
-      refundUuid: order?.refundUuid ?? null,
-    }))
+    .map(({ price, paymentOrder }) => {
+      const order = paymentOrder[0] ?? null;
+      return {
+        price: price ? Number(price) : 0,
+        orderStatus: order?.status ?? null,
+        orderUuid: order?.orderUuid ?? null,
+        refundUuid: order?.refundUuid ?? null,
+      };
+    })
     .filter((x) => isPriceReturnable(x));
 
   // multiple reservations shouldn't be paid and are not tested

--- a/apps/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/RequestedReservation.tsx
@@ -406,6 +406,7 @@ function RequestedReservation({
     parseFloat(pricing.highestPrice) >= 0;
 
   const reservationTagline = createTagString(reservation, t);
+  const order = reservation.paymentOrder[0];
 
   const route = [
     {
@@ -536,9 +537,9 @@ function RequestedReservation({
                   {reservation.price && reservationPrice(reservation, t)}
                 </DataWrapper>
                 <DataWrapper label={t("RequestedReservation.paymentState")}>
-                  {reservation.order?.status == null
+                  {order?.status == null
                     ? "-"
-                    : t(`Payment.status.${reservation.order?.status}`)}
+                    : t(`Payment.status.${order?.status}`)}
                 </DataWrapper>
                 <DataWrapper
                   label={t("RequestedReservation.applyingForFreeOfCharge")}

--- a/apps/admin-ui/src/component/reservations/requested/ReservationTitleSection.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/ReservationTitleSection.tsx
@@ -115,19 +115,20 @@ const ReservationTitleSection = forwardRef<HTMLDivElement, Props>(
       ? getApplicationUrl(applicationPk, sectionPk)
       : null;
 
+    const order = reservation.paymentOrder[0];
     return (
       <div>
         <NameState ref={ref}>
           <H1 $legacy>{overrideTitle ?? getName(reservation, t)}</H1>
           <HorisontalFlex>
             <AlignVertically>
-              {reservation.order?.status && (
+              {order?.status != null && (
                 <Tag
                   theme={{ "--tag-background": "var(--color-engel-light)" }}
                   data-testid="reservation_title_section__order_status"
                   id="reservation-order_status"
                 >
-                  {t(`Payment.status.${reservation.order?.status}`)}
+                  {t(`Payment.status.${order?.status}`)}
                 </Tag>
               )}
             </AlignVertically>

--- a/apps/admin-ui/src/component/reservations/requested/hooks/index.ts
+++ b/apps/admin-ui/src/component/reservations/requested/hooks/index.ts
@@ -7,6 +7,7 @@ import {
   useReservationsByReservationUnitQuery,
   useRecurringReservationQuery,
   ReservationUnitNode,
+  ReservationNode,
 } from "@gql/gql-types";
 import { useTranslation } from "react-i18next";
 import { toApiDate } from "common/src/common/util";
@@ -30,7 +31,9 @@ function convertReservationToCalendarEvent(
   // NOTE funky because we are converting affectedReservations also and they don't have reservationUnit
   // but these are passed to event handlers that allow changing the reservation that requires a reservationUnit
   // affected don't have event handlers so empty reservationUnit is fine
-  r: CalendarReservationFragment & { reservationUnit?: ReservationUnitNode[] },
+  r: CalendarReservationFragment & {
+    reservationUnit?: ReservationUnitNode[];
+  } & Partial<Pick<ReservationNode, "paymentOrder">>,
   blockedName: string
 ): CalendarEventType {
   const title = getEventName(r.type, getReservationTitle(r), blockedName);
@@ -39,12 +42,14 @@ function convertReservationToCalendarEvent(
     "reservationUnit" in r && r.reservationUnit != null
       ? r.reservationUnit
       : [];
+  const paymentOrder = "paymentOrder" in r ? r.paymentOrder ?? [] : [];
   return {
     title,
     event: {
       ...r,
       name: r.name?.trim() !== "" ? r.name : "No name",
       reservationUnit,
+      paymentOrder,
     },
     // TODO use zod for datetime conversions
     start: new Date(r.begin),

--- a/apps/admin-ui/src/component/reservations/requested/hooks/queries.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/hooks/queries.tsx
@@ -94,7 +94,7 @@ const SPECIALISED_SINGLE_RESERVATION_FRAGMENT = gql`
     calendarUrl
     price
     taxPercentageValue
-    order {
+    paymentOrder {
       id
       orderUuid
       refundUuid
@@ -163,6 +163,10 @@ export const RECURRING_RESERVATION_QUERY = gql`
         begin
         end
         state
+        paymentOrder {
+          id
+          status
+        }
         reservationUnit {
           id
           pk

--- a/apps/ui/components/reservations/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/reservations/UnpaidReservationNotification.tsx
@@ -78,7 +78,7 @@ function ReservationNotification({
   disabled?: boolean;
   isLoading?: boolean;
 }) {
-  const startRemainingMinutes = reservation.order?.expiresInMinutes;
+  const startRemainingMinutes = reservation.paymentOrder[0]?.expiresInMinutes;
   const [remainingMinutes, setRemainingMinutes] = useState(
     startRemainingMinutes
   );
@@ -203,7 +203,7 @@ export function InProgressReservationNotification() {
   } = useDeleteReservation();
 
   const { order } = useOrder({
-    orderUuid: unpaidReservation?.order?.orderUuid ?? undefined,
+    orderUuid: unpaidReservation?.paymentOrder[0]?.orderUuid ?? undefined,
   });
   const checkoutUrl = getCheckoutUrl(order, i18n.language);
 

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5979,12 +5979,12 @@ export type ListReservationsQuery = {
         end: string;
         state: State;
         price?: string | null;
-        order?: {
+        paymentOrder: Array<{
           id: string;
           orderUuid?: string | null;
           expiresInMinutes?: number | null;
           status?: OrderStatus | null;
-        } | null;
+        }>;
         reservationUnit: Array<{
           id: string;
           pk?: number | null;
@@ -6089,11 +6089,11 @@ export type ReservationQuery = {
     description?: string | null;
     numPersons?: number | null;
     user?: { id: string; email: string; pk?: number | null } | null;
-    order?: {
+    paymentOrder: Array<{
       id: string;
       orderUuid?: string | null;
       status?: OrderStatus | null;
-    } | null;
+    }>;
     reservationUnit: Array<{
       id: string;
       canApplyFreeOfCharge: boolean;
@@ -9425,7 +9425,7 @@ export const ListReservationsDocument = gql`
           name
           bufferTimeBefore
           bufferTimeAfter
-          order {
+          paymentOrder {
             id
             orderUuid
             expiresInMinutes
@@ -9543,7 +9543,7 @@ export const ReservationDocument = gql`
       price
       priceNet
       taxPercentageValue
-      order {
+      paymentOrder {
         id
         orderUuid
         status

--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -100,7 +100,7 @@ export const LIST_RESERVATIONS = gql`
           name
           bufferTimeBefore
           bufferTimeAfter
-          order {
+          paymentOrder {
             id
             orderUuid
             expiresInMinutes
@@ -177,7 +177,7 @@ export const GET_RESERVATION = gql`
       price
       priceNet
       taxPercentageValue
-      order {
+      paymentOrder {
         id
         orderUuid
         status

--- a/apps/ui/pages/reservation/confirmation/[id].tsx
+++ b/apps/ui/pages/reservation/confirmation/[id].tsx
@@ -74,9 +74,10 @@ const ReservationSuccess = ({ reservationPk, apiBaseUrl }: Props) => {
     order,
     isError: orderError,
     isLoading: orderLoading,
-  } = useOrder({ orderUuid: reservation?.order?.orderUuid ?? "" });
+  } = useOrder({ orderUuid: reservation?.paymentOrder[0]?.orderUuid ?? "" });
 
-  const isOrderUuidMissing = reservation && !reservation.order?.orderUuid;
+  const isOrderUuidMissing =
+    reservation && !reservation.paymentOrder[0]?.orderUuid;
 
   // TODO display error if the orderUuid is missing or the pk is invalid
   if (isError || orderError || isOrderUuidMissing) {

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -423,7 +423,7 @@ function Reservation({
 
   // TODO this should be moved to SSR also
   const { order, isLoading: orderLoading } = useOrder({
-    orderUuid: reservation.order?.orderUuid ?? "",
+    orderUuid: reservation.paymentOrder[0]?.orderUuid ?? "",
   });
 
   const reservationUnit = reservation.reservationUnit?.[0] ?? null;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: Core: deprecated `order` field in favour of `paymentOrder`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automated: Lint.
- Manual testing: payment status should be shown correctly on both ui:s.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
