### PR TITLE
fix: order filter options and fix reservation type filter

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -7921,8 +7921,11 @@ export type ReservationUnitsFilterParamsQuery = {
 };
 
 export type ReservationUnitTypesFilterQueryVariables = Exact<{
-  offset?: InputMaybe<Scalars["Int"]["input"]>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  after?: InputMaybe<Scalars["String"]["input"]>;
+  orderBy?: InputMaybe<
+    | Array<InputMaybe<ReservationUnitTypeOrderingChoices>>
+    | InputMaybe<ReservationUnitTypeOrderingChoices>
+  >;
 }>;
 
 export type ReservationUnitTypesFilterQuery = {
@@ -7936,6 +7939,9 @@ export type ReservationUnitTypesFilterQuery = {
 
 export type UnitsFilterQueryVariables = Exact<{
   after?: InputMaybe<Scalars["String"]["input"]>;
+  orderBy?: InputMaybe<
+    Array<InputMaybe<UnitOrderingChoices>> | InputMaybe<UnitOrderingChoices>
+  >;
 }>;
 
 export type UnitsFilterQuery = {
@@ -13784,8 +13790,11 @@ export type ReservationUnitsFilterParamsQueryResult = Apollo.QueryResult<
   ReservationUnitsFilterParamsQueryVariables
 >;
 export const ReservationUnitTypesFilterDocument = gql`
-  query ReservationUnitTypesFilter($offset: Int, $first: Int) {
-    reservationUnitTypes(offset: $offset, first: $first) {
+  query ReservationUnitTypesFilter(
+    $after: String
+    $orderBy: [ReservationUnitTypeOrderingChoices]
+  ) {
+    reservationUnitTypes(after: $after, orderBy: $orderBy) {
       edges {
         node {
           id
@@ -13810,8 +13819,8 @@ export const ReservationUnitTypesFilterDocument = gql`
  * @example
  * const { data, loading, error } = useReservationUnitTypesFilterQuery({
  *   variables: {
- *      offset: // value for 'offset'
- *      first: // value for 'first'
+ *      after: // value for 'after'
+ *      orderBy: // value for 'orderBy'
  *   },
  * });
  */
@@ -13865,8 +13874,8 @@ export type ReservationUnitTypesFilterQueryResult = Apollo.QueryResult<
   ReservationUnitTypesFilterQueryVariables
 >;
 export const UnitsFilterDocument = gql`
-  query UnitsFilter($after: String) {
-    units(onlyWithPermission: true, after: $after) {
+  query UnitsFilter($after: String, $orderBy: [UnitOrderingChoices]) {
+    units(onlyWithPermission: true, after: $after, orderBy: $orderBy) {
       edges {
         node {
           id
@@ -13896,6 +13905,7 @@ export const UnitsFilterDocument = gql`
  * const { data, loading, error } = useUnitsFilterQuery({
  *   variables: {
  *      after: // value for 'after'
+ *      orderBy: // value for 'orderBy'
  *   },
  * });
  */

--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -7408,6 +7408,9 @@ export type ReservationsQueryVariables = Exact<{
     | Array<InputMaybe<Scalars["Int"]["input"]>>
     | InputMaybe<Scalars["Int"]["input"]>
   >;
+  reservationType?: InputMaybe<
+    Array<InputMaybe<ReservationTypeChoice>> | InputMaybe<ReservationTypeChoice>
+  >;
   state?: InputMaybe<
     | Array<InputMaybe<ReservationStateChoice>>
     | InputMaybe<ReservationStateChoice>
@@ -12704,6 +12707,7 @@ export const ReservationsDocument = gql`
     $unit: [Int]
     $reservationUnit: [Int]
     $reservationUnitType: [Int]
+    $reservationType: [ReservationTypeChoice]
     $state: [ReservationStateChoice]
     $orderStatus: [OrderStatusWithFree]
     $textSearch: String
@@ -12723,6 +12727,7 @@ export const ReservationsDocument = gql`
       unit: $unit
       reservationUnit: $reservationUnit
       reservationUnitType: $reservationUnitType
+      reservationType: $reservationType
       state: $state
       orderStatus: $orderStatus
       textSearch: $textSearch
@@ -12778,6 +12783,7 @@ export const ReservationsDocument = gql`
  *      unit: // value for 'unit'
  *      reservationUnit: // value for 'reservationUnit'
  *      reservationUnitType: // value for 'reservationUnitType'
+ *      reservationType: // value for 'reservationType'
  *      state: // value for 'state'
  *      orderStatus: // value for 'orderStatus'
  *      textSearch: // value for 'textSearch'

--- a/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
+++ b/apps/admin-ui/src/component/my-units/MyUnitRecurringReservation/MyUnitRecurringReservationForm.tsx
@@ -203,7 +203,7 @@ const MyUnitRecurringReservationForm = ({ reservationUnits }: Props) => {
     reservationUnitPk: reservationUnit?.pk ?? undefined,
     begin: fromUIDate(getValues("startingDate")) ?? new Date(),
     end: fromUIDate(getValues("endingDate")) ?? new Date(),
-    reservationType: reservationType as ReservationTypeChoice,
+    reservationType,
   });
 
   const navigate = useNavigate();

--- a/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
+++ b/apps/admin-ui/src/component/my-units/create-reservation/CreateReservationModal.tsx
@@ -116,8 +116,7 @@ const useCheckFormCollisions = ({
       before: bufferBeforeSeconds,
       after: bufferAfterSeconds,
     },
-    reservationType: (type ??
-      ReservationTypeChoice.Blocked) as ReservationTypeChoice,
+    reservationType: type,
   });
 
   return { hasCollisions };

--- a/apps/admin-ui/src/component/reservations/ReservationsDataLoader.tsx
+++ b/apps/admin-ui/src/component/reservations/ReservationsDataLoader.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
 import { type ApolloError } from "@apollo/client";
 import {
-  type QueryReservationsArgs,
   ReservationOrderingChoices,
   useReservationsQuery,
   ReservationStateChoice,
   OrderStatusWithFree,
+  type ReservationsQueryVariables,
 } from "@gql/gql-types";
 import { More } from "@/component/More";
 import { LIST_PAGE_SIZE } from "@/common/const";
@@ -15,6 +15,7 @@ import { ReservationsTable } from "./ReservationsTable";
 import { fromUIDate, toApiDate } from "common/src/common/util";
 import { filterNonNullable, toNumber } from "common/src/helpers";
 import { useSearchParams } from "react-router-dom";
+import { transformReservationTypeSafe } from "common/src/conversion";
 
 function transformPaymentStatusSafe(t: string): OrderStatusWithFree | null {
   switch (t) {
@@ -56,7 +57,9 @@ function transformStateSafe(t: string): ReservationStateChoice | null {
   }
 }
 
-function mapFilterParams(searchParams: URLSearchParams): QueryReservationsArgs {
+function mapFilterParams(
+  searchParams: URLSearchParams
+): ReservationsQueryVariables {
   const reservationUnitType = searchParams
     .getAll("reservationUnitType")
     .map(Number)
@@ -75,6 +78,10 @@ function mapFilterParams(searchParams: URLSearchParams): QueryReservationsArgs {
 
   const state = filterNonNullable(
     searchParams.getAll("state").map(transformStateSafe)
+  );
+
+  const reservationType = filterNonNullable(
+    searchParams.getAll("reservationType").map(transformReservationTypeSafe)
   );
 
   const textSearch = searchParams.get("search");
@@ -109,10 +116,11 @@ function mapFilterParams(searchParams: URLSearchParams): QueryReservationsArgs {
 
   const applyingForFreeOfCharge = searchParams.get("freeOfCharge") === "true";
 
-  const filterParams = {
+  return {
     unit,
     reservationUnit,
     reservationUnitType,
+    reservationType,
     state,
     orderStatus,
     textSearch,
@@ -125,8 +133,6 @@ function mapFilterParams(searchParams: URLSearchParams): QueryReservationsArgs {
     isRecurring,
     applyingForFreeOfCharge,
   };
-
-  return filterParams;
 }
 
 export function ReservationsDataLoader(): JSX.Element {

--- a/apps/admin-ui/src/component/reservations/queries.tsx
+++ b/apps/admin-ui/src/component/reservations/queries.tsx
@@ -10,6 +10,7 @@ export const RESERVATIONS_QUERY = gql`
     $unit: [Int]
     $reservationUnit: [Int]
     $reservationUnitType: [Int]
+    $reservationType: [ReservationTypeChoice]
     $state: [ReservationStateChoice]
     $orderStatus: [OrderStatusWithFree]
     $textSearch: String
@@ -29,6 +30,7 @@ export const RESERVATIONS_QUERY = gql`
       unit: $unit
       reservationUnit: $reservationUnit
       reservationUnitType: $reservationUnitType
+      reservationType: $reservationType
       state: $state
       orderStatus: $orderStatus
       textSearch: $textSearch

--- a/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
+++ b/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from "react";
 import { gql } from "@apollo/client";
 import { filterNonNullable } from "common/src/helpers";
-import { useReservationUnitsFilterParamsQuery } from "@gql/gql-types";
+import {
+  ReservationUnitOrderingChoices,
+  useReservationUnitsFilterParamsQuery,
+} from "@gql/gql-types";
 
 export const RESERVATION_UNITS_FILTER_PARAMS_QUERY = gql`
   query ReservationUnitsFilterParams(
@@ -32,7 +35,11 @@ export const RESERVATION_UNITS_FILTER_PARAMS_QUERY = gql`
 `;
 
 export function useReservationUnitOptions() {
-  const { data, loading, fetchMore } = useReservationUnitsFilterParamsQuery();
+  const { data, loading, fetchMore } = useReservationUnitsFilterParamsQuery({
+    variables: {
+      orderBy: [ReservationUnitOrderingChoices.NameFiAsc],
+    },
+  });
 
   // auto fetch more (there is no limit, expect number of them would be a few hundred, but in theory this might cause problems)
   // NOTE have to useEffect, onComplete stops at 200 items

--- a/apps/admin-ui/src/hooks/useReservationUnitTypes.tsx
+++ b/apps/admin-ui/src/hooks/useReservationUnitTypes.tsx
@@ -1,10 +1,16 @@
 import { gql } from "@apollo/client";
 import { filterNonNullable } from "common/src/helpers";
-import { useReservationUnitTypesFilterQuery } from "@gql/gql-types";
+import {
+  ReservationUnitTypeOrderingChoices,
+  useReservationUnitTypesFilterQuery,
+} from "@gql/gql-types";
 
 export const RESERVATION_UNIT_TYPES_QUERY = gql`
-  query ReservationUnitTypesFilter($offset: Int, $first: Int) {
-    reservationUnitTypes(offset: $offset, first: $first) {
+  query ReservationUnitTypesFilter(
+    $after: String
+    $orderBy: [ReservationUnitTypeOrderingChoices]
+  ) {
+    reservationUnitTypes(after: $after, orderBy: $orderBy) {
       edges {
         node {
           id
@@ -18,7 +24,11 @@ export const RESERVATION_UNIT_TYPES_QUERY = gql`
 `;
 
 export function useReservationUnitTypes() {
-  const { data, loading } = useReservationUnitTypesFilterQuery();
+  const { data, loading } = useReservationUnitTypesFilterQuery({
+    variables: {
+      orderBy: ReservationUnitTypeOrderingChoices.NameFiAsc,
+    },
+  });
 
   const qd = data?.reservationUnitTypes;
   const types = filterNonNullable(qd?.edges.map((x) => x?.node));

--- a/apps/admin-ui/src/hooks/useUnitOptions.tsx
+++ b/apps/admin-ui/src/hooks/useUnitOptions.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
 import { gql } from "@apollo/client";
 import { filterNonNullable } from "common/src/helpers";
-import { useUnitsFilterQuery } from "@gql/gql-types";
+import { UnitOrderingChoices, useUnitsFilterQuery } from "@gql/gql-types";
 
 // exporting so it doesn't get removed
 // TODO combine with other options queries so we only make a single request for all of them
 export const UNITS_QUERY = gql`
-  query UnitsFilter($after: String) {
-    units(onlyWithPermission: true, after: $after) {
+  query UnitsFilter($after: String, $orderBy: [UnitOrderingChoices]) {
+    units(onlyWithPermission: true, after: $after, orderBy: $orderBy) {
       edges {
         node {
           id
@@ -25,7 +25,11 @@ export const UNITS_QUERY = gql`
 `;
 
 export function useUnitOptions() {
-  const { data, loading, fetchMore } = useUnitsFilterQuery();
+  const { data, loading, fetchMore } = useUnitsFilterQuery({
+    variables: {
+      orderBy: [UnitOrderingChoices.NameFiAsc],
+    },
+  });
 
   // auto fetch more (there is no limit, expect number of them would be a few hundred, but in theory this might cause problems)
   // NOTE have to useEffect, onComplete stops at 200 items

--- a/packages/common/src/conversion.ts
+++ b/packages/common/src/conversion.ts
@@ -1,4 +1,4 @@
-import { Weekday } from "../gql/gql-types";
+import { ReservationTypeChoice, Weekday } from "../gql/gql-types";
 
 export type Day = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 export function transformWeekday(d: Day): Weekday {
@@ -36,5 +36,24 @@ export function convertWeekday(d: Weekday): Day {
       return 5;
     case Weekday.Sunday:
       return 6;
+  }
+}
+
+export function transformReservationTypeSafe(
+  d: string
+): ReservationTypeChoice | null {
+  switch (d) {
+    case ReservationTypeChoice.Staff:
+      return ReservationTypeChoice.Staff;
+    case ReservationTypeChoice.Behalf:
+      return ReservationTypeChoice.Behalf;
+    case ReservationTypeChoice.Blocked:
+      return ReservationTypeChoice.Blocked;
+    case ReservationTypeChoice.Normal:
+      return ReservationTypeChoice.Normal;
+    case ReservationTypeChoice.Seasonal:
+      return ReservationTypeChoice.Seasonal;
+    default:
+      return null;
   }
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: use .tsx extension so gql lint works in the editor
- fix: sort filter options with nameFi when making the query
- fix: reservation type filter not working (missing from query)
- fix: use correct query param type when converting filter parameters (reservations list page)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: unit, reservation unit, reservation unit type comboboxes should have their options sorted by name (admin-ui).
- Manual testing: reservation type filter should work correctly (admin-ui).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3401](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3401) (bug fixes)


[TILA-3401]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ