### PR TITLE
Fix admin navigation history

### DIFF
--- a/apps/admin-ui/src/component/LinkPrev.tsx
+++ b/apps/admin-ui/src/component/LinkPrev.tsx
@@ -5,12 +5,6 @@ import { IconAngleLeft } from "hds-react";
 import { useNavigate } from "react-router-dom";
 import { BasicLink } from "../styles/util";
 
-interface IProps {
-  route?: string;
-  style?: React.CSSProperties;
-  className?: string;
-}
-
 const StyledLink = styled(BasicLink)`
   display: inline-flex;
   align-items: center;
@@ -20,7 +14,13 @@ const StyledLink = styled(BasicLink)`
   gap: var(--spacing-2-xs);
 `;
 
-function LinkPrev({ route, style, className }: IProps): JSX.Element {
+type Props = {
+  route?: string;
+  style?: React.CSSProperties;
+  className?: string;
+};
+
+function LinkPrevInner({ route, style, className }: Props): JSX.Element {
   const { t } = useTranslation();
   const navigate = useNavigate();
   return (
@@ -43,4 +43,14 @@ function LinkPrev({ route, style, className }: IProps): JSX.Element {
   );
 }
 
-export default LinkPrev;
+const PreviousLinkWrapper = styled.div`
+  padding: var(--spacing-s);
+`;
+
+export function LinkPrev(props: Props): JSX.Element {
+  return (
+    <PreviousLinkWrapper>
+      <LinkPrevInner {...props} />
+    </PreviousLinkWrapper>
+  );
+}

--- a/apps/admin-ui/src/component/SearchTags.tsx
+++ b/apps/admin-ui/src/component/SearchTags.tsx
@@ -26,7 +26,7 @@ export function SearchTags({
   const handleDelete = (tag: { key: string; value: string }) => {
     const vals = new URLSearchParams(params);
     vals.delete(tag.key, tag.value);
-    setParams(vals);
+    setParams(vals, { replace: true });
   };
 
   const handleReset = () => {
@@ -44,7 +44,7 @@ export function SearchTags({
         newParams.set(d.key, d.value);
       }
     }
-    setParams(newParams);
+    setParams(newParams, { replace: true });
   };
 
   const tags: { key: string; value: string; tr: string }[] = [];

--- a/apps/admin-ui/src/component/reservations/EditPageWrapper.tsx
+++ b/apps/admin-ui/src/component/reservations/EditPageWrapper.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { type ReservationQuery } from "@gql/gql-types";
-import styled from "styled-components";
-import LinkPrev from "../LinkPrev";
+import { LinkPrev } from "../LinkPrev";
 import { Container } from "../../styles/layout";
 import ReservationTitleSection from "./requested/ReservationTitleSection";
 import { createTagString } from "./requested/util";
-
-const PreviousLinkWrapper = styled.div`
-  padding: var(--spacing-s);
-`;
 
 type ReservationType = NonNullable<ReservationQuery["reservation"]>;
 const EditPageWrapper = ({
@@ -26,9 +21,7 @@ const EditPageWrapper = ({
 
   return (
     <>
-      <PreviousLinkWrapper>
-        <LinkPrev />
-      </PreviousLinkWrapper>
+      <LinkPrev />
       <Container>
         {reservation && (
           <ReservationTitleSection

--- a/apps/admin-ui/src/spa/my-units/recurring/RecurringReservation.tsx
+++ b/apps/admin-ui/src/spa/my-units/recurring/RecurringReservation.tsx
@@ -2,29 +2,16 @@ import { H1 } from "common/src/common/typography";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
-import styled from "styled-components";
 import { Container } from "@/styles/layout";
 import Loader from "@/component/Loader";
 import { RecurringReservationForm } from "./RecurringReservationForm";
 import { useRecurringReservationsUnits } from "./hooks";
-import LinkPrev from "@/component/LinkPrev";
-
-const PreviousLinkWrapper = styled.div`
-  padding: var(--spacing-s);
-`;
+import { LinkPrev } from "@/component/LinkPrev";
 
 type Params = {
   unitId: string;
   reservationUnitId: string;
 };
-
-function BackLinkHeader() {
-  return (
-    <PreviousLinkWrapper>
-      <LinkPrev />
-    </PreviousLinkWrapper>
-  );
-}
 
 function RecurringReservationInner({ unitId }: { unitId: number }) {
   const { t } = useTranslation();
@@ -37,35 +24,36 @@ function RecurringReservationInner({ unitId }: { unitId: number }) {
 
   return (
     <>
-      <BackLinkHeader />
-      <Container>
-        <H1 $legacy>{t("MyUnits.RecurringReservation.pageTitle")}</H1>
-        {reservationUnits !== undefined && reservationUnits?.length > 0 ? (
-          <RecurringReservationForm reservationUnits={reservationUnits} />
-        ) : (
-          <p>
-            {t("MyUnits.RecurringReservation.error.notPossibleForThisUnit")}
-          </p>
-        )}
-      </Container>
+      <H1 $legacy>{t("MyUnits.RecurringReservation.pageTitle")}</H1>
+      {reservationUnits !== undefined && reservationUnits?.length > 0 ? (
+        <RecurringReservationForm reservationUnits={reservationUnits} />
+      ) : (
+        <p>{t("MyUnits.RecurringReservation.error.notPossibleForThisUnit")}</p>
+      )}
     </>
   );
 }
 
+function RecurringErrorPage() {
+  const { t } = useTranslation();
+  return <div>{t("MyUnits.RecurringReservation.error.invalidUnitId")}</div>;
+}
+
 // Handle invalid route params
 export function RecurringReservation() {
-  const { t } = useTranslation();
   const { unitId } = useParams<Params>();
 
-  if (unitId == null || Number.isNaN(Number(unitId))) {
-    return (
-      <>
-        <BackLinkHeader />
-        <Container>
-          <div>{t("MyUnits.RecurringReservation.error.invalidUnitId")}</div>
-        </Container>
-      </>
-    );
-  }
-  return <RecurringReservationInner unitId={Number(unitId)} />;
+  const isError = unitId == null || Number.isNaN(Number(unitId));
+  return (
+    <>
+      <LinkPrev />
+      <Container>
+        {isError ? (
+          <RecurringErrorPage />
+        ) : (
+          <RecurringReservationInner unitId={Number(unitId)} />
+        )}
+      </Container>
+    </>
+  );
 }

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/hooks.ts
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/hooks.ts
@@ -32,11 +32,11 @@ export function useFocusApplicationEvent(): [
       const p = new URLSearchParams(params);
       p.set("aes", aes.pk.toString());
       p.delete("allocated");
-      setParams(p);
+      setParams(p, { replace: true });
     } else {
       const p = new URLSearchParams(params);
       p.delete("aes");
-      setParams(p);
+      setParams(p, { replace: true });
     }
   };
 
@@ -60,11 +60,11 @@ export function useFocusAllocatedSlot(): [
       const p = new URLSearchParams(params);
       p.set("allocated", allocated.pk.toString());
       p.delete("aes");
-      setParams(p);
+      setParams(p, { replace: true });
     } else {
       const p = new URLSearchParams(params);
       p.delete("allocated");
-      setParams(p);
+      setParams(p, { replace: true });
     }
   };
 
@@ -82,7 +82,7 @@ export function useSlotSelection(): [string[], (slots: string[]) => void] {
       const qp = new URLSearchParams(params);
       qp.delete("selectionBegin");
       qp.delete("selectionEnd");
-      setParams(qp);
+      setParams(qp, { replace: true });
     } else {
       // TODO change the save format
       // current format is: {day}-{hour}-{minute}
@@ -95,7 +95,7 @@ export function useSlotSelection(): [string[], (slots: string[]) => void] {
       const qp = new URLSearchParams(params);
       qp.set("selectionBegin", selectionBegin);
       qp.set("selectionEnd", selectionEnd);
-      setParams(qp);
+      setParams(qp, { replace: true });
     }
   };
 

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/index.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/allocation/index.tsx
@@ -35,6 +35,7 @@ import { AllocationPageContent } from "./ApplicationEvents";
 import { ComboboxFilter, SearchFilter } from "@/component/QueryParamFilters";
 import { convertPriorityFilter } from "./modules/applicationRoundAllocation";
 import { ApplicationRoundNode } from "common/gql/gql-types";
+import { LinkPrev } from "@/component/LinkPrev";
 
 const MAX_RES_UNIT_NAME_LENGTH = 35;
 
@@ -192,6 +193,7 @@ type ApplicationRoundFilterQueryType =
 type ReservationUnitFilterQueryType =
   NonNullable<ApplicationRoundFilterQueryType>["reservationUnits"][0];
 type UnitFilterQueryType = NonNullable<ReservationUnitFilterQueryType>["unit"];
+
 function ApplicationRoundAllocation({
   applicationRound,
   applicationRoundPk,
@@ -655,7 +657,12 @@ function ApplicationRoundAllocationRouted(): JSX.Element {
   if (!applicationRoundPk || Number.isNaN(Number(applicationRoundPk))) {
     return <div>{t("errors.router.invalidApplicationRoundNumber")}</div>;
   }
-  return <AllocationWrapper applicationRoundPk={Number(applicationRoundPk)} />;
+  return (
+    <>
+      <LinkPrev />
+      <AllocationWrapper applicationRoundPk={Number(applicationRoundPk)} />*
+    </>
+  );
 }
 
 export default ApplicationRoundAllocationRouted;

--- a/apps/admin-ui/src/styles/layout.tsx
+++ b/apps/admin-ui/src/styles/layout.tsx
@@ -140,13 +140,6 @@ export const Span12 = styled.div`
 
 // Tab causes horizontal overflow without this
 // we use grids primarily and components inside grid without max-width overflow.
-// Because of side navigation we have to some silly calculations here.
 export const TabWrapper = styled.div`
   max-width: 95vw;
-  @media (width > ${breakpoints.m}) {
-    max-width: min(
-      calc(95vw - var(--main-menu-width) - 2 * var(--spacing-layout-m)),
-      var(--container-width-xl)
-    );
-  }
 `;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: don't pollute navigation history (in allocation pages) when search parameter changes.
- Refactor: back link component.
- Fix: add back link to allocation page that got removed when breadcrumbs was removed.
- Fix: remove sidebar (that was removed) adjustment from application-round page.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: navigation / layout on `admin-ui` allocation / application-round pages.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
