### PR TITLE
fix: add a default autoClose time to all toast messages

### DIFF
--- a/packages/common/src/common/toast.tsx
+++ b/packages/common/src/common/toast.tsx
@@ -152,7 +152,7 @@ export default function toast({
       type={type ?? "info"}
       label={label}
       ariaLabel={ariaLabel}
-      duration={duration && duration * 1000}
+      duration={duration ? duration * 1000 : 5000}
       dataTestId={dataTestId}
     />,
     toastOptions


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds a default autoClose time of 5 seconds to all toast messages

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that toast messages close by themselves
- The toasts autoClose counter and its visualization (== the shortening "progress bar" at the top) should be paused if the browser window doesn't have focus, likewise when hovering over the message with the mouse pointer

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
