### PR TITLE
fix: hds mobile nav z-index

### DIFF
--- a/apps/admin-ui/src/variables.css
+++ b/apps/admin-ui/src/variables.css
@@ -86,4 +86,5 @@
 /* override HDS variables */
 * {
   --notification-z-index-toast: var(--tilavaraus-admin-stack-notification) !important;
+  --header-z-index: var(--tilavaraus-admin-stack-main-menu);
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: hds mobile nav too small z-index (use the old variable before navigation change).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

-

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
