### PR TITLE
fix: order deny reasons by rank

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -7003,6 +7003,25 @@ export type ReservationApplicationLinkQuery = {
   } | null;
 };
 
+export type ReservationDenyReasonsQueryVariables = Exact<{
+  orderBy?: InputMaybe<
+    | Array<InputMaybe<ReservationDenyReasonOrderingChoices>>
+    | InputMaybe<ReservationDenyReasonOrderingChoices>
+  >;
+}>;
+
+export type ReservationDenyReasonsQuery = {
+  reservationDenyReasons?: {
+    edges: Array<{
+      node?: {
+        id: string;
+        pk?: number | null;
+        reasonFi?: string | null;
+      } | null;
+    } | null>;
+  } | null;
+};
+
 export type ReservationMetaFieldsFragment = {
   numPersons?: number | null;
   name?: string | null;
@@ -7336,22 +7355,6 @@ export type RequireHandlingMutation = {
   requireHandlingForReservation?: {
     pk?: number | null;
     state?: ReservationStateChoice | null;
-  } | null;
-};
-
-export type ReservationDenyReasonsQueryVariables = Exact<{
-  [key: string]: never;
-}>;
-
-export type ReservationDenyReasonsQuery = {
-  reservationDenyReasons?: {
-    edges: Array<{
-      node?: {
-        id: string;
-        pk?: number | null;
-        reasonFi?: string | null;
-      } | null;
-    } | null>;
   } | null;
 };
 
@@ -12099,6 +12102,87 @@ export type ReservationApplicationLinkQueryResult = Apollo.QueryResult<
   ReservationApplicationLinkQuery,
   ReservationApplicationLinkQueryVariables
 >;
+export const ReservationDenyReasonsDocument = gql`
+  query ReservationDenyReasons(
+    $orderBy: [ReservationDenyReasonOrderingChoices]
+  ) {
+    reservationDenyReasons(orderBy: $orderBy) {
+      edges {
+        node {
+          id
+          pk
+          reasonFi
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useReservationDenyReasonsQuery__
+ *
+ * To run a query within a React component, call `useReservationDenyReasonsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReservationDenyReasonsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReservationDenyReasonsQuery({
+ *   variables: {
+ *      orderBy: // value for 'orderBy'
+ *   },
+ * });
+ */
+export function useReservationDenyReasonsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    ReservationDenyReasonsQuery,
+    ReservationDenyReasonsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ReservationDenyReasonsQuery,
+    ReservationDenyReasonsQueryVariables
+  >(ReservationDenyReasonsDocument, options);
+}
+export function useReservationDenyReasonsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ReservationDenyReasonsQuery,
+    ReservationDenyReasonsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ReservationDenyReasonsQuery,
+    ReservationDenyReasonsQueryVariables
+  >(ReservationDenyReasonsDocument, options);
+}
+export function useReservationDenyReasonsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    ReservationDenyReasonsQuery,
+    ReservationDenyReasonsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    ReservationDenyReasonsQuery,
+    ReservationDenyReasonsQueryVariables
+  >(ReservationDenyReasonsDocument, options);
+}
+export type ReservationDenyReasonsQueryHookResult = ReturnType<
+  typeof useReservationDenyReasonsQuery
+>;
+export type ReservationDenyReasonsLazyQueryHookResult = ReturnType<
+  typeof useReservationDenyReasonsLazyQuery
+>;
+export type ReservationDenyReasonsSuspenseQueryHookResult = ReturnType<
+  typeof useReservationDenyReasonsSuspenseQuery
+>;
+export type ReservationDenyReasonsQueryResult = Apollo.QueryResult<
+  ReservationDenyReasonsQuery,
+  ReservationDenyReasonsQueryVariables
+>;
 export const ReservationsByReservationUnitDocument = gql`
   query ReservationsByReservationUnit(
     $id: ID!
@@ -12594,84 +12678,6 @@ export type RequireHandlingMutationResult =
 export type RequireHandlingMutationOptions = Apollo.BaseMutationOptions<
   RequireHandlingMutation,
   RequireHandlingMutationVariables
->;
-export const ReservationDenyReasonsDocument = gql`
-  query ReservationDenyReasons {
-    reservationDenyReasons {
-      edges {
-        node {
-          id
-          pk
-          reasonFi
-        }
-      }
-    }
-  }
-`;
-
-/**
- * __useReservationDenyReasonsQuery__
- *
- * To run a query within a React component, call `useReservationDenyReasonsQuery` and pass it any options that fit your needs.
- * When your component renders, `useReservationDenyReasonsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useReservationDenyReasonsQuery({
- *   variables: {
- *   },
- * });
- */
-export function useReservationDenyReasonsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    ReservationDenyReasonsQuery,
-    ReservationDenyReasonsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    ReservationDenyReasonsQuery,
-    ReservationDenyReasonsQueryVariables
-  >(ReservationDenyReasonsDocument, options);
-}
-export function useReservationDenyReasonsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    ReservationDenyReasonsQuery,
-    ReservationDenyReasonsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    ReservationDenyReasonsQuery,
-    ReservationDenyReasonsQueryVariables
-  >(ReservationDenyReasonsDocument, options);
-}
-export function useReservationDenyReasonsSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    ReservationDenyReasonsQuery,
-    ReservationDenyReasonsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<
-    ReservationDenyReasonsQuery,
-    ReservationDenyReasonsQueryVariables
-  >(ReservationDenyReasonsDocument, options);
-}
-export type ReservationDenyReasonsQueryHookResult = ReturnType<
-  typeof useReservationDenyReasonsQuery
->;
-export type ReservationDenyReasonsLazyQueryHookResult = ReturnType<
-  typeof useReservationDenyReasonsLazyQuery
->;
-export type ReservationDenyReasonsSuspenseQueryHookResult = ReturnType<
-  typeof useReservationDenyReasonsSuspenseQuery
->;
-export type ReservationDenyReasonsQueryResult = Apollo.QueryResult<
-  ReservationDenyReasonsQuery,
-  ReservationDenyReasonsQueryVariables
 >;
 export const CheckPermissionsDocument = gql`
   query CheckPermissions(

--- a/apps/admin-ui/src/component/reservations/requested/hooks/index.ts
+++ b/apps/admin-ui/src/component/reservations/requested/hooks/index.ts
@@ -8,12 +8,14 @@ import {
   useRecurringReservationQuery,
   ReservationUnitNode,
   ReservationNode,
+  ReservationDenyReasonOrderingChoices,
 } from "@gql/gql-types";
 import { useTranslation } from "react-i18next";
 import { toApiDate } from "common/src/common/util";
 import { errorToast } from "common/src/common/toast";
 import { base64encode, filterNonNullable } from "common/src/helpers";
 import { type CalendarEventType } from "../Calendar";
+import { gql } from "@apollo/client";
 
 export { default as useCheckCollisions } from "./useCheckCollisions";
 
@@ -160,6 +162,22 @@ export function useRecurringReservations(recurringPk?: number) {
   };
 }
 
+export const RESERVATION_DENY_REASONS = gql`
+  query ReservationDenyReasons(
+    $orderBy: [ReservationDenyReasonOrderingChoices]
+  ) {
+    reservationDenyReasons(orderBy: $orderBy) {
+      edges {
+        node {
+          id
+          pk
+          reasonFi
+        }
+      }
+    }
+  }
+`;
+
 // TODO this has the same useState being local problems as useRecurringReservations
 // used to have but it's not obvious because we don't mutate / refetch this.
 // Cache it in Apollo InMemory cache instead.
@@ -167,6 +185,9 @@ export function useDenyReasonOptions() {
   const { t } = useTranslation();
 
   const { data, loading } = useReservationDenyReasonsQuery({
+    variables: {
+      orderBy: [ReservationDenyReasonOrderingChoices.RankAsc],
+    },
     onError: () => {
       errorToast({ text: t("errors.errorFetchingData") });
     },

--- a/apps/admin-ui/src/component/reservations/requested/queries.tsx
+++ b/apps/admin-ui/src/component/reservations/requested/queries.tsx
@@ -34,17 +34,3 @@ export const REQUIRE_HANDLING_RESERVATION = gql`
     }
   }
 `;
-
-export const RESERVATION_DENY_REASONS = gql`
-  query ReservationDenyReasons {
-    reservationDenyReasons {
-      edges {
-        node {
-          id
-          pk
-          reasonFi
-        }
-      }
-    }
-  }
-`;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: order deny reasons by rank (`admin-ui`)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: if rank information is set for deny reasons (in django) they should be ordered correctly when denying a reservations.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3399](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3399)

[TILA-3399]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ