### PR TITLE
fix: remove search result count

### DIFF
--- a/apps/ui/components/common/ListWithPagination.tsx
+++ b/apps/ui/components/common/ListWithPagination.tsx
@@ -14,13 +14,9 @@ const TopWrapper = styled.div`
   }
 `;
 
-const HitCount = styled.div`
+const HitCountSummary = styled.div`
   font-size: var(--fontsize-body-l);
-  margin-bottom: var(--spacing-s);
-
-  @media (min-width: ${breakpoints.s}) {
-    margin-bottom: 0;
-  }
+  margin: var(--spacing-l) 0 var(--spacing-m);
 `;
 
 const NoResults = styled.div`
@@ -38,10 +34,6 @@ const Paginator = styled.div`
   display: grid;
   justify-content: center;
   height: 140px;
-`;
-
-const HitCountSummary = styled(HitCount)`
-  margin: var(--spacing-l) 0 var(--spacing-m);
 `;
 
 const PaginationButton = styled(Button)`
@@ -136,12 +128,10 @@ export function ListWithPagination({
   return (
     <div className={className}>
       <TopWrapper data-testid="list-with-pagination__hit-count">
-        {items.length > 0 ? (
-          <HitCount>
-            {t("searchResultList:count", { count: items.length })}
-          </HitCount>
-        ) : (
+        {items.length === 0 ? (
           <NoResults>{t("searchResultList:noResults")}</NoResults>
+        ) : (
+          <div />
         )}
         {sortingComponent && sortingComponent}
       </TopWrapper>


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Remove `ui` search page count because it's miss leading to the user as we don't know the total count so it looks like there are no more result.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: search page only thing that should have changed is the count before the list is removed (the one next to load more is still intact).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3550
