### PR TITLE
fix: permission checking units missing unit groups

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -362,10 +362,8 @@ export type ApplicationRoundNode = Node & {
   reservationUnitCount?: Maybe<Scalars["Int"]["output"]>;
   reservationUnits: Array<ReservationUnitNode>;
   sentDate?: Maybe<Scalars["DateTime"]["output"]>;
-  serviceSector?: Maybe<ServiceSectorNode>;
   status?: Maybe<ApplicationRoundStatusChoice>;
   statusTimestamp?: Maybe<Scalars["DateTime"]["output"]>;
-  targetGroup: TargetGroup;
   termsOfUse?: Maybe<TermsOfUseNode>;
 };
 
@@ -4801,16 +4799,6 @@ export type SuitableTimeRangeSerializerInput = {
   priority: Priority;
 };
 
-/** An enumeration. */
-export enum TargetGroup {
-  /** Kaikki */
-  All = "ALL",
-  /** Sisäinen */
-  Internal = "INTERNAL",
-  /** Julkinen */
-  Public = "PUBLIC",
-}
-
 export type TaxPercentageNode = Node & {
   /** The ID of the object */
   id: Scalars["ID"]["output"];
@@ -5310,7 +5298,7 @@ export enum UserRoleChoice {
   NotificationManager = "NOTIFICATION_MANAGER",
   /** Varaaja */
   Reserver = "RESERVER",
-  /** Katselika */
+  /** Katselija */
   Viewer = "VIEWER",
 }
 
@@ -7451,6 +7439,10 @@ export type CurrentUserQuery = {
       permissions?: Array<UserPermissionChoice | null> | null;
       role: UserRoleChoice;
       units: Array<{ id: string; pk?: number | null; nameFi?: string | null }>;
+      unitGroups: Array<{
+        id: string;
+        units: Array<{ id: string; pk?: number | null }>;
+      }>;
     }>;
     generalRoles: Array<{
       id: string;
@@ -13049,6 +13041,13 @@ export const CurrentUserDocument = gql`
           id
           pk
           nameFi
+        }
+        unitGroups {
+          id
+          units {
+            id
+            pk
+          }
         }
         role
       }

--- a/apps/admin-ui/src/modules/permissionHelper.ts
+++ b/apps/admin-ui/src/modules/permissionHelper.ts
@@ -20,6 +20,13 @@ export const CURRENT_USER = gql`
           pk
           nameFi
         }
+        unitGroups {
+          id
+          units {
+            id
+            pk
+          }
+        }
         role
       }
       generalRoles {
@@ -44,6 +51,12 @@ function hasUnitPermission(
     const perms = filterNonNullable(role.permissions?.map((x) => x));
     if (perms.find((x) => x === permission) == null) {
       continue;
+    }
+    const unitsInGroups = filterNonNullable(
+      role.unitGroups?.flatMap((x) => x.units.map((y) => y.pk))
+    );
+    if (unitsInGroups.find((x) => x === unitPk)) {
+      return true;
     }
 
     // Check unit specific permissions

--- a/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
+++ b/apps/admin-ui/src/spa/recurring-reservations/application-rounds/[id]/review/Review.tsx
@@ -252,8 +252,10 @@ export function Review({
   const { user } = useSession();
 
   // need filtered list of units that the user has permission to view
-  const ds = getUnitOptions(resUnits).filter((unit) =>
-    hasPermission(user, UserPermissionChoice.CanViewApplications, unit.pk)
+  const ds = getUnitOptions(resUnits).filter(
+    (unit) =>
+      hasPermission(user, UserPermissionChoice.CanViewApplications, unit.pk) ||
+      hasPermission(user, UserPermissionChoice.CanManageApplications, unit.pk)
   );
   const unitOptions = uniqBy(ds, (unit) => unit.pk).sort((a, b) =>
     a.nameFi.localeCompare(b.nameFi)

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -362,10 +362,8 @@ export type ApplicationRoundNode = Node & {
   reservationUnitCount?: Maybe<Scalars["Int"]["output"]>;
   reservationUnits: Array<ReservationUnitNode>;
   sentDate?: Maybe<Scalars["DateTime"]["output"]>;
-  serviceSector?: Maybe<ServiceSectorNode>;
   status?: Maybe<ApplicationRoundStatusChoice>;
   statusTimestamp?: Maybe<Scalars["DateTime"]["output"]>;
-  targetGroup: TargetGroup;
   termsOfUse?: Maybe<TermsOfUseNode>;
 };
 
@@ -4801,16 +4799,6 @@ export type SuitableTimeRangeSerializerInput = {
   priority: Priority;
 };
 
-/** An enumeration. */
-export enum TargetGroup {
-  /** Kaikki */
-  All = "ALL",
-  /** Sisäinen */
-  Internal = "INTERNAL",
-  /** Julkinen */
-  Public = "PUBLIC",
-}
-
 export type TaxPercentageNode = Node & {
   /** The ID of the object */
   id: Scalars["ID"]["output"];
@@ -5310,7 +5298,7 @@ export enum UserRoleChoice {
   NotificationManager = "NOTIFICATION_MANAGER",
   /** Varaaja */
   Reserver = "RESERVER",
-  /** Katselika */
+  /** Katselija */
   Viewer = "VIEWER",
 }
 

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -362,10 +362,8 @@ export type ApplicationRoundNode = Node & {
   reservationUnitCount?: Maybe<Scalars["Int"]["output"]>;
   reservationUnits: Array<ReservationUnitNode>;
   sentDate?: Maybe<Scalars["DateTime"]["output"]>;
-  serviceSector?: Maybe<ServiceSectorNode>;
   status?: Maybe<ApplicationRoundStatusChoice>;
   statusTimestamp?: Maybe<Scalars["DateTime"]["output"]>;
-  targetGroup: TargetGroup;
   termsOfUse?: Maybe<TermsOfUseNode>;
 };
 
@@ -4801,16 +4799,6 @@ export type SuitableTimeRangeSerializerInput = {
   priority: Priority;
 };
 
-/** An enumeration. */
-export enum TargetGroup {
-  /** Kaikki */
-  All = "ALL",
-  /** Sisäinen */
-  Internal = "INTERNAL",
-  /** Julkinen */
-  Public = "PUBLIC",
-}
-
 export type TaxPercentageNode = Node & {
   /** The ID of the object */
   id: Scalars["ID"]["output"];
@@ -5310,7 +5298,7 @@ export enum UserRoleChoice {
   NotificationManager = "NOTIFICATION_MANAGER",
   /** Varaaja */
   Reserver = "RESERVER",
-  /** Katselika */
+  /** Katselija */
   Viewer = "VIEWER",
 }
 

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -444,10 +444,8 @@ type ApplicationRoundNode implements Node {
     unit: [Int]
   ): [ReservationUnitNode!]!
   sentDate: DateTime
-  serviceSector: ServiceSectorNode
   status: ApplicationRoundStatusChoice
   statusTimestamp: DateTime
-  targetGroup: TargetGroup!
   termsOfUse: TermsOfUseNode
 }
 
@@ -5345,24 +5343,6 @@ input SuitableTimeRangeSerializerInput {
   priority: Priority!
 }
 
-"""
-An enumeration.
-"""
-enum TargetGroup {
-  """
-  Kaikki
-  """
-  ALL
-  """
-  Sisäinen
-  """
-  INTERNAL
-  """
-  Julkinen
-  """
-  PUBLIC
-}
-
 type TaxPercentageNode implements Node {
   """
   The ID of the object
@@ -5983,7 +5963,7 @@ enum UserRoleChoice {
   """
   RESERVER
   """
-  Katselika
+  Katselija
   """
   VIEWER
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: when checking unit access (frontend only check) unit groups were ignored. Caused permission errors on application-round tabs when user didn't have access to all units.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
