### PR TITLE
fix: allocation card missing unit name

### DIFF
--- a/apps/admin-ui/src/common/const.ts
+++ b/apps/admin-ui/src/common/const.ts
@@ -36,6 +36,7 @@ export const GQL_MAX_RESULTS_PER_QUERY = 100;
 export const MAX_NAME_LENGTH = 22;
 export const MAX_UNIT_NAME_LENGTH = 40;
 export const MAX_APPLICATION_ROUND_NAME_LENGTH = 30;
+export const MAX_ALLOCATION_CARD_UNIT_NAME_LENGTH = 31;
 
 // TODO PUBLIC_URL should be cleaned up and always end in /
 export const HERO_IMAGE_URL = `${PUBLIC_URL}/hero-user@1x.jpg`;

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/ApplicationEventCard.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/ApplicationEventCard.tsx
@@ -9,7 +9,7 @@ import {
 } from "@gql/gql-types";
 import { SemiBold, fontMedium } from "common";
 import { ageGroup } from "@/component/reservations/requested/util";
-import { filterNonNullable } from "common/src/helpers";
+import { filterNonNullable, truncate } from "common/src/helpers";
 import { convertWeekday } from "common/src/conversion";
 import {
   type ReservationUnitFilterQueryT,
@@ -24,6 +24,7 @@ import { type ApolloQueryResult } from "@apollo/client";
 import { getApplicationSectionUrl } from "@/common/urls";
 import { useNotification } from "@/context/NotificationContext";
 import { getApplicantName } from "@/helpers";
+import { MAX_ALLOCATION_CARD_UNIT_NAME_LENGTH } from "@/common/const";
 
 export type AllocationApplicationSectionCardType =
   | "unallocated"
@@ -410,6 +411,9 @@ function AllocatedScheduleSection({
     allocatedReservationUnit != null &&
     allocatedReservationUnit.pk !== currentReservationUnit.pk;
 
+  const combinedName = `${allocatedReservationUnit?.nameFi ?? "-"}, ${
+    allocatedReservationUnit.unit?.nameFi ?? "-"
+  }`;
   return (
     <ScheduleCard key={allocatedTimeSlot.pk}>
       {/* TODO functionality for selecting the schedule vs. an applicationSection */}
@@ -423,7 +427,9 @@ function AllocatedScheduleSection({
         <SemiBold>
           {t(`dayShort.${day}`)} {formatTime(begin)}-{formatTime(end)}
         </SemiBold>
-        <div>{allocatedReservationUnit?.nameFi ?? "-"}</div>
+        <div>
+          {truncate(combinedName, MAX_ALLOCATION_CARD_UNIT_NAME_LENGTH)}
+        </div>
       </div>
     </ScheduleCard>
   );


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: add unit name (with the reservation unit name) to allocated cards.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: in allocation tool check that cards for already allocated have the unit name also (not just reservation unit), and it's sized reasonably. 

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3448](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3448)


[TILA-3448]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ