### PR TITLE
fix: admin-ui navigation active check

### DIFF
--- a/apps/admin-ui/src/common/urls.ts
+++ b/apps/admin-ui/src/common/urls.ts
@@ -9,11 +9,13 @@ export const prefixes = {
 };
 
 export const reservationUnitsUrl = "/premises-and-settings/reservation-units";
+export const singleUnitUrl = "/unit";
 export const applicationRoundsUrl =
   "/recurring-reservations/application-rounds";
 export const unitsUrl = "/premises-and-settings/units";
 export const bannerNotificationsUrl = "/messaging/notifications";
 export const requestedReservationsUrl = "/reservations/requested";
+export const reservationsUrl = "/reservations";
 export const allReservationsUrl = "/reservations/all";
 export const myUnitsUrl = "/my-units";
 

--- a/apps/ui/components/common/Navigation.tsx
+++ b/apps/ui/components/common/Navigation.tsx
@@ -19,6 +19,13 @@ import { useLocation } from "react-use";
 import { signIn, signOut } from "common/src/browserHelpers";
 import { getLocalizationLang } from "common/src/helpers";
 import { env } from "@/env.mjs";
+import {
+  applicationsPrefix,
+  recurringReservationsPrefix,
+  reservationsPrefix,
+  reservationUnitPrefix,
+  singleSearchPrefix,
+} from "@/modules/const";
 
 type HeaderProps = {
   apiBaseUrl: string;
@@ -99,20 +106,20 @@ const menuItems = [
   },
   {
     label: "navigation:Item.reservationUnitSearch",
-    routes: ["/search/single", "/reservation-unit"],
+    routes: [singleSearchPrefix, reservationUnitPrefix],
   },
   {
     label: "navigation:Item.spaceReservation",
-    routes: ["/recurring"],
+    routes: [recurringReservationsPrefix],
   },
   {
     label: "navigation:Item.reservations",
-    routes: ["/reservations"],
+    routes: [reservationsPrefix],
     requireLogin: true,
   },
   {
     label: "navigation:Item.applications",
-    routes: ["/applications"],
+    routes: [applicationsPrefix],
     requireLogin: true,
   },
 ];

--- a/apps/ui/modules/const.ts
+++ b/apps/ui/modules/const.ts
@@ -8,6 +8,7 @@ export const searchPrefix = "/search";
 export const singleSearchPrefix = "/search/single";
 export const applicationsPrefix = "/applications";
 export const reservationsPrefix = "/reservations";
+export const recurringReservationsPrefix = "/recurring";
 
 export const mapUrlPrefix = "https://palvelukartta.hel.fi/";
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes the active page check, so that there's an active section for all the pathnames you can end up in

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that there's an active section shown in the navigation, e.g. when navigating to a single reservation from the requested reservations page.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
