### PR TITLE
fix: navigation styling and function as discussed

### DIFF
--- a/apps/admin-ui/src/component/Navigation.tsx
+++ b/apps/admin-ui/src/component/Navigation.tsx
@@ -1,52 +1,88 @@
 import { useTranslation } from "react-i18next";
 import { signIn, signOut } from "common/src/browserHelpers";
 import { useSession } from "@/hooks/auth";
-import { Header, IconStar, IconUser, Logo, TitleStyleType } from "hds-react";
+import {
+  Header,
+  IconSignout,
+  IconStar,
+  IconUser,
+  TitleStyleType,
+} from "hds-react";
 import React from "react";
 import styled from "styled-components";
 import { useLocation } from "react-router-dom";
 import useHandling from "@/hooks/useHandling";
 import usePermission from "@/hooks/usePermission";
 import { Permission } from "@/modules/permissionHelper";
-import IconPremises from "common/src/icons/IconPremises";
+import Logo from "common/src/components/Logo";
 import { env } from "@/env.mjs";
 
 type Props = {
   apiBaseUrl: string;
 };
 
-const ActionBar = styled(Header.ActionBar)`
-  background: var(--color-bus);
+const BackgroundHeader = styled(Header)`
+  --header-color: black;
+  --actionbar-background-color: var(--color-bus-dark);
+  --notification-bubble-background-color: var(
+    --tilavaraus-admin-handling-count-color
+  );
+  #user-menu-dropdown {
+    color: black;
+    button,
+    span,
+    div {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+    }
+    svg {
+      color: var(--header-color);
+    }
+  }
+  #user-menu {
+    > button span {
+      color: white !important;
+      svg {
+        color: white;
+      }
+    }
+  }
+  #hds-mobile-menu {
+    #user-menu * {
+      color: var(--header-color);
+      box-sizing: border-box;
+    }
+    ul > li {
+      > span {
+        padding: var(--spacing-s);
+        li {
+          width: 100%;
+          font-size: var(--fontsize-body-xl);
+        }
+      }
 
-  --action-bar-item-title-font-color: white;
+      /* hide the big link to frontpage which HDS adds by default */
+      &:first-child {
+        display: none;
+      }
+    }
+  }
+`;
+
+const ActionBar = styled(Header.ActionBar)`
   [class*="HeaderActionBar-module_title"] {
     color: white;
   }
-  #user-menu > button {
+  [class*="icon_hds-icon"] {
     color: white;
-  }
-  #user-menu-dropdown {
-    color: black;
-
-    --action-bar-item-title-font-color: black;
   }
 `;
 
 const NavigationMenuWrapper = styled.div`
-  --notification-bubble-background-color: var(
-    --tilavaraus-admin-handling-count-color
-  );
   span:has(.active) {
     /* using box-shadow for a bottom border inside of the element, without affecting text positioning */
     box-shadow: 0 -4px 0 0 var(--color-black) inset;
-  }
-
-  /* We only want underline on the label text, not the text in the bubble */
-  a:hover {
-    text-decoration: none;
-    span:first-child {
-      text-decoration: underline;
-    }
   }
 `;
 
@@ -62,12 +98,6 @@ const getFilteredMenu = (
   hasOwnUnits: boolean,
   hasPermission: (perm: Permission) => boolean
 ): IMenuChild[] => [
-  {
-    title: "MainMenu.home",
-    icon: <IconPremises aria-hidden />,
-    route: "/",
-    exact: true,
-  },
   ...(hasOwnUnits
     ? [
         {
@@ -143,7 +173,6 @@ function NavigationLink({
   const shouldDisplayCount =
     title === t("MainMenu.requestedReservations") && count && count > 0;
   const isActive = exact ? pathname === href : pathname.startsWith(href);
-
   return (
     <Header.ActionBarSubItem
       key={href}
@@ -171,26 +200,16 @@ const Navigation = ({ apiBaseUrl }: Props) => {
     (item) => item != null
   );
 
-  const base64Logo =
-    "data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNzggMzYiIHRpdGxlPSJIZWxzaW5naW4ga2F1cHVua2kiIHJvbGU9ImltZyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoCiAgICAgICAgZD0iTTc1Ljc1MyAyLjI1MXYyMC43YzAgMy45NS0zLjI3NSA3LjE3OC03LjMxIDcuMTc4aC0yMi4yNmMtMi42NzQgMC01LjIwNS45Ni03LjE4MyAyLjczOWExMC43NDkgMTAuNzQ5IDAgMDAtNy4xODMtMi43NEg5LjUwOWMtNC4wMDMgMC03LjI0Ny0zLjIxLTcuMjQ3LTcuMTc3VjIuMjVoNzMuNDkxek00MC4xODcgMzQuODM1YTguNDcgOC40NyAwIDAxNi4wMTItMi40NzFoMjIuMjQ1YzUuMjY4IDAgOS41NTYtNC4yMTkgOS41NTYtOS40MTNWMEgwdjIyLjkzNWMwIDUuMTk0IDQuMjU2IDkuNDEzIDkuNTA5IDkuNDEzaDIyLjMwOGMyLjI2MyAwIDQuMzk4Ljg4MiA2LjAxMiAyLjQ3MUwzOS4wMTYgMzZsMS4xNy0xLjE2NXoiCiAgICAgICAgZmlsbD0iY3VycmVudENvbG9yIiAvPgogICAgPHBhdGgKICAgICAgICBkPSJNNjcuNTIyIDExLjY3NmMwIC42ODEtLjU1NiAxLjE3Ny0xLjI1NSAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43LS4wMyAxLjI1NS40NjUgMS4yNTUgMS4xNzh6bS0yLjM1MiA5LjYyMmgyLjE3OHYtNy41NDZINjUuMTd2Ny41NDZ6bS0zLjkwOS00LjU1NmwyLjg0NSA0LjU1NmgtMi4zNjhsLTEuOTA3LTMuMDIyLTEuMDMzIDEuMjcxdjEuNzVoLTIuMTYxVjEwLjQ1M2gyLjE2djUuMDA0YzAgLjkzLS4xMSAxLjg2LS4xMSAxLjg2aC4wNDdzLjUwOS0uODIxLjkzOC0xLjQxbDEuNjUzLTIuMTU0aDIuNTQybC0yLjYwNiAyLjk5em0tNi44MTctLjI3OGMwLTEuODc1LS45MzgtMi44OTgtMi40MzItMi44OTgtMS4yNzEgMC0xLjkzOS43MjgtMi4zMiAxLjQyNmgtLjA0OGwuMTEyLTEuMjRoLTIuMTYydjcuNTQ2aDIuMTYyVjE2LjgyYzAtLjg2OC41MjQtMS40NzIgMS4zMzUtMS40NzIuODEgMCAxLjE2LjUyNyAxLjE2IDEuNTM0djQuNDE2aDIuMTc3bC4wMTYtNC44MzR6bS04LjkzMS00Ljc4OGMwIC42ODEtLjU1NyAxLjE3Ny0xLjI1NiAxLjE3Ny0uNyAwLTEuMjU1LS40OTYtMS4yNTUtMS4xNzcgMC0uNjgyLjU1Ni0xLjE3OCAxLjI1NS0xLjE3OC43MTUtLjAzIDEuMjU2LjQ2NSAxLjI1NiAxLjE3OHptLTIuMzUyIDkuNjIyaDIuMTc3di03LjU0Nkg0My4xNnY3LjU0NnptLTMuNzUtMi4xMDdjMC0uNjA1LS44NTktLjcyOS0xLjg2LTEuMDA4LTEuMTYtLjI5NC0yLjYyMi0uODY3LTIuNjIyLTIuMzA4IDAtMS40MjYgMS4zOTgtMi4zMjQgMy4wNTEtMi4zMjQgMS41NDEgMCAyLjk1Ni43MTIgMy41NDQgMS43MmwtMS44NiAxLjAyMmMtLjE5LS42NjYtLjc2Mi0xLjE5My0xLjYyLTEuMTkzLS41NTcgMC0xLjAxOC4yMzItMS4wMTguNjgyIDAgLjU3MyAxLjAxOC42MzUgMi4xNjIuOTkxIDEuMjA4LjM3MiAyLjMyLjkxNSAyLjMyIDIuMjk0IDAgMS41MTgtMS40NDYgMi40MTctMy4xMTUgMi40MTctMS44MTEgMC0zLjI0Mi0uNzQ0LTMuODc3LTEuOTUybDEuODktMS4wMzljLjI0LjgyMi45MjIgMS40NDEgMS45NTUgMS40NDEuNjIgMCAxLjA1LS4yNDggMS4wNS0uNzQzem0tNi44ODItOC42NzdoLTIuMTc3djguNjkyYzAgLjc3NS4xNzUgMS4zNDguNTA5IDEuNzA1LjM1LjM1Ni44OS41MjYgMS42MzYuNTI2LjI1NSAwIC41MjUtLjAzLjc4LS4wNzcuMjctLjA2Mi40NzYtLjE0LjY1LS4yMzNsLjE5MS0xLjQyNWEyLjA3IDIuMDcgMCAwMS0uNDYuMTI0Yy0uMTI4LjAzLS4yODcuMDMtLjQ2MS4wMy0uMjg2IDAtLjQxNC0uMDc3LS41MDktLjIxNi0uMTExLS4xNC0uMTU5LS4zODctLjE1OS0uNzQ0di04LjM4MnptLTcuMjQ2IDQuNTdjLS43OTUgMC0xLjQ0Ni41NTgtMS42MjEgMS41ODFoMy4wNWMuMDE3LS44OTktLjU4Ny0xLjU4LTEuNDMtMS41OHptMy4zNTMgMy4wMDdIMjMuNjNjLjA5NSAxLjIyNC43OTQgMS44MjggMS43IDEuODI4LjgxIDAgMS4zNjctLjUyNyAxLjQ5NC0xLjI0bDEuODI4IDEuMDA3Yy0uNTQuOTYxLTEuNyAxLjc5OC0zLjMyMiAxLjc5OC0yLjE2IDAtMy43NS0xLjQ3Mi0zLjc1LTMuOTUxIDAtMi40NjQgMS42Mi0zLjk1MSAzLjcwMy0zLjk1MSAyLjA4MSAwIDMuNDY0IDEuNDQgMy40NjQgMy40ODYtLjAxNi42MDQtLjExMSAxLjAyMy0uMTExIDEuMDIzem0tMTEuMDc3IDMuMjA3aDIuMjU3VjEwLjkxNmgtMi4yNTd2NC4xMDdoLTQuMjQzdi00LjA5MUgxMS4wNnYxMC4zNjZoMi4yNTZ2LTQuMjkyaDQuMjQzdjQuMjkyeiIKICAgICAgICBmaWxsPSJjdXJyZW50Q29sb3IiIC8+Cjwvc3ZnPg==";
-
   return (
-    <Header>
+    <BackgroundHeader>
       <ActionBar
         title={t("common:applicationName")}
         titleAriaLabel={t("common:applicationName")}
         frontPageLabel={t("common:gotoFrontpage")}
         titleStyle={TitleStyleType.Bold}
-        titleHref="/"
+        titleHref={env.NEXT_PUBLIC_BASE_URL ?? "/"}
         openFrontPageLinksAriaLabel={t("common:applicationName")}
-        logo={
-          <Logo
-            alt={t("common:applicationName")}
-            size="large"
-            src={base64Logo}
-            style={{ filter: "invert(1)" }}
-          />
-        }
+        logo={<Logo size="large" style={{ filter: "invert(1)" }} />}
         logoAriaLabel={`${t("common:applicationName")} logo`}
         logoHref={env.NEXT_PUBLIC_BASE_URL}
       >
@@ -199,10 +218,15 @@ const Navigation = ({ apiBaseUrl }: Props) => {
             id="user-menu"
             label={name}
             icon={<IconUser />}
-            style={{ color: "white" }}
+            fixedRightPosition
           >
             <Header.ActionBarButton
-              label={t("Navigation.logout")}
+              label={
+                <>
+                  <span>{t("Navigation.logout")}</span>
+                  <IconSignout />
+                </>
+              }
               onClick={() => signOut(apiBaseUrl)}
             />
           </Header.ActionBarItem>
@@ -226,7 +250,7 @@ const Navigation = ({ apiBaseUrl }: Props) => {
           ))}
         </Header.NavigationMenu>
       </NavigationMenuWrapper>
-    </Header>
+    </BackgroundHeader>
   );
 };
 

--- a/apps/ui/components/common/Navigation.tsx
+++ b/apps/ui/components/common/Navigation.tsx
@@ -13,14 +13,17 @@ import styled from "styled-components";
 import { useSession } from "@/hooks/auth";
 import { type CurrentUserQuery } from "@gql/gql-types";
 import Logo from "common/src/components/Logo";
-import router from "next/router";
+import { useRouter } from "next/router";
 import { breakpoints } from "common";
 import { useLocation } from "react-use";
 import { signIn, signOut } from "common/src/browserHelpers";
+import { getLocalizationLang } from "common/src/helpers";
+import { env } from "@/env.mjs";
 
 type HeaderProps = {
   apiBaseUrl: string;
   profileLink: string;
+  languageOptions?: LanguageOption[];
 };
 
 const Wrapper = styled.div`
@@ -42,64 +45,73 @@ const Wrapper = styled.div`
       a {
         margin: 0;
       }
+
       span:has(.active) {
         /* using box-shadow for a bottom border inside of the element, without affecting text positioning */
         box-shadow: 0 -4px 0 0 var(--color-black) inset;
       }
     }
   }
-  @media (max-width: ${breakpoints.l}) {
-    #user-menu-dropdown ul {
-      display: flex;
-      flex-direction: column;
-      > {
-        appearance: none !important;
-      }
-      /* force the user specific navigation items (nth-child > 2) to the right */
-      &:nth-child(2) {
-        flex-grow: 1;
-      }
-    }
-  }
+
   #user-menu-dropdown ul {
     display: flex;
     flex-direction: column;
+
     > * {
       display: flex;
-      background: white;
+      background: transparent;
       border: 0;
       justify-content: space-between;
+      border-bottom: 1px solid var(--color-black-20);
+      transition: background 0.2s;
       &:hover {
+        background: var(--color-black-10);
         cursor: pointer;
         text-decoration: underline;
       }
     }
   }
-`;
 
-const languageOptions: LanguageOption[] = [
-  { label: "Suomeksi", value: "fi" },
-  { label: "Svenska", value: "sv" },
-  { label: "English", value: "en" },
-];
+  #hds-mobile-menu {
+    ul > li {
+      > span {
+        padding: var(--spacing-s);
+        li,
+        a {
+          display: block;
+          width: 100%;
+          font-size: var(--fontsize-body-xl);
+        }
+      }
+      &:first-child {
+        display: none;
+      }
+    }
+  }
+`;
 
 const menuItems = [
   {
+    label: "navigation:Item.home",
+    routes: ["/"],
+    exact: true,
+  },
+  {
     label: "navigation:Item.reservationUnitSearch",
-    href: ["/search/single", "/reservation-unit"],
+    routes: ["/search/single", "/reservation-unit"],
   },
   {
     label: "navigation:Item.spaceReservation",
-    href: ["/recurring"],
+    routes: ["/recurring"],
   },
   {
     label: "navigation:Item.reservations",
-    href: ["/reservations"],
+    routes: ["/reservations"],
     requireLogin: true,
   },
   {
     label: "navigation:Item.applications",
-    href: ["/applications"],
+    routes: ["/applications"],
     requireLogin: true,
   },
 ];
@@ -108,31 +120,49 @@ function constructName(firstName?: string, lastName?: string) {
   return firstName || lastName ? `${firstName} ${lastName}` : undefined;
 }
 
+function checkActive(pathname: string, routes: string[], exact: boolean) {
+  return routes.some((route) =>
+    exact ? pathname === route : pathname.startsWith(route)
+  );
+}
+
 function NavigationMenu({ user }: { user: CurrentUserQuery["currentUser"] }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { pathname } = useLocation();
+  const router = useRouter();
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    router.push(e.currentTarget.href);
+  };
+
   return (
     <Header.NavigationMenu>
       {menuItems.map((item) => {
         if (item.requireLogin && !user) {
           return null;
         }
-        const isActive = () => {
-          if (!pathname) return false;
-          let active = false;
-          item.href.forEach((href) => {
-            if (pathname.startsWith(href)) {
-              active = true;
-            }
-          });
-          return active;
-        };
+        if (!pathname) {
+          return;
+        }
+        const localisationString =
+          i18n.language === "fi" ? "" : getLocalizationLang(i18n.language);
+
         return (
-          <Header.Link
+          <Header.ActionBarSubItem
             key={item.label}
             label={t(item.label)}
-            href={item.href[0]}
-            className={isActive() ? "active" : ""}
+            href={
+              getLocalizationLang(i18n.language) === "fi"
+                ? item.routes[0]
+                : `/${localisationString}${item.routes[0]}`
+            }
+            onClick={handleClick}
+            className={
+              checkActive(pathname, item.routes, item.exact ?? false)
+                ? "active"
+                : ""
+            }
           />
         );
       })}
@@ -140,7 +170,7 @@ function NavigationMenu({ user }: { user: CurrentUserQuery["currentUser"] }) {
   );
 }
 
-function ActionBar({ apiBaseUrl, profileLink }: HeaderProps) {
+function ActionBar({ apiBaseUrl, profileLink, languageOptions }: HeaderProps) {
   const { t } = useTranslation();
   const { isAuthenticated, user } = useSession();
   const { firstName, lastName } = user ?? {};
@@ -152,13 +182,17 @@ function ActionBar({ apiBaseUrl, profileLink }: HeaderProps) {
       titleAriaLabel={t("common:applicationName")}
       frontPageLabel={t("common:gotoFrontpage")}
       titleStyle={TitleStyleType.Bold}
-      titleHref="/"
+      titleHref={env.NEXT_PUBLIC_BASE_URL ?? "/"}
       openFrontPageLinksAriaLabel={t("common:applicationName")}
       logo={<Logo size="large" />}
       logoAriaLabel={`${t("common:applicationName")} logo`}
-      logoHref="/"
+      logoHref={env.NEXT_PUBLIC_BASE_URL}
+      menuButtonLabel="Menu"
     >
-      <Header.LanguageSelector ariaLabel={t("navigation:languageSelection")} />
+      <Header.SimpleLanguageOptions
+        languages={languageOptions}
+        ariaLabel={t("navigation:languageSelection")}
+      />
       {isAuthenticated ? (
         <Header.ActionBarItem
           fixedRightPosition
@@ -196,8 +230,15 @@ function ActionBar({ apiBaseUrl, profileLink }: HeaderProps) {
 }
 
 function Navigation({ apiBaseUrl, profileLink }: HeaderProps) {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user } = useSession();
+  const router = useRouter();
+
+  const languageOptions: LanguageOption[] = [
+    { label: t("navigation:languages.fi"), value: getLocalizationLang("fi") },
+    { label: t("navigation:languages.sv"), value: getLocalizationLang("sv") },
+    { label: t("navigation:languages.en"), value: getLocalizationLang("en") },
+  ];
 
   const languageChangeHandler = (language: string) => {
     i18n.changeLanguage(language);
@@ -208,9 +249,13 @@ function Navigation({ apiBaseUrl, profileLink }: HeaderProps) {
     <Wrapper>
       <Header
         onDidChangeLanguage={languageChangeHandler}
-        languages={languageOptions}
+        defaultLanguage={router.locale}
       >
-        <ActionBar apiBaseUrl={apiBaseUrl} profileLink={profileLink} />
+        <ActionBar
+          apiBaseUrl={apiBaseUrl}
+          profileLink={profileLink}
+          languageOptions={languageOptions}
+        />
         <NavigationMenu user={user} />
       </Header>
     </Wrapper>

--- a/apps/ui/public/locales/en/navigation.json
+++ b/apps/ui/public/locales/en/navigation.json
@@ -1,6 +1,7 @@
 {
   "userNoName": "Anonymous User",
   "Item": {
+    "home": "Front page",
     "spaceReservation": "Seasonal booking",
     "reservationUnitSearch": "Single booking",
     "reservations": "My bookings",
@@ -8,5 +9,10 @@
   },
   "profileLinkLabel": "Go to Helsinki profile",
   "skipToMainContent": "Skip to main content of the page",
-  "languageSelection": "Select language"
+  "languageSelection": "Select language",
+  "languages": {
+    "fi": "Suomi",
+    "sv": "Swedish",
+    "en": "English"
+  },
 }

--- a/apps/ui/public/locales/fi/navigation.json
+++ b/apps/ui/public/locales/fi/navigation.json
@@ -1,6 +1,7 @@
 {
   "userNoName": "Nimetön Käyttäjä",
   "Item": {
+    "home": "Etusivu",
     "spaceReservation": "Kausivaraus",
     "reservationUnitSearch": "Tilan varaus",
     "reservations": "Omat varaukset",
@@ -8,5 +9,10 @@
   },
   "profileLinkLabel": "Siirry Helsinki-profiiliin",
   "skipToMainContent": "Siirry sivun pääsisältöön",
-  "languageSelection": "Valitse kieli"
+  "languageSelection": "Valitse kieli",
+  "languages": {
+    "fi": "Suomi",
+    "sv": "Svenska",
+    "en": "English"
+  }
 }

--- a/apps/ui/public/locales/sv/navigation.json
+++ b/apps/ui/public/locales/sv/navigation.json
@@ -1,6 +1,7 @@
 {
   "userNoName": "Namnlös användare",
   "Item": {
+    "home": "Hemsidan",
     "spaceReservation": "Säsongsbokning",
     "reservationUnitSearch": "Bokning av lokal",
     "reservations": "Mina bokningar",
@@ -8,5 +9,10 @@
   },
   "profileLinkLabel": "Gå till Helsinkiprofilen",
   "skipToMainContent": "Gå till sidans huvudinnehåll",
-  "languageSelection": "Välj språk"
+  "languageSelection": "Välj språk",
+    "languages": {
+        "fi": "Suomi",
+        "sv": "Svenska",
+        "en": "English"
+    }
 }

--- a/packages/common/src/components/Logo.tsx
+++ b/packages/common/src/components/Logo.tsx
@@ -9,14 +9,17 @@ function logoSrcFromLanguage(language: string) {
   return logoFi;
 }
 
-export default function Logo({ size }: Pick<LogoProps, "size">): JSX.Element {
+export default function Logo({
+  size,
+  style,
+}: Pick<LogoProps, "size"> & { style?: React.CSSProperties }): JSX.Element {
   const { t, i18n } = useTranslation();
   return (
     <HDSLogo
       src={logoSrcFromLanguage(i18n.language)}
       alt={t("common:applicationName")}
       size={size ?? "medium"}
-      style={{ color: "black" }}
+      style={style}
     />
   );
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes styling on both admin and client pages as discussed with Oiva:
  - extends the blue background to entire screen width
  - fixes admin pages mobile layout
  - adds correctly styled marker for the active page on client pages
- Makes better use of the inbuilt HDS component's methods in Navigation
- Fixes navigation routes and `isActive` for swedish and english localizations

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that both Headers/Navigations work and look as intended, on both client and admin pages
- Also check the mobile functionality/styling, and client pages in Swedish and English localizations

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
