### PR TITLE
fix: nowrap reservation subheading date

### DIFF
--- a/apps/admin-ui/src/component/Unit/ReservationUnitCard.tsx
+++ b/apps/admin-ui/src/component/Unit/ReservationUnitCard.tsx
@@ -14,6 +14,7 @@ import { ImageType, type UnitQuery } from "@gql/gql-types";
 import { BasicLink } from "@/styles/util";
 import IconDraft from "@/images/icon_draft.svg";
 import { getImageSource } from "common/src/helpers";
+import { NoWrap } from "common/styles/util";
 
 type UnitType = NonNullable<UnitQuery["unit"]>;
 type ReservationUnitType = NonNullable<UnitType["reservationunitSet"]>[0];
@@ -97,10 +98,6 @@ const Prop = styled.div<{ $disabled?: boolean }>`
 const Published = styled(Tag)`
   background-color: var(--color-success);
   color: var(--color-white);
-`;
-
-const NoWrap = styled.span`
-  white-space: nowrap;
 `;
 
 export function ReservationUnitCard({

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -13,6 +13,7 @@ import {
 import { useTranslation } from "next-i18next";
 import { H2, H4, fontRegular } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
+import { NoWrap } from "common/styles/util";
 import {
   CustomerTypeChoice,
   ReservationStateChoice,
@@ -550,7 +551,7 @@ function Reservation({
               >
                 {getReservationUnitName(reservationUnit)}
               </Link>
-              <span data-testid="reservation__time">{timeString}</span>
+              <NoWrap data-testid="reservation__time">{timeString}</NoWrap>
             </SubHeading>
             <StatusContainer>
               <ReservationStatus

--- a/packages/common/styles/util.ts
+++ b/packages/common/styles/util.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const NoWrap = styled.span`
+  white-space: nowrap;
+`;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: reservation subheading date breaking at awkward places.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: style (CSS) change, check the reservation page on mobile / desktop. 

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
