### PR TITLE
Fix VAT change

### DIFF
--- a/apps/admin-ui/src/component/reservations/requested/util.ts
+++ b/apps/admin-ui/src/component/reservations/requested/util.ts
@@ -38,7 +38,6 @@ export function reservationPrice(
   return getReservationPrice(
     reservation.price,
     t("RequestedReservation.noPrice"),
-    "fi",
     true
   );
 }
@@ -95,17 +94,17 @@ export function getReservationPriceDetails(
   const taxP = parseFloat(pricing.taxPercentage?.value ?? "");
   const taxPercentage = Number.isNaN(taxP) ? 0 : taxP;
   return priceUnit === PriceUnit.Fixed
-    ? getReservationPrice(maxPrice, t("RequestedReservation.noPrice"))
+    ? getReservationPrice(maxPrice, t("RequestedReservation.noPrice"), false)
     : t("RequestedReservation.ApproveDialog.priceBreakdown", {
         volume: formatters.strippedDecimal.format(volume),
         units: t(`RequestedReservation.ApproveDialog.priceUnits.${priceUnit}`),
         vatPercent: formatters.whole.format(taxPercentage),
         unit: t(`RequestedReservation.ApproveDialog.priceUnit.${priceUnit}`),
-        unitPrice: getReservationPrice(maxPrice, ""),
+        unitPrice: getReservationPrice(maxPrice, "", false),
         price: getReservationPrice(
           String(volume * parseFloat(maxPrice)),
           t("RequestedReservation.noPrice"),
-          "fi"
+          false
         ),
       });
 }

--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -257,7 +257,7 @@ function TogglerLabelContent({
   areControlsVisible: boolean;
   togglerLabel: string;
   t: TFunction;
-  price?: string;
+  price: string | null;
 }) {
   if (areControlsVisible) {
     return <div>&nbsp;</div>;
@@ -287,7 +287,6 @@ function ReservationCalendarControls({
   const { control, watch, handleSubmit, setValue } = reservationForm;
   const formDate = watch("date");
   const formDuration = watch("duration");
-  const date = new Date(formDate ?? "");
   const dateValue = useMemo(() => fromUIDate(formDate ?? ""), [formDate]);
   const duration = !Number.isNaN(Number(formDuration))
     ? Number(formDuration)
@@ -306,14 +305,14 @@ function ReservationCalendarControls({
   })();
 
   const price =
-    date != null && duration != null
+    dateValue != null && duration != null
       ? getReservationUnitPrice({
           reservationUnit,
-          pricingDate: date,
+          pricingDate: dateValue,
           minutes: duration,
           trailingZeros: true,
         })
-      : undefined;
+      : null;
 
   const lastOpeningDate = maxBy(
     reservationUnit.reservableTimeSpans,

--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -310,7 +310,6 @@ function ReservationCalendarControls({
           reservationUnit,
           pricingDate: dateValue,
           minutes: duration,
-          trailingZeros: true,
         })
       : null;
 

--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -18,9 +18,10 @@ import IconWithText from "../common/IconWithText";
 import { Images } from "./Images";
 import {
   getActivePricing,
-  getPrice,
+  getPriceString,
   getReservationUnitName,
   getUnitName,
+  isReservationUnitPaid,
 } from "@/modules/reservationUnit";
 import BreadcrumbWrapper from "../common/BreadcrumbWrapper";
 import { isReservationStartInFuture } from "@/modules/reservation";
@@ -154,14 +155,10 @@ function Head({
   const maxReservationDuration = formatDuration(maxDur / 60, t, true);
 
   const pricing = getActivePricing(reservationUnit);
-  const unitPrice = pricing ? getPrice({ pricing }) : undefined;
+  const unitPrice = pricing ? getPriceString({ pricing }) : undefined;
 
-  const unitPriceSuffix =
-    pricing &&
-    getPrice({ pricing, asNumeral: true }) !== "0" &&
-    subventionSuffix != null
-      ? subventionSuffix
-      : undefined;
+  const isPaid = isReservationUnitPaid(reservationUnit.pricings);
+  const hasSubventionSuffix = pricing && isPaid && subventionSuffix != null;
 
   const reservationUnitName = getReservationUnitName(reservationUnit);
 
@@ -241,7 +238,7 @@ function Head({
                     text={
                       <>
                         {unitPrice}
-                        {unitPriceSuffix}
+                        {hasSubventionSuffix ? subventionSuffix : null}
                       </>
                     }
                   />
@@ -252,7 +249,7 @@ function Head({
               )}
             </div>
             <Images
-              images={orderImages(reservationUnit.images ?? [])}
+              images={orderImages(reservationUnit.images)}
               contextName={reservationUnitName}
             />
           </RightContainer>

--- a/apps/ui/components/reservation-unit/QuickReservation.tsx
+++ b/apps/ui/components/reservation-unit/QuickReservation.tsx
@@ -188,7 +188,6 @@ function QuickReservation({
       reservationUnit,
       pricingDate: dateValue,
       minutes: duration,
-      trailingZeros: true,
     });
   }, [duration, reservationUnit, dateValue]);
 

--- a/apps/ui/components/reservation-unit/RelatedUnits.tsx
+++ b/apps/ui/components/reservation-unit/RelatedUnits.tsx
@@ -14,7 +14,7 @@ import IconWithText from "../common/IconWithText";
 import Carousel from "../Carousel";
 import {
   getActivePricing,
-  getPrice,
+  getPriceString,
   getReservationUnitName,
   getUnitName,
 } from "@/modules/reservationUnit";
@@ -126,7 +126,8 @@ function RelatedUnits({ units }: PropsType): JSX.Element | null {
         {units.map((unit) => {
           const name = getReservationUnitName(unit);
           const pricing = getActivePricing(unit);
-          const unitPrice = pricing != null ? getPrice({ pricing }) : undefined;
+          const unitPrice =
+            pricing != null ? getPriceString({ pricing }) : undefined;
           const reservationUnitTypeName =
             unit.reservationUnitType != null
               ? getTranslation(unit.reservationUnitType, "name")

--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -210,11 +210,12 @@ function ReservationCard({ reservation, type }: PropsT): JSX.Element {
             new Date(reservation.end),
             new Date(reservation.begin)
           ),
-          trailingZeros: true,
+          trailingZeros: false,
         })
       : getReservationPrice(
           reservation.price ?? undefined,
           t("prices:priceFree"),
+          false,
           i18n.language
         );
 

--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -210,12 +210,11 @@ function ReservationCard({ reservation, type }: PropsT): JSX.Element {
             new Date(reservation.end),
             new Date(reservation.begin)
           ),
-          trailingZeros: false,
         })
       : getReservationPrice(
           reservation.price ?? undefined,
           t("prices:priceFree"),
-          false,
+          true,
           i18n.language
         );
 

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -141,7 +141,6 @@ export function ReservationInfoCard({
           reservationUnit,
           pricingDate: new Date(begin),
           minutes: duration,
-          trailingZeros: true,
         })
       : getReservationPrice(
           reservation?.price,

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -7,8 +7,14 @@ import styled from "styled-components";
 import { getReservationPrice, formatters as getFormatters } from "common";
 import { breakpoints } from "common/src/common/style";
 import { H4, Strong } from "common/src/common/typography";
-import type { ReservationInfoCardFragment } from "@gql/gql-types";
-import { getReservationUnitPrice } from "@/modules/reservationUnit";
+import {
+  ReservationStateChoice,
+  type ReservationInfoCardFragment,
+} from "@gql/gql-types";
+import {
+  getReservationUnitPrice,
+  isReservationUnitPaid,
+} from "@/modules/reservationUnit";
 import {
   capitalize,
   formatDuration,
@@ -127,7 +133,7 @@ export function ReservationInfoCard({
     return null;
   }
 
-  const price: string | undefined =
+  const price: string | null =
     begin &&
     (reservation?.state === "REQUIRES_HANDLING" ||
       shouldDisplayReservationUnitPrice)
@@ -140,18 +146,13 @@ export function ReservationInfoCard({
       : getReservationPrice(
           reservation?.price,
           t("prices:priceFree"),
-          i18n.language,
-          true
+          true,
+          i18n.language
         );
 
   const shouldDisplayTaxPercentage: boolean =
-    reservation.state === "REQUIRES_HANDLING" && begin
-      ? getReservationUnitPrice({
-          reservationUnit,
-          pricingDate: new Date(begin),
-          minutes: 0,
-          asNumeral: true,
-        }) !== "0"
+    reservation.state === ReservationStateChoice.RequiresHandling && begin
+      ? isReservationUnitPaid(reservationUnit.pricings, new Date(begin))
       : Number(reservation?.price) > 0;
 
   const name = getTranslation(reservationUnit, "name");

--- a/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
+++ b/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
@@ -17,7 +17,7 @@ import IconWithText from "../common/IconWithText";
 import { truncatedText } from "@/styles/util";
 import {
   getActivePricing,
-  getPrice,
+  getPriceString,
   getReservationUnitName,
   getUnitName,
 } from "@/modules/reservationUnit";
@@ -263,7 +263,7 @@ function ReservationUnitCard({ reservationUnit }: PropsT): JSX.Element {
   const unitName = getUnitName(reservationUnit.unit ?? undefined);
 
   const pricing = getActivePricing(reservationUnit);
-  const unitPrice = pricing != null ? getPrice({ pricing }) : undefined;
+  const unitPrice = pricing != null ? getPriceString({ pricing }) : undefined;
 
   const reservationUnitTypeName =
     reservationUnit.reservationUnitType != null

--- a/apps/ui/modules/__tests__/reservationUnit.test.ts
+++ b/apps/ui/modules/__tests__/reservationUnit.test.ts
@@ -38,6 +38,7 @@ import {
   isReservationUnitPaidInFuture,
   isReservationUnitPublished,
   isReservationUnitReservable,
+  GetPriceType,
 } from "../reservationUnit";
 import mockTranslations from "../../public/locales/fi/prices.json";
 import { type ReservableMap, dateToKey, type RoundPeriod } from "../reservable";
@@ -217,7 +218,7 @@ describe("getPriceString", () => {
     highestPrice?: number;
     priceUnit?: PriceUnit;
     minutes?: number;
-  }) {
+  }): GetPriceType {
     return {
       pricing: constructPricing({
         lowestPrice,
@@ -234,7 +235,7 @@ describe("getPriceString", () => {
       highestPrice: 50.5,
       priceUnit: PriceUnit.Per_15Mins,
     });
-    expect(getPriceString(input)).toBe("10 - 50,5 € / 15 min");
+    expect(getPriceString(input)).toBe("10,00 - 50,50 € / 15 min");
   });
 
   test("price range with no min", () => {
@@ -243,7 +244,7 @@ describe("getPriceString", () => {
       highestPrice: 50.5,
       priceUnit: PriceUnit.Per_15Mins,
     });
-    expect(getPriceString(input)).toBe("0 - 50,5 € / 15 min");
+    expect(getPriceString(input)).toBe("0 - 50,50 € / 15 min");
   });
 
   test("price range with minutes", () => {
@@ -252,7 +253,7 @@ describe("getPriceString", () => {
       highestPrice: 60.5,
       minutes: 60,
     });
-    expect(getPriceString(input)).toBe("0 - 60,5 €");
+    expect(getPriceString(input)).toBe("0 - 60,50 €");
   });
 
   test("price range with minutes", () => {
@@ -270,7 +271,7 @@ describe("getPriceString", () => {
       highestPrice: 100,
       minutes: 61,
     });
-    expect(getPriceString(input)).toBe("0 - 125 €");
+    expect(getPriceString(input)).toBe("0 - 125,00 €");
   });
 
   test("price range with minutes", () => {
@@ -279,7 +280,7 @@ describe("getPriceString", () => {
       highestPrice: 100,
       minutes: 90,
     });
-    expect(getPriceString(input)).toBe("0 - 150 €");
+    expect(getPriceString(input)).toBe("0 - 150,00 €");
   });
 
   test("price range with minutes", () => {
@@ -288,7 +289,7 @@ describe("getPriceString", () => {
       highestPrice: 100,
       minutes: 91,
     });
-    expect(getPriceString(input)).toBe("0 - 175 €");
+    expect(getPriceString(input)).toBe("0 - 175,00 €");
   });
 
   test("price range with minutes", () => {
@@ -298,7 +299,7 @@ describe("getPriceString", () => {
       minutes: 60,
       priceUnit: PriceUnit.Per_15Mins,
     });
-    expect(getPriceString(input)).toBe("0 - 120 €");
+    expect(getPriceString(input)).toBe("0 - 120,00 €");
   });
 
   test("price range with minutes", () => {
@@ -308,7 +309,7 @@ describe("getPriceString", () => {
       minutes: 60,
       priceUnit: PriceUnit.Per_30Mins,
     });
-    expect(getPriceString(input)).toBe("0 - 60 €");
+    expect(getPriceString(input)).toBe("0 - 60,00 €");
   });
 
   test("price range with minutes", () => {
@@ -318,7 +319,7 @@ describe("getPriceString", () => {
       minutes: 61,
       priceUnit: PriceUnit.Per_30Mins,
     });
-    expect(getPriceString(input)).toBe("0 - 75 €");
+    expect(getPriceString(input)).toBe("0 - 75,00 €");
   });
 
   test("price range with minutes and fixed unit", () => {
@@ -328,7 +329,7 @@ describe("getPriceString", () => {
       minutes: 61,
       priceUnit: PriceUnit.PerHalfDay,
     });
-    expect(getPriceString(input)).toBe("10 - 100 €");
+    expect(getPriceString(input)).toBe("10,00 - 100,00 €");
   });
 
   test("price range with minutes and fixed unit", () => {
@@ -338,7 +339,7 @@ describe("getPriceString", () => {
       minutes: 1234,
       priceUnit: PriceUnit.PerDay,
     });
-    expect(getPriceString(input)).toBe("10 - 100 €");
+    expect(getPriceString(input)).toBe("10,00 - 100,00 €");
   });
 
   test("price range with minutes and fixed unit", () => {
@@ -348,7 +349,7 @@ describe("getPriceString", () => {
       minutes: 1234,
       priceUnit: PriceUnit.PerWeek,
     });
-    expect(getPriceString(input)).toBe("10 - 100 €");
+    expect(getPriceString(input)).toBe("10,00 - 100,00 €");
   });
 
   test("fixed price", () => {
@@ -357,16 +358,7 @@ describe("getPriceString", () => {
       highestPrice: 50,
       priceUnit: PriceUnit.Fixed,
     });
-    expect(getPriceString(input)).toBe("50 €");
-  });
-
-  test("fixed price with decimals", () => {
-    const input = constructInput({
-      lowestPrice: 50,
-      highestPrice: 50,
-      priceUnit: PriceUnit.Fixed,
-    });
-    expect(getPriceString({ ...input, trailingZeros: true })).toBe("50,00 €");
+    expect(getPriceString(input)).toBe("50,00 €");
   });
 
   test("no price", () => {
@@ -384,19 +376,7 @@ describe("getPriceString", () => {
       minutes: 180,
       priceUnit: PriceUnit.Per_15Mins,
     });
-    expect(getPriceString(input)).toBe("0 - 606 €");
-  });
-
-  test("total price with minutes and decimals", () => {
-    const input = constructInput({
-      lowestPrice: 0,
-      highestPrice: 50.5,
-      minutes: 180,
-      priceUnit: PriceUnit.Per_15Mins,
-    });
-    expect(getPriceString({ ...input, trailingZeros: true })).toBe(
-      "0 - 606,00 €"
-    );
+    expect(getPriceString(input)).toBe("0 - 606,00 €");
   });
 });
 
@@ -1041,7 +1021,6 @@ describe("getReservationUnitPrice", () => {
   }): GetReservationUnitPriceProps {
     return {
       pricingDate: date,
-      trailingZeros: true,
       reservationUnit: {
         pricings: [
           constructPricing({

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -274,7 +274,7 @@ function isReservationConfirmed(reservation: {
 function isReservationFreeOfCharge(
   reservation: Pick<ReservationNode, "price">
 ): boolean {
-  return parseInt(String(reservation.price), 10) === 0;
+  return !(Number(reservation.price) > 0);
 }
 
 export type CanReservationBeChangedProps = {

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -335,7 +335,8 @@ export function getReservationUnitPrice(
   if (
     futurePricing &&
     activePricing &&
-    futurePricing.taxPercentage.value !== activePricing.taxPercentage.value
+    futurePricing.taxPercentage.value !== activePricing.taxPercentage.value &&
+    isReservationUnitPaid([activePricing])
   ) {
     pricing = activePricing;
   }

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -258,12 +258,8 @@ export function getFuturePricing(
     : futurePricings[0];
 }
 
-function formatPrice(
-  price: number,
-  trailingZeros: boolean,
-  toCurrency?: boolean
-): string {
-  const enableDecimals = price !== 0 && trailingZeros;
+function formatPrice(price: number, toCurrency?: boolean): string {
+  const enableDecimals = price !== 0;
   const currencyFormatter = enableDecimals
     ? "currencyWithDecimals"
     : "currency";
@@ -273,10 +269,9 @@ function formatPrice(
   return formatter.format(price);
 }
 
-type GetPriceType = {
+export type GetPriceType = {
   pricing: PricingFieldsFragment;
   minutes?: number; // additional minutes for total price calculation
-  trailingZeros?: boolean;
 };
 
 function isPriceZero(pricing: PricingFieldsFragment): boolean {
@@ -294,7 +289,7 @@ function isPriceZero(pricing: PricingFieldsFragment): boolean {
 // TODO rewrite this return number normally
 // and a separate function to format it to string
 export function getPriceString(props: GetPriceType): string {
-  const { pricing, minutes, trailingZeros = false } = props;
+  const { pricing, minutes } = props;
 
   if (isPriceZero(pricing)) {
     return i18n?.t("prices:priceFree") ?? "0";
@@ -305,8 +300,8 @@ export function getPriceString(props: GetPriceType): string {
   const lowestPrice = parseFloat(pricing.lowestPrice) * volume;
   const priceString =
     lowestPrice === highestPrice
-      ? formatPrice(lowestPrice, trailingZeros, true)
-      : `${formatPrice(lowestPrice, trailingZeros)} - ${formatPrice(highestPrice, trailingZeros, true)}`;
+      ? formatPrice(lowestPrice, true)
+      : `${formatPrice(lowestPrice)} - ${formatPrice(highestPrice, true)}`;
   const unitString =
     pricing.priceUnit === PriceUnit.Fixed || minutes
       ? ""
@@ -318,18 +313,12 @@ export type GetReservationUnitPriceProps = {
   reservationUnit?: PriceReservationUnitFragment | null;
   pricingDate?: Date;
   minutes?: number;
-  trailingZeros?: boolean;
 };
 
 export function getReservationUnitPrice(
   props: GetReservationUnitPriceProps
 ): string | null {
-  const {
-    reservationUnit: ru,
-    pricingDate,
-    minutes,
-    trailingZeros = false,
-  } = props;
+  const { reservationUnit: ru, pricingDate, minutes } = props;
   if (pricingDate != null && Number.isNaN(pricingDate.getTime())) {
     // eslint-disable-next-line no-console
     console.warn("Invalid pricing date", pricingDate);
@@ -358,7 +347,6 @@ export function getReservationUnitPrice(
   return getPriceString({
     pricing,
     minutes,
-    trailingZeros,
   });
 }
 

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -34,7 +34,7 @@ import { createApolloClient } from "@/modules/apolloClient";
 import { reservationUnitPrefix, reservationsPrefix } from "@/modules/const";
 import { getTranslation, reservationsUrl } from "@/modules/util";
 import Sanitize from "@/components/common/Sanitize";
-import { getReservationUnitPrice } from "@/modules/reservationUnit";
+import { isReservationUnitPaid } from "@/modules/reservationUnit";
 import {
   getCheckoutUrl,
   getReservationApplicationMutationValues,
@@ -184,15 +184,12 @@ function ReservationUnitReservation(props: PropsNarrowed): JSX.Element | null {
     reservation?.applyingForFreeOfCharge;
 
   const steps: ReservationStep[] = useMemo(() => {
-    const price = getReservationUnitPrice({
-      reservationUnit,
-      pricingDate: reservation?.begin
-        ? new Date(reservation?.begin)
-        : undefined,
-      asNumeral: true,
-    });
+    const isUnitFreeOfCharge = isReservationUnitPaid(
+      reservationUnit.pricings,
+      new Date(reservation.begin)
+    );
 
-    const stepLength = price === "0" || requireHandling ? 2 : 5;
+    const stepLength = isUnitFreeOfCharge || requireHandling ? 2 : 5;
 
     return Array.from(Array(stepLength)).map((_n, i) => {
       const state = i === step ? 0 : i < step ? 1 : 2;

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -82,7 +82,7 @@ import {
 import {
   getFuturePricing,
   getPossibleTimesForDay,
-  getPrice,
+  getPriceString,
   getTimeString,
   isReservationUnitPaidInFuture,
   isReservationUnitPublished,
@@ -1220,7 +1220,7 @@ function ReservationUnit({
                         defaults="Huomioi <bold>hinnoittelumuutos {{date}} alkaen. Uusi hinta on {{price}}</bold>."
                         values={{
                           date: toUIDate(new Date(futurePricing.begins)),
-                          price: getPrice({
+                          price: getPriceString({
                             pricing: futurePricing,
                             trailingZeros: true,
                           }).toLocaleLowerCase(),

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -1222,7 +1222,6 @@ function ReservationUnit({
                           date: toUIDate(new Date(futurePricing.begins)),
                           price: getPriceString({
                             pricing: futurePricing,
-                            trailingZeros: true,
                           }).toLocaleLowerCase(),
                         }}
                         components={{ bold: <strong /> }}

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -51,7 +51,7 @@ import {
 import {
   getReservationUnitInstructionsKey,
   getReservationUnitName,
-  getReservationUnitPrice,
+  isReservationUnitPaid,
 } from "@/modules/reservationUnit";
 import BreadcrumbWrapper from "@/components/common/BreadcrumbWrapper";
 import { ReservationStatus } from "@/components/reservation/ReservationStatus";
@@ -369,15 +369,14 @@ function Reservation({
       return false;
     }
 
-    const reservationUnitPrice = getReservationUnitPrice({
-      reservationUnit,
-      pricingDate: reservation.begin ? new Date(reservation.begin) : undefined,
-      asNumeral: true,
-    });
+    const isFreeOfCharge = !isReservationUnitPaid(
+      reservationUnit.pricings,
+      new Date(reservation.begin)
+    );
 
     return (
       reservation.applyingForFreeOfCharge ||
-      (reservationUnit.canApplyFreeOfCharge && reservationUnitPrice !== "0")
+      (reservationUnit.canApplyFreeOfCharge && !isFreeOfCharge)
     );
   }, [reservation, reservationUnit]);
 

--- a/packages/common/src/reservation-pricing.test.ts
+++ b/packages/common/src/reservation-pricing.test.ts
@@ -2,26 +2,26 @@ import { getReservationPrice } from "./reservation-pricing";
 
 describe("getReservationPrice", () => {
   test("with no price", () => {
-    expect(getReservationPrice("0", "Maksuton", "fi")).toBe("Maksuton");
+    expect(getReservationPrice("0", "Maksuton", false)).toBe("Maksuton");
   });
 
   test("with a price", () => {
-    expect(getReservationPrice("10", "Maksuton")).toBe("10 €"); // contains non-breaking space
+    expect(getReservationPrice("10", "Maksuton", false)).toBe("10 €"); // contains non-breaking space
   });
 
   test("with a price and a decimal", () => {
-    expect(getReservationPrice("10.2", "Maksuton")).toBe("10,2 €"); // contains non-breaking space
+    expect(getReservationPrice("10.2", "Maksuton", false)).toBe("10,2 €"); // contains non-breaking space
   });
 
   test("with a price and a decimal and a forced leading one", () => {
-    expect(getReservationPrice("10.2", "Maksuton", "fi", true)).toBe("10,20 €"); // contains non-breaking space
+    expect(getReservationPrice("10.2", "Maksuton", true)).toBe("10,20 €"); // contains non-breaking space
   });
 
   test("with a price and decimals", () => {
-    expect(getReservationPrice("10.23", "Maksuton", "fi")).toBe("10,23 €"); // contains non-breaking space
+    expect(getReservationPrice("10.23", "Maksuton", false)).toBe("10,23 €"); // contains non-breaking space
   });
 
   test("with a price and forced decimals", () => {
-    expect(getReservationPrice("10", "Maksuton", "fi", true)).toBe("10,00 €"); // contains non-breaking space
+    expect(getReservationPrice("10", "Maksuton", true)).toBe("10,00 €"); // contains non-breaking space
   });
 });

--- a/packages/common/src/reservation-pricing.ts
+++ b/packages/common/src/reservation-pricing.ts
@@ -69,8 +69,8 @@ export function getReservationVolume(minutes: number, unit: PriceUnit): number {
 export function getReservationPrice(
   price: Maybe<string> | undefined,
   defaultText: string,
-  language = "fi",
-  trailingZeros = false
+  trailingZeros: boolean,
+  language = "fi"
 ): string {
   if (price == null) {
     return defaultText;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: don't show price changes that modify VAT before the active date (other price changes are based on the reservation date).
- Refactor: all customer prices include trailing zeros.
- Refactor: price related tests to use `constructInput`
- Fix: CalendarControls price not based on the reservation date (unlike QuickReservation).
- Refactor: remove string comparisons for checking if reservation would be free.
- Refactor: prefer `null` over `undefined` to avoid mistakes.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: shown prices should match the actual prices (i.e. VAT becomes active on the day of purchase, not the day of the reservation).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3490](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3490)


[TILA-3490]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ