### PR TITLE
fix: remove double cancellation reasons

### DIFF
--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -19,7 +19,6 @@ import {
   getDurationOptions,
   getNormalizedReservationOrderStatus,
   getReservationApplicationMutationValues,
-  getWhyReservationCantBeCancelled,
   isReservationEditable,
   isReservationStartInFuture,
 } from "../reservation";
@@ -398,97 +397,6 @@ describe("getReservationApplcationMutationValues", () => {
       reserveeFirstName: "Etunimi",
       reserveeType: CustomerTypeChoice.Individual,
     });
-  });
-});
-
-describe("getWhyReservationCantBeCancelled", () => {
-  beforeAll(() => {
-    jest.useFakeTimers({
-      now: new Date(2024, 0, 1, 9, 0, 0),
-    });
-  });
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
-  function constructInput({
-    begin,
-    needsHandling,
-    canBeCancelledTimeBefore,
-  }: {
-    begin: Date; // reservation begin time
-    needsHandling?: boolean; // if the reservation unit needs handling
-    canBeCancelledTimeBefore?: number; // in seconds
-  }) {
-    return {
-      ...createMockReservation({
-        begin,
-        reservationUnit: createMockReservationUnit({
-          needsHandling,
-          canBeCancelledTimeBefore,
-        }),
-      }),
-    };
-  }
-
-  test("with no reservation unit", () => {
-    const input = {
-      ...constructInput({
-        begin: addDays(new Date(), 1),
-      }),
-      reservationUnit: [],
-    };
-    expect(getWhyReservationCantBeCancelled(input)).toBe(
-      "NO_CANCELLATION_RULE"
-    );
-  });
-
-  test("with no cancellation rule", () => {
-    const resUnit = {
-      ...createMockReservationUnit({}),
-      cancellationRule: null,
-    };
-    const input = {
-      ...constructInput({
-        begin: addDays(new Date(), 1),
-      }),
-      reservationUnit: [resUnit],
-    };
-    expect(getWhyReservationCantBeCancelled(input)).toBe(
-      "NO_CANCELLATION_RULE"
-    );
-  });
-
-  test("with required handling", () => {
-    const input = constructInput({
-      begin: addDays(new Date(), 1),
-      needsHandling: true,
-    });
-    expect(getWhyReservationCantBeCancelled(input)).toBe("REQUIRES_HANDLING");
-  });
-
-  test("with cancellation period", () => {
-    const input = constructInput({
-      begin: addDays(new Date(), 1),
-      canBeCancelledTimeBefore: 60 * 60,
-    });
-    expect(getWhyReservationCantBeCancelled(input)).toBe(null);
-  });
-
-  test("can be cancelled when the reservation is outside the cancellation buffer", () => {
-    const input = constructInput({
-      begin: addHours(new Date(), 12),
-      canBeCancelledTimeBefore: 60 * 60, // 1 hour
-    });
-    expect(getWhyReservationCantBeCancelled(input)).toBe(null);
-  });
-
-  test("can't cancel if the reservation is too close to the start time", () => {
-    const input = constructInput({
-      begin: addHours(new Date(), 12),
-      canBeCancelledTimeBefore: 24 * 60 * 60, // 24 hours
-    });
-    expect(getWhyReservationCantBeCancelled(input)).toBe("BUFFER");
   });
 });
 

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -45,7 +45,6 @@ import {
   getCheckoutUrl,
   getNormalizedReservationOrderStatus,
   getReservationValue,
-  getWhyReservationCantBeCancelled,
   getWhyReservationCantBeChanged,
 } from "@/modules/reservation";
 import {
@@ -400,19 +399,6 @@ function Reservation({
   const modifyTimeReason = getWhyReservationCantBeChanged({ reservation });
   const canTimeBeModified = modifyTimeReason == null;
 
-  const cancellationReason = useMemo(() => {
-    const reason = getWhyReservationCantBeCancelled(reservation);
-    switch (reason) {
-      case "NO_CANCELLATION_RULE":
-      case "REQUIRES_HANDLING":
-        return "termsAreBinding";
-      case "BUFFER":
-        return "buffer";
-      default:
-        return null;
-    }
-  }, [reservation]);
-
   const normalizedOrderStatus =
     getNormalizedReservationOrderStatus(reservation);
 
@@ -434,8 +420,10 @@ function Reservation({
     reservationUnit.metadataSet?.supportedFields
   );
 
-  const isReservationCancelled = reservation.state === "CANCELLED";
-  const isBeingHandled = reservation.state === "REQUIRES_HANDLING";
+  const isReservationCancelled =
+    reservation.state === ReservationStateChoice.Cancelled;
+  const isBeingHandled =
+    reservation.state === ReservationStateChoice.RequiresHandling;
 
   const isReservationCancellable =
     canUserCancelReservation(reservation) &&
@@ -573,7 +561,7 @@ function Reservation({
               )}
             </Actions>
             <Reasons>
-              {modifyTimeReason && (
+              {modifyTimeReason != null && (
                 <ReasonText>
                   {t(`reservations:modifyTimeReasons:${modifyTimeReason}`)}
                   {modifyTimeReason ===
@@ -582,11 +570,6 @@ function Reservation({
                     ` ${t(
                       "reservations:modifyTimeReasons:RESERVATION_MODIFICATION_NOT_ALLOWED_SUFFIX"
                     )}`}
-                </ReasonText>
-              )}
-              {cancellationReason && (
-                <ReasonText>
-                  {t(`reservations:cancellationReasons:${cancellationReason}`)}
                 </ReasonText>
               )}
             </Reasons>

--- a/apps/ui/public/locales/fi/reservations.json
+++ b/apps/ui/public/locales/fi/reservations.json
@@ -84,12 +84,7 @@
     "RESERVATION_MODIFICATION_NOT_ALLOWED_SUFFIX": "Tarvittaessa voit perua ja tehdä uuden varauksen.",
     "RESERVATION_BEGIN_IN_PAST": "Varausta ei voi enää perua tai muuttaa, koska varausaika on mennyt.",
     "CANCELLATION_NOT_ALLOWED": "Varaus on sitova ja sitä ei voi perua.",
-    "CANCELLATION_TIME_PAST": "Valitettavasti varausta ei voi enää perua tai muuttaa, koska peruutusaika on umpeutunut.",
-    "RESERVATION_TIME_INVALID": "Varauksen aika on liian lyhyt."
-  },
-  "cancellationReasons": {
-    "termsAreBinding": "Varaus on sitova ja sitä ei voi perua.",
-    "buffer": "Valitettavasti varausta ei voi enää perua tai muuttaa, koska peruutusaika on umpeutunut."
+    "CANCELLATION_TIME_PAST": "Valitettavasti varausta ei voi enää perua tai muuttaa, koska peruutusaika on umpeutunut."
   },
   "makeReservation": "Tee varaus",
   "orderStatus": {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: remove extra reason why cancellation is not allowed. (customer ui)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: when looking at an existing reservation there should be correct reason why it can't be moved or cancelled (not two reasons).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3521](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3521)


[TILA-3521]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ