### PR TITLE
fix: admin-ui mobile menu styling

### DIFF
--- a/apps/admin-ui/src/component/Navigation.tsx
+++ b/apps/admin-ui/src/component/Navigation.tsx
@@ -38,6 +38,27 @@ const BackgroundHeader = styled(Header)`
   --notification-bubble-background-color: var(
     --tilavaraus-admin-handling-count-color
   );
+  [class^="HeaderActionBarItem-module_container"] {
+    > button span {
+      color: white !important;
+      svg {
+        color: white;
+      }
+    }
+  }
+
+  /* retain text-decoration: underline on the plain text in navigation items, but disable it in the notificationBubble */
+  [class^="HeaderNavigationMenu-module_headerNavigationMenuLinkContent__"]:hover {
+    a {
+      text-decoration: none;
+      span {
+        text-decoration: underline;
+      }
+      [class^="HeaderActionBarSubItem-module_notificationBubble__"] {
+        text-decoration: none;
+      }
+    }
+  }
   #user-menu-dropdown {
     color: black;
     button,
@@ -66,6 +87,7 @@ const BackgroundHeader = styled(Header)`
     }
     ul > li {
       > span {
+        box-sizing: border-box;
         padding: var(--spacing-s);
         li {
           width: 100%;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Admin menu button color is now white
- The mobile menu items (== the number in Varaustoiveet) fit the screen
- - doesn’t underline the above mentioned number on hover

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- check that the admin-ui header menu fits the screen/looks okay with mobile screen size
- hover the cursor on "Varaustoiveet" (admin-ui): the plain text should be underlined, while the number in the bubble should not

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
