### PR TITLE
fix: show text underline in navigation on focus

### DIFF
--- a/apps/admin-ui/src/component/Navigation.tsx
+++ b/apps/admin-ui/src/component/Navigation.tsx
@@ -48,7 +48,8 @@ const BackgroundHeader = styled(Header)`
   }
 
   /* retain text-decoration: underline on the plain text in navigation items, but disable it in the notificationBubble */
-  [class^="HeaderNavigationMenu-module_headerNavigationMenuLinkContent__"]:hover {
+  [class^="HeaderNavigationMenu-module_headerNavigationMenuLinkContent__"]:hover,
+  [class^="HeaderNavigationMenu-module_headerNavigationMenuLinkContent__"]:focus-within {
     a {
       text-decoration: none;
       span {

--- a/apps/ui/components/common/Navigation.tsx
+++ b/apps/ui/components/common/Navigation.tsx
@@ -52,6 +52,9 @@ const Wrapper = styled.div`
     [class*="module_headerNavigationMenuContainer__"] li {
       a {
         margin: 0;
+        &:focus {
+          text-decoration: underline;
+        }
       }
 
       span:has(.active) {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Underlines the link text on `:focus` in the header navigation

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Try focusing using the tabulator on the keyboard. The navigation links should show the text underlined when they're focused on.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
