### PR TITLE
fix: my-unit date query param shown in tags

### DIFF
--- a/apps/admin-ui/src/component/my-units/UnitReservationsView.tsx
+++ b/apps/admin-ui/src/component/my-units/UnitReservationsView.tsx
@@ -89,7 +89,7 @@ function UnitReservationsView(): JSX.Element {
           options={reservationUnitTypeOptions}
         />
       </AutoGrid>
-      <SearchTags hide={[]} translateTag={translateTag} />
+      <SearchTags hide={["date"]} translateTag={translateTag} />
       <HR />
       <HorisontalFlexWrapper>
         <Button


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: incorrectly showing date query param as a tag even though it should not be clearable.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: my-units page should not allow clearing the date (selected from the calendar) using the tags, nor should it be shown in them (admin-ui).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3419](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3419) (bugfix)


[TILA-3419]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ