### PR TITLE
fix: price is free boolean inverted

### DIFF
--- a/apps/ui/components/reservation-unit/QuickReservation.tsx
+++ b/apps/ui/components/reservation-unit/QuickReservation.tsx
@@ -8,7 +8,7 @@ import type { ReservationUnitPageQuery } from "@gql/gql-types";
 import { breakpoints } from "common";
 import {
   getReservationUnitPrice,
-  isReservationUnitPaid,
+  isReservationUnitFreeOfCharge,
 } from "@/modules/reservationUnit";
 import Carousel from "../Carousel";
 import { getLastPossibleReservationDate } from "@/components/reservation-unit/utils";
@@ -175,7 +175,7 @@ function QuickReservation({
   const dateValue = useMemo(() => fromUIDate(formDate ?? ""), [formDate]);
   const duration = watch("duration");
 
-  const isFreeOfCharge = !isReservationUnitPaid(
+  const isFreeOfCharge = isReservationUnitFreeOfCharge(
     reservationUnit?.pricings ?? [],
     dateValue ?? new Date()
   );

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -37,7 +37,7 @@ import {
   getPossibleTimesForDay,
   getReservationUnitPrice,
   getTimeString,
-  isReservationUnitPaid,
+  isReservationUnitFreeOfCharge,
 } from "@/modules/reservationUnit";
 import { formatDuration, isTouchDevice } from "@/modules/util";
 import { BlackButton, MediumButton } from "@/styles/util";
@@ -286,7 +286,7 @@ export function EditStep0({
       return undefined;
     }
     const isSlotFree = (start: Date): boolean => {
-      return isReservationUnitPaid(reservationUnit.pricings, start);
+      return isReservationUnitFreeOfCharge(reservationUnit.pricings, start);
     };
 
     return getSlotPropGetter({
@@ -312,7 +312,10 @@ export function EditStep0({
       return;
     }
     const { start } = focusSlot;
-    const isFree = isReservationUnitPaid(reservationUnit.pricings, start);
+    const isFree = isReservationUnitFreeOfCharge(
+      reservationUnit.pricings,
+      start
+    );
     const newReservation: PendingReservation = {
       begin: focusSlot.start.toISOString(),
       end: focusSlot.end.toISOString(),

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -351,6 +351,13 @@ export function getReservationUnitPrice(
   });
 }
 
+export function isReservationUnitFreeOfCharge(
+  pricings: PricingFieldsFragment[],
+  date?: Date
+): boolean {
+  return !isReservationUnitPaid(pricings, date);
+}
+
 export function isReservationUnitPaid(
   pricings: PricingFieldsFragment[],
   date?: Date

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -34,7 +34,7 @@ import { createApolloClient } from "@/modules/apolloClient";
 import { reservationUnitPrefix, reservationsPrefix } from "@/modules/const";
 import { getTranslation, reservationsUrl } from "@/modules/util";
 import Sanitize from "@/components/common/Sanitize";
-import { isReservationUnitPaid } from "@/modules/reservationUnit";
+import { isReservationUnitFreeOfCharge } from "@/modules/reservationUnit";
 import {
   getCheckoutUrl,
   getReservationApplicationMutationValues,
@@ -184,7 +184,7 @@ function ReservationUnitReservation(props: PropsNarrowed): JSX.Element | null {
     reservation?.applyingForFreeOfCharge;
 
   const steps: ReservationStep[] = useMemo(() => {
-    const isUnitFreeOfCharge = isReservationUnitPaid(
+    const isUnitFreeOfCharge = isReservationUnitFreeOfCharge(
       reservationUnit.pricings,
       new Date(reservation.begin)
     );

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -51,7 +51,7 @@ import {
 import {
   getReservationUnitInstructionsKey,
   getReservationUnitName,
-  isReservationUnitPaid,
+  isReservationUnitFreeOfCharge,
 } from "@/modules/reservationUnit";
 import BreadcrumbWrapper from "@/components/common/BreadcrumbWrapper";
 import { ReservationStatus } from "@/components/reservation/ReservationStatus";
@@ -369,7 +369,7 @@ function Reservation({
       return false;
     }
 
-    const isFreeOfCharge = !isReservationUnitPaid(
+    const isFreeOfCharge = isReservationUnitFreeOfCharge(
       reservationUnit.pricings,
       new Date(reservation.begin)
     );


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: some isFree booleans inverted after price refactor
- fixes issue: Edit page all times showing disabled.
- fixes issue: can't make paid reservations through the funnel.
- fix for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1348

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: making paid and free reservations and editing them, should work as before.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
