### PR TITLE
fix: allow pdf access without csrf token

### DIFF
--- a/apps/ui/middleware.ts
+++ b/apps/ui/middleware.ts
@@ -121,7 +121,7 @@ function redirectCsrfToken(req: NextRequest): URL | undefined {
     requestUrl.pathname.startsWith("/healthcheck") ||
     requestUrl.pathname.startsWith("/_next") ||
     requestUrl.pathname.match(
-      /\.(webmanifest|js|css|png|jpg|jpeg|svg|gif|ico|json|woff|woff2|ttf|eot|otf)$/
+      /\.(webmanifest|js|css|png|jpg|jpeg|svg|gif|ico|json|woff|woff2|ttf|eot|otf|pdf)$/
     )
   ) {
     return undefined;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: allow routes to pdf documents without csrf token so webstore can fetch them.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: use `curl` (or similar tool without following redirects / including headers) to fetch the pdf terms and services. Should return the document, not a redirect.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3531](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3531)


[TILA-3531]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ