### PR TITLE
fix: search page toggle and pagination

### DIFF
--- a/apps/ui/components/search/SeasonalSearchForm.tsx
+++ b/apps/ui/components/search/SeasonalSearchForm.tsx
@@ -191,7 +191,7 @@ export function SeasonalSearchForm({
       if (cv[1] == null || cv[1] === "") return c;
       return { ...c, [cv[0]]: cv[1] };
     }, {});
-    handleSearch(searchCriteria);
+    handleSearch(searchCriteria, true);
   };
 
   const translateTag = (key: string, value: string): string | undefined => {
@@ -209,7 +209,7 @@ export function SeasonalSearchForm({
   };
 
   const multiSelectFilters = ["unit", "reservationUnitTypes", "purposes"];
-  const hideList = ["applicationRound", "order", "sort"];
+  const hideList = ["applicationRound", "order", "sort", "ref"];
 
   return (
     <form noValidate onSubmit={handleSubmit(search)}>

--- a/apps/ui/components/search/SingleSearchForm.tsx
+++ b/apps/ui/components/search/SingleSearchForm.tsx
@@ -214,7 +214,7 @@ const multiSelectFilters = [
   "equipments",
 ];
 // we don't want to show "showOnlyReservable" as a FilterTag, as it has its own checkbox in the form
-const hideTagList = ["showOnlyReservable", "order", "sort"];
+const hideTagList = ["showOnlyReservable", "order", "sort", "ref"];
 
 // TODO rewrite this witout the form state (use query params directly, but don't refresh the page)
 export function SingleSearchForm({
@@ -270,13 +270,13 @@ export function SingleSearchForm({
     }
   };
 
-  const search: SubmitHandler<FormValues> = (criteria: FormValues) => {
+  const onSearch: SubmitHandler<FormValues> = (criteria: FormValues) => {
     // Remove empty (null || "") values from the criteria
     const searchCriteria = Object.entries(criteria).reduce((c, cv) => {
       if (cv[1] == null || cv[1] === "") return c;
       return { ...c, [cv[0]]: cv[1] };
     }, {});
-    handleSearch(searchCriteria);
+    handleSearch(searchCriteria, true);
   };
 
   const showOptionalFilters =
@@ -286,7 +286,7 @@ export function SingleSearchForm({
     formValues.textSearch != null;
 
   return (
-    <form noValidate onSubmit={handleSubmit(search)}>
+    <form noValidate onSubmit={handleSubmit(onSearch)}>
       <TopContainer>
         <Filters>
           <ControlledMultiSelect
@@ -397,7 +397,7 @@ export function SingleSearchForm({
               placeholder={t("searchForm:searchTermPlaceholder")}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
-                  handleSubmit(search)();
+                  handleSubmit(onSearch)();
                 }
               }}
             />

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -220,15 +220,19 @@ export function mapSingleParamToFormValue(
   return param;
 }
 
+// default to false if the param is present but not true, null if not present
 export function mapSingleBooleanParamToFormValue(
   param: string | string[] | undefined
 ): boolean | null {
   if (param == null) return null;
   if (param === "") return null;
   if (Array.isArray(param)) {
-    return param.find((p) => p === "true") != null ? true : null;
+    const found = param.find((p) => p === "true");
+    if (found != null) return true;
+    if (param.length > 1) return false;
+    return null;
   }
-  return param === "true" ? true : null;
+  return param === "true";
 }
 
 export function mapQueryParamToNumber(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: boolean query param incorrectly defaulted to `null` instead of `false` causing toggle to show incorrect value.
- Fix: search pagination breaking: "Show more" button disappears if the query params have not changed and "Search" is pressed again. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing (see Jira).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3496](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3496)


[TILA-3496]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ