### PR TITLE
hack: close the admin mobile menu when navigating

### DIFF
--- a/apps/admin-ui/src/component/Navigation.tsx
+++ b/apps/admin-ui/src/component/Navigation.tsx
@@ -232,6 +232,9 @@ function NavigationLink({
   const handleClick = (evt: React.MouseEvent<HTMLAnchorElement>) => {
     evt.preventDefault();
     if (!routes) return;
+    // NOTE: this is a workaround for the HDS Header component not closing the mobile menu on navigation, if there isn't a page reload
+    // TODO: remove this when HDS Header is fixed
+    document.getElementById("Menu")?.querySelector("button")?.click();
     navigate(routes[0]);
   };
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- force the mobile menu to close when navigating

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Use the header navigation on a mobile screenwidth, see that the menu closes when you navigate

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3523
