### PR TITLE
Update reservationUnit state properties as per backend changes

### DIFF
--- a/apps/admin-ui/src/component/reservation-units/queries.tsx
+++ b/apps/admin-ui/src/component/reservation-units/queries.tsx
@@ -12,7 +12,7 @@ export const SEARCH_RESERVATION_UNITS_QUERY = gql`
     $unit: [Int]
     $reservationUnitType: [Int]
     $orderBy: [ReservationUnitOrderingChoices]
-    $state: [ReservationUnitState]
+    $publishingState: [ReservationUnitPublishingState]
   ) {
     reservationUnits(
       first: $first
@@ -27,7 +27,7 @@ export const SEARCH_RESERVATION_UNITS_QUERY = gql`
       surfaceAreaLte: $surfaceAreaLte
       unit: $unit
       reservationUnitType: $reservationUnitType
-      state: $state
+      publishingState: $publishingState
       onlyWithPermission: true
     ) {
       edges {
@@ -46,7 +46,7 @@ export const SEARCH_RESERVATION_UNITS_QUERY = gql`
           }
           maxPersons
           surfaceArea
-          state
+          publishingState
           reservationState
         }
       }

--- a/apps/admin-ui/src/spa/ReservationUnit/edit/queries.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/queries.tsx
@@ -8,7 +8,7 @@ export const RESERVATION_UNIT_EDIT_QUERY = gql`
     reservationUnit(id: $id) {
       id
       pk
-      state
+      publishingState
       reservationState
       images {
         pk

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -404,6 +404,9 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -414,10 +417,11 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
@@ -2296,6 +2300,9 @@ export type QueryReservationUnitsArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -2306,10 +2313,11 @@ export type QueryReservationUnitsArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
@@ -3112,6 +3120,9 @@ export type ReservationNodeReservationUnitArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -3122,10 +3133,11 @@ export type ReservationNodeReservationUnitArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
@@ -3526,15 +3538,6 @@ export enum ReservationStartInterval {
 }
 
 /** An enumeration. */
-export enum ReservationState {
-  Reservable = "RESERVABLE",
-  ReservationClosed = "RESERVATION_CLOSED",
-  ScheduledClosing = "SCHEDULED_CLOSING",
-  ScheduledPeriod = "SCHEDULED_PERIOD",
-  ScheduledReservation = "SCHEDULED_RESERVATION",
-}
-
-/** An enumeration. */
 export enum ReservationStateChoice {
   Cancelled = "CANCELLED",
   Confirmed = "CONFIRMED",
@@ -3712,6 +3715,7 @@ export type ReservationUnitCreateMutationPayload = {
   pricings?: Maybe<Array<Maybe<ReservationUnitPricingNode>>>;
   publishBegins?: Maybe<Scalars["DateTime"]["output"]>;
   publishEnds?: Maybe<Scalars["DateTime"]["output"]>;
+  publishingState?: Maybe<Scalars["String"]["output"]>;
   purposes?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   qualifiers?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   requireIntroduction?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3740,7 +3744,6 @@ export type ReservationUnitCreateMutationPayload = {
   serviceSpecificTerms?: Maybe<Scalars["String"]["output"]>;
   services?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   spaces?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-  state?: Maybe<Scalars["String"]["output"]>;
   surfaceArea?: Maybe<Scalars["Int"]["output"]>;
   termsOfUse?: Maybe<Scalars["String"]["output"]>;
   termsOfUseEn?: Maybe<Scalars["String"]["output"]>;
@@ -3846,6 +3849,7 @@ export type ReservationUnitNode = Node & {
   pricings: Array<ReservationUnitPricingNode>;
   publishBegins?: Maybe<Scalars["DateTime"]["output"]>;
   publishEnds?: Maybe<Scalars["DateTime"]["output"]>;
+  publishingState?: Maybe<ReservationUnitPublishingState>;
   purposes: Array<PurposeNode>;
   qualifiers: Array<QualifierNode>;
   rank?: Maybe<Scalars["Int"]["output"]>;
@@ -3870,7 +3874,7 @@ export type ReservationUnitNode = Node & {
   reservationPendingInstructionsSv?: Maybe<Scalars["String"]["output"]>;
   reservationSet?: Maybe<Array<ReservationNode>>;
   reservationStartInterval: ReservationStartInterval;
-  reservationState?: Maybe<ReservationState>;
+  reservationState?: Maybe<ReservationUnitReservationState>;
   reservationUnitType?: Maybe<ReservationUnitTypeNode>;
   reservationsMaxDaysBefore?: Maybe<Scalars["Int"]["output"]>;
   reservationsMinDaysBefore?: Maybe<Scalars["Int"]["output"]>;
@@ -3878,7 +3882,6 @@ export type ReservationUnitNode = Node & {
   serviceSpecificTerms?: Maybe<TermsOfUseNode>;
   services: Array<ServiceNode>;
   spaces: Array<SpaceNode>;
-  state?: Maybe<ReservationUnitState>;
   surfaceArea?: Maybe<Scalars["Int"]["output"]>;
   termsOfUse?: Maybe<Scalars["String"]["output"]>;
   termsOfUseEn?: Maybe<Scalars["String"]["output"]>;
@@ -4142,7 +4145,7 @@ export type ReservationUnitPricingSerializerInput = {
 };
 
 /** An enumeration. */
-export enum ReservationUnitState {
+export enum ReservationUnitPublishingState {
   Archived = "ARCHIVED",
   Draft = "DRAFT",
   Hidden = "HIDDEN",
@@ -4150,6 +4153,15 @@ export enum ReservationUnitState {
   ScheduledHiding = "SCHEDULED_HIDING",
   ScheduledPeriod = "SCHEDULED_PERIOD",
   ScheduledPublishing = "SCHEDULED_PUBLISHING",
+}
+
+/** An enumeration. */
+export enum ReservationUnitReservationState {
+  Reservable = "RESERVABLE",
+  ReservationClosed = "RESERVATION_CLOSED",
+  ScheduledClosing = "SCHEDULED_CLOSING",
+  ScheduledPeriod = "SCHEDULED_PERIOD",
+  ScheduledReservation = "SCHEDULED_RESERVATION",
 }
 
 export type ReservationUnitTypeNode = Node & {
@@ -4306,6 +4318,7 @@ export type ReservationUnitUpdateMutationPayload = {
   pricings?: Maybe<Array<Maybe<ReservationUnitPricingNode>>>;
   publishBegins?: Maybe<Scalars["DateTime"]["output"]>;
   publishEnds?: Maybe<Scalars["DateTime"]["output"]>;
+  publishingState?: Maybe<Scalars["String"]["output"]>;
   purposes?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   qualifiers?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   requireIntroduction?: Maybe<Scalars["Boolean"]["output"]>;
@@ -4334,7 +4347,6 @@ export type ReservationUnitUpdateMutationPayload = {
   serviceSpecificTerms?: Maybe<Scalars["String"]["output"]>;
   services?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   spaces?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-  state?: Maybe<Scalars["String"]["output"]>;
   surfaceArea?: Maybe<Scalars["Int"]["output"]>;
   termsOfUse?: Maybe<Scalars["String"]["output"]>;
   termsOfUseEn?: Maybe<Scalars["String"]["output"]>;
@@ -4994,6 +5006,9 @@ export type UnitNodeReservationunitSetArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -5004,10 +5019,11 @@ export type UnitNodeReservationunitSetArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
@@ -6224,8 +6240,8 @@ export type ReservationUnitPageFieldsFragment = {
   bufferTimeAfter: number;
   reservationStartInterval: ReservationStartInterval;
   canApplyFreeOfCharge: boolean;
-  state?: ReservationUnitState | null;
-  reservationState?: ReservationState | null;
+  publishingState?: ReservationUnitPublishingState | null;
+  reservationState?: ReservationUnitReservationState | null;
   numActiveUserReservations?: number | null;
   requireReservationHandling: boolean;
   id: string;
@@ -6382,8 +6398,8 @@ export type ReservationUnitQuery = {
     bufferTimeAfter: number;
     reservationStartInterval: ReservationStartInterval;
     canApplyFreeOfCharge: boolean;
-    state?: ReservationUnitState | null;
-    reservationState?: ReservationState | null;
+    publishingState?: ReservationUnitPublishingState | null;
+    reservationState?: ReservationUnitReservationState | null;
     numActiveUserReservations?: number | null;
     requireReservationHandling: boolean;
     id: string;
@@ -6563,8 +6579,8 @@ export type ReservationUnitPageQuery = {
     bufferTimeAfter: number;
     reservationStartInterval: ReservationStartInterval;
     canApplyFreeOfCharge: boolean;
-    state?: ReservationUnitState | null;
-    reservationState?: ReservationState | null;
+    publishingState?: ReservationUnitPublishingState | null;
+    reservationState?: ReservationUnitReservationState | null;
     numActiveUserReservations?: number | null;
     requireReservationHandling: boolean;
     maxReservationDuration?: number | null;
@@ -7974,7 +7990,7 @@ export const ReservationUnitPageFieldsFragmentDoc = gql`
     bufferTimeAfter
     reservationStartInterval
     canApplyFreeOfCharge
-    state
+    publishingState
     reservationState
     reservationUnitType {
       ...ReservationUnitTypeFields

--- a/apps/ui/modules/__tests__/reservationUnit.test.ts
+++ b/apps/ui/modules/__tests__/reservationUnit.test.ts
@@ -14,13 +14,13 @@ import {
   ReservationStateChoice,
   PriceUnit,
   PricingType,
-  ReservationUnitState,
+  ReservationUnitPublishingState,
   type ReservationUnitNode,
   Status,
   Authentication,
   ReservationKind,
   ReservationStartInterval,
-  ReservationState,
+  ReservationUnitReservationState,
   type PriceReservationUnitFragment,
 } from "@gql/gql-types";
 import {
@@ -387,38 +387,46 @@ describe("isReservationUnitPublished", () => {
 
   test("with valid states", () => {
     expect(
-      isReservationUnitPublished({ state: ReservationUnitState.Published })
+      isReservationUnitPublished({
+        publishingState: ReservationUnitPublishingState.Published,
+      })
     ).toBe(true);
 
     expect(
       isReservationUnitPublished({
-        state: ReservationUnitState.ScheduledHiding,
+        publishingState: ReservationUnitPublishingState.ScheduledHiding,
       })
     ).toBe(true);
   });
 
   test("with invalid states", () => {
     expect(
-      isReservationUnitPublished({ state: ReservationUnitState.Archived })
-    ).toBe(false);
-
-    expect(
-      isReservationUnitPublished({ state: ReservationUnitState.Draft })
-    ).toBe(false);
-
-    expect(
-      isReservationUnitPublished({ state: ReservationUnitState.Hidden })
-    ).toBe(false);
-
-    expect(
       isReservationUnitPublished({
-        state: ReservationUnitState.ScheduledPeriod,
+        publishingState: ReservationUnitPublishingState.Archived,
       })
     ).toBe(false);
 
     expect(
       isReservationUnitPublished({
-        state: ReservationUnitState.ScheduledPublishing,
+        publishingState: ReservationUnitPublishingState.Draft,
+      })
+    ).toBe(false);
+
+    expect(
+      isReservationUnitPublished({
+        publishingState: ReservationUnitPublishingState.Hidden,
+      })
+    ).toBe(false);
+
+    expect(
+      isReservationUnitPublished({
+        publishingState: ReservationUnitPublishingState.ScheduledPeriod,
+      })
+    ).toBe(false);
+
+    expect(
+      isReservationUnitPublished({
+        publishingState: ReservationUnitPublishingState.ScheduledPublishing,
       })
     ).toBe(false);
   });
@@ -1224,11 +1232,11 @@ describe("isReservationUnitReservable", () => {
   function constructReservationUnitNode({
     minReservationDuration = 3600,
     maxReservationDuration = 3600,
-    reservationState = ReservationState.Reservable,
+    reservationState = ReservationUnitReservationState.Reservable,
   }: {
     minReservationDuration?: number;
     maxReservationDuration?: number;
-    reservationState?: ReservationState;
+    reservationState?: ReservationUnitReservationState;
   }) {
     const date = new Date().toISOString().split("T")[0];
     const reservationUnit: ReservationUnitNode = {
@@ -1297,7 +1305,7 @@ describe("isReservationUnitReservable", () => {
 
     const [res2] = isReservationUnitReservable(
       constructReservationUnitNode({
-        reservationState: ReservationState.ScheduledClosing,
+        reservationState: ReservationUnitReservationState.ScheduledClosing,
       })
     );
     expect(res2).toBe(true);
@@ -1307,25 +1315,25 @@ describe("isReservationUnitReservable", () => {
     const [res1] = isReservationUnitReservable({
       ...constructReservationUnitNode({}),
       reservableTimeSpans: undefined,
-      reservationState: ReservationState.ReservationClosed,
+      reservationState: ReservationUnitReservationState.ReservationClosed,
     });
     expect(res1).toBe(false);
 
     const [res2] = isReservationUnitReservable({
       ...constructReservationUnitNode({}),
-      reservationState: ReservationState.ReservationClosed,
+      reservationState: ReservationUnitReservationState.ReservationClosed,
     });
     expect(res2).toBe(false);
 
     const [res5] = isReservationUnitReservable({
       ...constructReservationUnitNode({}),
-      reservationState: ReservationState.ScheduledReservation,
+      reservationState: ReservationUnitReservationState.ScheduledReservation,
     });
     expect(res5).toBe(false);
 
     const [res6] = isReservationUnitReservable({
       ...constructReservationUnitNode({}),
-      reservationState: ReservationState.ScheduledPeriod,
+      reservationState: ReservationUnitReservationState.ScheduledPeriod,
     });
     expect(res6).toBe(false);
   });

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -72,7 +72,7 @@ const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
     bufferTimeAfter
     reservationStartInterval
     canApplyFreeOfCharge
-    state
+    publishingState
     reservationState
     reservationUnitType {
       ...ReservationUnitTypeFields

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -16,7 +16,7 @@ import {
   toUIDate,
 } from "common/src/common/util";
 import {
-  ReservationUnitState,
+  ReservationUnitPublishingState,
   type ReservationUnitNode,
   PricingType,
   PriceUnit,
@@ -24,7 +24,7 @@ import {
   type EquipmentFieldsFragment,
   type PriceReservationUnitFragment,
   type UnitNode,
-  ReservationState,
+  ReservationUnitReservationState,
   type MetadataSetsFragment,
   ReservationKind,
   ReservationStateChoice,
@@ -57,16 +57,16 @@ function formatTime(date: Date): string {
 export { formatTime as getTimeString };
 
 export function isReservationUnitPublished(
-  reservationUnit?: Pick<ReservationUnitNode, "state"> | null
+  reservationUnit?: Pick<ReservationUnitNode, "publishingState"> | null
 ): boolean {
   if (!reservationUnit) {
     return false;
   }
-  const { state } = reservationUnit;
+  const { publishingState } = reservationUnit;
 
-  switch (state) {
-    case ReservationUnitState.Published:
-    case ReservationUnitState.ScheduledHiding:
+  switch (publishingState) {
+    case ReservationUnitPublishingState.Published:
+    case ReservationUnitPublishingState.ScheduledHiding:
       return true;
     default:
       return false;
@@ -534,8 +534,8 @@ export function isReservationUnitReservable(
   } = reservationUnit;
 
   switch (reservationState) {
-    case ReservationState.Reservable:
-    case ReservationState.ScheduledClosing: {
+    case ReservationUnitReservationState.Reservable:
+    case ReservationUnitReservationState.ScheduledClosing: {
       const resBegins = reservationUnit.reservationBegins
         ? new Date(reservationUnit.reservationBegins)
         : null;

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -404,6 +404,9 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -414,10 +417,11 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
@@ -2296,6 +2300,9 @@ export type QueryReservationUnitsArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -2306,10 +2313,11 @@ export type QueryReservationUnitsArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
@@ -3112,6 +3120,9 @@ export type ReservationNodeReservationUnitArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -3122,10 +3133,11 @@ export type ReservationNodeReservationUnitArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
@@ -3526,15 +3538,6 @@ export enum ReservationStartInterval {
 }
 
 /** An enumeration. */
-export enum ReservationState {
-  Reservable = "RESERVABLE",
-  ReservationClosed = "RESERVATION_CLOSED",
-  ScheduledClosing = "SCHEDULED_CLOSING",
-  ScheduledPeriod = "SCHEDULED_PERIOD",
-  ScheduledReservation = "SCHEDULED_RESERVATION",
-}
-
-/** An enumeration. */
 export enum ReservationStateChoice {
   Cancelled = "CANCELLED",
   Confirmed = "CONFIRMED",
@@ -3712,6 +3715,7 @@ export type ReservationUnitCreateMutationPayload = {
   pricings?: Maybe<Array<Maybe<ReservationUnitPricingNode>>>;
   publishBegins?: Maybe<Scalars["DateTime"]["output"]>;
   publishEnds?: Maybe<Scalars["DateTime"]["output"]>;
+  publishingState?: Maybe<Scalars["String"]["output"]>;
   purposes?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   qualifiers?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   requireIntroduction?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3740,7 +3744,6 @@ export type ReservationUnitCreateMutationPayload = {
   serviceSpecificTerms?: Maybe<Scalars["String"]["output"]>;
   services?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   spaces?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-  state?: Maybe<Scalars["String"]["output"]>;
   surfaceArea?: Maybe<Scalars["Int"]["output"]>;
   termsOfUse?: Maybe<Scalars["String"]["output"]>;
   termsOfUseEn?: Maybe<Scalars["String"]["output"]>;
@@ -3846,6 +3849,7 @@ export type ReservationUnitNode = Node & {
   pricings: Array<ReservationUnitPricingNode>;
   publishBegins?: Maybe<Scalars["DateTime"]["output"]>;
   publishEnds?: Maybe<Scalars["DateTime"]["output"]>;
+  publishingState?: Maybe<ReservationUnitPublishingState>;
   purposes: Array<PurposeNode>;
   qualifiers: Array<QualifierNode>;
   rank?: Maybe<Scalars["Int"]["output"]>;
@@ -3870,7 +3874,7 @@ export type ReservationUnitNode = Node & {
   reservationPendingInstructionsSv?: Maybe<Scalars["String"]["output"]>;
   reservationSet?: Maybe<Array<ReservationNode>>;
   reservationStartInterval: ReservationStartInterval;
-  reservationState?: Maybe<ReservationState>;
+  reservationState?: Maybe<ReservationUnitReservationState>;
   reservationUnitType?: Maybe<ReservationUnitTypeNode>;
   reservationsMaxDaysBefore?: Maybe<Scalars["Int"]["output"]>;
   reservationsMinDaysBefore?: Maybe<Scalars["Int"]["output"]>;
@@ -3878,7 +3882,6 @@ export type ReservationUnitNode = Node & {
   serviceSpecificTerms?: Maybe<TermsOfUseNode>;
   services: Array<ServiceNode>;
   spaces: Array<SpaceNode>;
-  state?: Maybe<ReservationUnitState>;
   surfaceArea?: Maybe<Scalars["Int"]["output"]>;
   termsOfUse?: Maybe<Scalars["String"]["output"]>;
   termsOfUseEn?: Maybe<Scalars["String"]["output"]>;
@@ -4142,7 +4145,7 @@ export type ReservationUnitPricingSerializerInput = {
 };
 
 /** An enumeration. */
-export enum ReservationUnitState {
+export enum ReservationUnitPublishingState {
   Archived = "ARCHIVED",
   Draft = "DRAFT",
   Hidden = "HIDDEN",
@@ -4150,6 +4153,15 @@ export enum ReservationUnitState {
   ScheduledHiding = "SCHEDULED_HIDING",
   ScheduledPeriod = "SCHEDULED_PERIOD",
   ScheduledPublishing = "SCHEDULED_PUBLISHING",
+}
+
+/** An enumeration. */
+export enum ReservationUnitReservationState {
+  Reservable = "RESERVABLE",
+  ReservationClosed = "RESERVATION_CLOSED",
+  ScheduledClosing = "SCHEDULED_CLOSING",
+  ScheduledPeriod = "SCHEDULED_PERIOD",
+  ScheduledReservation = "SCHEDULED_RESERVATION",
 }
 
 export type ReservationUnitTypeNode = Node & {
@@ -4306,6 +4318,7 @@ export type ReservationUnitUpdateMutationPayload = {
   pricings?: Maybe<Array<Maybe<ReservationUnitPricingNode>>>;
   publishBegins?: Maybe<Scalars["DateTime"]["output"]>;
   publishEnds?: Maybe<Scalars["DateTime"]["output"]>;
+  publishingState?: Maybe<Scalars["String"]["output"]>;
   purposes?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   qualifiers?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   requireIntroduction?: Maybe<Scalars["Boolean"]["output"]>;
@@ -4334,7 +4347,6 @@ export type ReservationUnitUpdateMutationPayload = {
   serviceSpecificTerms?: Maybe<Scalars["String"]["output"]>;
   services?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
   spaces?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-  state?: Maybe<Scalars["String"]["output"]>;
   surfaceArea?: Maybe<Scalars["Int"]["output"]>;
   termsOfUse?: Maybe<Scalars["String"]["output"]>;
   termsOfUseEn?: Maybe<Scalars["String"]["output"]>;
@@ -4994,6 +5006,9 @@ export type UnitNodeReservationunitSetArgs = {
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<ReservationUnitOrderingChoices>>>;
   pk?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  publishingState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitPublishingState>>
+  >;
   purposes?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
@@ -5004,10 +5019,11 @@ export type UnitNodeReservationunitSetArgs = {
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
-  reservationState?: InputMaybe<Array<InputMaybe<ReservationState>>>;
+  reservationState?: InputMaybe<
+    Array<InputMaybe<ReservationUnitReservationState>>
+  >;
   reservationUnitType?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  state?: InputMaybe<Array<InputMaybe<ReservationUnitState>>>;
   surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
   surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -420,6 +420,7 @@ type ApplicationRoundNode implements Node {
     """
     orderBy: [ReservationUnitOrderingChoices]
     pk: [Int]
+    publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
     rankGte: Decimal
@@ -430,10 +431,9 @@ type ApplicationRoundNode implements Node {
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
-    reservationState: [ReservationState]
+    reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    state: [ReservationUnitState]
     surfaceAreaGte: Decimal
     surfaceAreaLte: Decimal
     textSearch: String
@@ -2487,6 +2487,7 @@ type Query {
     """
     orderBy: [ReservationUnitOrderingChoices]
     pk: [Int]
+    publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
     rankGte: Decimal
@@ -2497,10 +2498,9 @@ type Query {
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
-    reservationState: [ReservationState]
+    reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    state: [ReservationUnitState]
     surfaceAreaGte: Decimal
     surfaceAreaLte: Decimal
     textSearch: String
@@ -3392,6 +3392,7 @@ type ReservationNode implements Node {
     """
     orderBy: [ReservationUnitOrderingChoices]
     pk: [Int]
+    publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
     rankGte: Decimal
@@ -3402,10 +3403,9 @@ type ReservationNode implements Node {
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
-    reservationState: [ReservationState]
+    reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    state: [ReservationUnitState]
     surfaceAreaGte: Decimal
     surfaceAreaLte: Decimal
     textSearch: String
@@ -3900,17 +3900,6 @@ enum ReservationStartInterval {
 """
 An enumeration.
 """
-enum ReservationState {
-  RESERVABLE
-  RESERVATION_CLOSED
-  SCHEDULED_CLOSING
-  SCHEDULED_PERIOD
-  SCHEDULED_RESERVATION
-}
-
-"""
-An enumeration.
-"""
 enum ReservationStateChoice {
   CANCELLED
   CONFIRMED
@@ -4106,6 +4095,7 @@ type ReservationUnitCreateMutationPayload {
   pricings: [ReservationUnitPricingNode]
   publishBegins: DateTime
   publishEnds: DateTime
+  publishingState: String
   purposes: [Int]
   qualifiers: [Int]
   requireIntroduction: Boolean
@@ -4134,7 +4124,6 @@ type ReservationUnitCreateMutationPayload {
   serviceSpecificTerms: String
   services: [Int]
   spaces: [Int]
-  state: String
   surfaceArea: Int
   termsOfUse: String
   termsOfUseEn: String
@@ -4273,6 +4262,7 @@ type ReservationUnitNode implements Node {
   pricings: [ReservationUnitPricingNode!]!
   publishBegins: DateTime
   publishEnds: DateTime
+  publishingState: ReservationUnitPublishingState
   purposes(
     nameEn: String
     nameFi: String
@@ -4346,7 +4336,7 @@ type ReservationUnitNode implements Node {
     user: [Int]
   ): [ReservationNode!]
   reservationStartInterval: ReservationStartInterval!
-  reservationState: ReservationState
+  reservationState: ReservationUnitReservationState
   reservationUnitType: ReservationUnitTypeNode
   reservationsMaxDaysBefore: Int
   reservationsMinDaysBefore: Int
@@ -4386,7 +4376,6 @@ type ReservationUnitNode implements Node {
     orderBy: [SpaceOrderingChoices]
     pk: [Int]
   ): [SpaceNode!]!
-  state: ReservationUnitState
   surfaceArea: Int
   termsOfUse: String
   termsOfUseEn: String
@@ -4592,7 +4581,7 @@ input ReservationUnitPricingSerializerInput {
 """
 An enumeration.
 """
-enum ReservationUnitState {
+enum ReservationUnitPublishingState {
   ARCHIVED
   DRAFT
   HIDDEN
@@ -4600,6 +4589,17 @@ enum ReservationUnitState {
   SCHEDULED_HIDING
   SCHEDULED_PERIOD
   SCHEDULED_PUBLISHING
+}
+
+"""
+An enumeration.
+"""
+enum ReservationUnitReservationState {
+  RESERVABLE
+  RESERVATION_CLOSED
+  SCHEDULED_CLOSING
+  SCHEDULED_PERIOD
+  SCHEDULED_RESERVATION
 }
 
 type ReservationUnitTypeNode implements Node {
@@ -4764,6 +4764,7 @@ type ReservationUnitUpdateMutationPayload {
   pricings: [ReservationUnitPricingNode]
   publishBegins: DateTime
   publishEnds: DateTime
+  publishingState: String
   purposes: [Int]
   qualifiers: [Int]
   requireIntroduction: Boolean
@@ -4792,7 +4793,6 @@ type ReservationUnitUpdateMutationPayload {
   serviceSpecificTerms: String
   services: [Int]
   spaces: [Int]
-  state: String
   surfaceArea: Int
   termsOfUse: String
   termsOfUseEn: String
@@ -5599,6 +5599,7 @@ type UnitNode implements Node {
     """
     orderBy: [ReservationUnitOrderingChoices]
     pk: [Int]
+    publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
     rankGte: Decimal
@@ -5609,10 +5610,9 @@ type UnitNode implements Node {
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
-    reservationState: [ReservationState]
+    reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    state: [ReservationUnitState]
     surfaceAreaGte: Decimal
     surfaceAreaLte: Decimal
     textSearch: String


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Renames reservation unit state properties as per the changes in the backend
  - `reservationUnit.state` => `reservationUnit.publishingState`
  - `ReservationState`=> `ReservationUnitReservationState`
- requires the back end changes in PR [#1278](https://github.com/City-of-Helsinki/tilavarauspalvelu-core/pull/1278) to work (==not break)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Everything reservation unit state related should work as it did before the change

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3473
