### PR TITLE
Add: universal Card component

### DIFF
--- a/apps/admin-ui/src/spa/ReservationUnit/edit/tags.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/tags.tsx
@@ -13,9 +13,8 @@ import {
   IconQuestionCircle,
 } from "hds-react";
 import { useTranslation } from "react-i18next";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 type StatusPropsType = {
   type: StatusLabelType;

--- a/apps/admin-ui/src/spa/application-rounds/ApplicationRoundStatusLabel.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/ApplicationRoundStatusLabel.tsx
@@ -9,9 +9,8 @@ import {
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { ApplicationRoundStatusChoice, type Maybe } from "@gql/gql-types";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 type RoundStatus = {
   type: StatusLabelType;

--- a/apps/admin-ui/src/spa/notifications/page.tsx
+++ b/apps/admin-ui/src/spa/notifications/page.tsx
@@ -49,9 +49,8 @@ import { base64encode } from "common/src/helpers";
 import { ControlledDateInput } from "common/src/components/form";
 import ControlledTimeInput from "@/component/ControlledTimeInput";
 import { errorToast, successToast } from "common/src/common/toast";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 const RichTextInput = dynamic(() => import("@/component/RichTextInput"), {
   ssr: false,

--- a/apps/admin-ui/src/spa/reservations/[id]/ReservationTitleSection.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/ReservationTitleSection.tsx
@@ -16,9 +16,8 @@ import { formatDateTime } from "@/common/util";
 import { getApplicationUrl } from "@/common/urls";
 import { gql } from "@apollo/client";
 import { ExternalLink } from "@/component/ExternalLink";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 const Dot = styled.div`
   display: inline-block;

--- a/apps/ui/components/Carousel.tsx
+++ b/apps/ui/components/Carousel.tsx
@@ -42,7 +42,7 @@ const Button = styled(MediumButton).attrs({
   }
 `;
 
-const SmallArrowButton = styled(Button)<{ $disabled: boolean }>`
+const SmallArrowButton = styled(Button)`
   &&& {
     --color-bus: transparent;
     --color-bus-dark: transparent;
@@ -52,17 +52,12 @@ const SmallArrowButton = styled(Button)<{ $disabled: boolean }>`
     margin: 0;
     padding: 0;
 
-    ${({ $disabled }) =>
-      $disabled
-        ? `
-    display: none !important;
-  `
-        : `
     &:hover {
       opacity: 0.7;
     }
-    opacity: 1;
-  `};
+    :disabled {
+      opacity: 0.1;
+    }
 
     svg {
       color: black;
@@ -138,7 +133,7 @@ const Carousel = ({
     <StyledCarousel
       renderCenterLeftControls={({ previousSlide, previousDisabled }) => (
         <ButtonComponent
-          $disabled={previousDisabled}
+          disabled={previousDisabled}
           type="button"
           onClick={previousSlide}
           aria-label={t("common:prev")}
@@ -149,7 +144,7 @@ const Carousel = ({
       )}
       renderCenterRightControls={({ nextSlide, nextDisabled }) => (
         <ButtonComponent
-          $disabled={nextDisabled}
+          disabled={nextDisabled}
           type="button"
           onClick={nextSlide}
           aria-label={t("common:next")}

--- a/apps/ui/components/applications/ApplicationCard.tsx
+++ b/apps/ui/components/applications/ApplicationCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useTranslation, type TFunction } from "next-i18next";
 import styled from "styled-components";
 import {
-  Card as HdsCard,
+  Button,
   IconArrowRight,
   IconCheck,
   IconCogwheel,
@@ -20,101 +20,21 @@ import {
   type ApplicationsQuery,
 } from "@gql/gql-types";
 import { applicationUrl, formatDateTime } from "@/modules/util";
-import { BlackButton } from "@/styles/util";
 import { getApplicationRoundName } from "@/modules/applicationRound";
 import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
 import { ConfirmationDialog } from "common/src/components/ConfirmationDialog";
 import StatusLabel, {
   type StatusLabelType,
 } from "common/src/components/StatusLabel";
+import Card from "common/src/components/Card";
 
-const Card = styled(HdsCard)`
-  border-width: 0;
-  padding-inline: var(--spacing-s);
-  padding-block: var(--spacing-s);
-  margin-bottom: var(--spacing-m);
-  width: auto;
-  grid-template-columns: 1fr;
-  display: block;
-
-  @media (min-width: ${breakpoints.m}) {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--spacing-m);
-  }
-`;
-
-const Buttons = styled.div`
-  font-family: var(--font-medium);
-  font-size: var(--fontsize-body-s);
-  margin-top: var(--spacing-m);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
-
-  > * {
-    flex-grow: 1;
-    text-wrap: nowrap;
-  }
-
-  @media (width > ${breakpoints.s}) {
-    flex-direction: row;
-    gap: var(--spacing-s);
-  }
-
-  @media (width > ${breakpoints.m}) {
-    flex-direction: column;
-    align-items: flex-end;
-    justify-content: flex-end;
-
-    /* swapping flex-direction makes grow resize buttons vertically */
-    > * {
-      flex-grow: 0;
-      width: 100%;
-    }
-  }
-
-  @media (width > ${breakpoints.l}) {
-    flex-direction: row;
-  }
-`;
-
-const Applicant = styled.div`
-  font-family: var(--font-regular);
-  font-size: var(--fontsize-body-m);
-  margin-top: var(--spacing-xs);
-  margin-bottom: var(--spacing-s);
-  padding-right: var(--spacing-m);
-`;
-
-const RoundName = styled.div`
-  margin-top: var(--spacing-xs);
-  font-size: var(--fontsize-heading-m);
-  font-family: var(--font-bold);
-  margin-bottom: 0;
-
-  @media (max-width: ${breakpoints.s}) {
-    font-size: var(--fontsize-heading-m);
-  }
-`;
-
-const Modified = styled.div`
-  font-size: var(--fontsize-body-m);
-  font-family: var(--font-regular);
-  color: var(--color-black-70);
-  margin-top: var(--spacing-l);
-
-  @media (min-width: ${breakpoints.s}) {
-    margin-top: var(--spacing-xl);
-  }
-`;
-
-const StyledButton = styled(BlackButton).attrs({
+const StyledButton = styled(Button).attrs({
   variant: "secondary",
   size: "small",
 })`
   white-space: nowrap;
-
+  font-family: var(--font-medium) !important;
+  font-size: var(--fontsize-body-m) !important;
   svg {
     min-width: 24px;
   }
@@ -232,58 +152,66 @@ function ApplicationCard({ application, actionCallback }: Props): JSX.Element {
 
   const labelProps = getApplicationStatusLabelProps(application.status);
 
+  const tags = [
+    <StatusLabel
+      type={labelProps.type}
+      icon={labelProps.icon}
+      key="status-label"
+    >
+      {t(`applicationCard:status.${application.status}`)}
+    </StatusLabel>,
+  ];
+
+  const buttons = [
+    <StyledButton
+      aria-label={t("applicationCard:cancel")}
+      onClick={() => setIsWaitingForDelete(true)}
+      isLoading={isLoading}
+      disabled={!editable}
+      iconRight={<IconCross aria-hidden />}
+      key="cancel"
+    >
+      {t("applicationCard:cancel")}
+    </StyledButton>,
+    <ButtonLikeLink
+      disabled={!editable || application.pk == null || isLoading}
+      href={
+        editable && application.pk != null
+          ? `${applicationUrl(application.pk ?? 0)}/page1`
+          : ""
+      }
+      key="edit"
+    >
+      {t("applicationCard:edit")}
+      <IconPen aria-hidden />
+    </ButtonLikeLink>,
+    <ButtonLikeLink
+      href={
+        application.pk != null
+          ? `${applicationUrl(application.pk ?? 0)}/view`
+          : ""
+      }
+      disabled={application.pk == null}
+      key="view"
+    >
+      {t("applicationCard:view")}
+      <IconArrowRight aria-hidden />
+    </ButtonLikeLink>,
+  ];
+
   return (
-    <Card border key={application.pk} data-testid="applications__card--wrapper">
-      <div>
-        <StatusLabel type={labelProps.type} icon={labelProps.icon}>
-          {t(`applicationCard:status.${application.status}`)}
-        </StatusLabel>
-        <RoundName>{getApplicationRoundName(applicationRound)}</RoundName>
-        <Applicant>
-          {application.applicantType != null
-            ? getApplicant(application, t)
-            : ""}
-        </Applicant>
-        <Modified>
-          {t("applicationCard:saved")}{" "}
-          {formatDateTime(t, new Date(application.lastModifiedDate))}
-        </Modified>
-      </div>
-      <Buttons>
-        <StyledButton
-          aria-label={t("applicationCard:cancel")}
-          onClick={() => setIsWaitingForDelete(true)}
-          isLoading={isLoading}
-          disabled={!editable}
-          iconRight={<IconCross aria-hidden />}
-        >
-          {t("applicationCard:cancel")}
-        </StyledButton>
-        <ButtonLikeLink
-          disabled={!editable || application.pk == null || isLoading}
-          href={
-            editable && application.pk != null
-              ? `${applicationUrl(application.pk ?? 0)}/page1`
-              : ""
-          }
-          fontSize="small"
-        >
-          {t("applicationCard:edit")}
-          <IconPen aria-hidden />
-        </ButtonLikeLink>
-        <ButtonLikeLink
-          href={
-            application.pk != null
-              ? `${applicationUrl(application.pk ?? 0)}/view`
-              : ""
-          }
-          disabled={application.pk == null}
-          fontSize="small"
-        >
-          {t("applicationCard:view")}
-          <IconArrowRight aria-hidden />
-        </ButtonLikeLink>
-      </Buttons>
+    <Card
+      heading={getApplicationRoundName(applicationRound)}
+      headingLevel={2}
+      text={
+        application.applicantType != null ? getApplicant(application, t) : ""
+      }
+      tags={tags}
+      buttons={buttons}
+    >
+      <br />
+      {t("applicationCard:saved")}{" "}
+      {formatDateTime(t, new Date(application.lastModifiedDate))}
       {isWaitingForDelete && (
         <ConfirmationDialog
           isOpen

--- a/apps/ui/components/applications/ApplicationCard.tsx
+++ b/apps/ui/components/applications/ApplicationCard.tsx
@@ -23,10 +23,9 @@ import { applicationUrl, formatDateTime } from "@/modules/util";
 import { getApplicationRoundName } from "@/modules/applicationRound";
 import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
 import { ConfirmationDialog } from "common/src/components/ConfirmationDialog";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
 import Card from "common/src/components/Card";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 const StyledButton = styled(Button).attrs({
   variant: "secondary",

--- a/apps/ui/components/applications/ApplicationsGroup.tsx
+++ b/apps/ui/components/applications/ApplicationsGroup.tsx
@@ -19,6 +19,9 @@ type Props = {
 };
 
 const Wrapper = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--spacing-m);
   margin-bottom: var(--spacing-layout-l);
 `;
 

--- a/apps/ui/components/common/Navigation.tsx
+++ b/apps/ui/components/common/Navigation.tsx
@@ -45,7 +45,6 @@ const Wrapper = styled.div`
     [class*="module_headerNavigationMenu__"] ul {
       width: 100%;
       margin: 0 auto;
-      padding-inline: 0;
       max-width: var(--container-width-xl);
     }
 

--- a/apps/ui/components/common/PageWrapper.tsx
+++ b/apps/ui/components/common/PageWrapper.tsx
@@ -19,7 +19,8 @@ interface Props {
 const Main = styled.main<{ $bgColor?: string }>`
   font-size: var(--fontsize-body-m);
   flex: 1 0 auto;
-  ${({ $bgColor }) => ($bgColor ? `background: ${$bgColor}` : ``)}
+  margin-bottom: -14px;
+  background: ${({ $bgColor }) => $bgColor || "var(--color-white)"};
 `;
 
 function PageWrapper({
@@ -42,11 +43,7 @@ function PageWrapper({
         target={BannerNotificationTarget.User}
       />
       <InProgressReservationNotification />
-      <Main
-        $bgColor={overrideBackgroundColor}
-        id="main"
-        style={{ marginBottom: "-14px" }}
-      >
+      <Main id="main" $bgColor={overrideBackgroundColor}>
         {children}
       </Main>
       <Footer feedbackUrl={feedbackUrl} />

--- a/apps/ui/components/recurring/ApplicationRoundCard.tsx
+++ b/apps/ui/components/recurring/ApplicationRoundCard.tsx
@@ -1,78 +1,21 @@
 import React from "react";
-import { Card, Container, IconArrowRight } from "hds-react";
+import { IconArrowRight, IconLinkExternal } from "hds-react";
 import { TFunction, useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import styled from "styled-components";
-import { breakpoints } from "common/src/common/style";
-import { H4 } from "common/src/common/typography";
 import ClientOnly from "common/src/ClientOnly";
 import {
   type ApplicationRoundFieldsFragment,
   ApplicationRoundStatusChoice,
 } from "@gql/gql-types";
-import { IconButton } from "common/src/components";
 import { formatDateTime, searchUrl } from "@/modules/util";
-import { MediumButton } from "@/styles/util";
 import { getApplicationRoundName } from "@/modules/applicationRound";
 import { isValid } from "date-fns";
+import Card from "common/src/components/Card";
+import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
 
 interface Props {
   applicationRound: ApplicationRoundFieldsFragment;
 }
-
-const StyledCard = styled(Card)`
-  && {
-    --background-color: var(--color-black-8);
-    --border-color: var(--color-black-8);
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-gap: var(--spacing-m);
-    align-items: start;
-    padding: var(--spacing-s);
-    margin-bottom: var(--spacing-m);
-
-    @media (min-width: ${breakpoints.s}) {
-      grid-template-columns: 1fr auto;
-    }
-  }
-`;
-
-const StyledContainer = styled(Container)`
-  line-height: var(--lineheight-l);
-  max-width: 100%;
-`;
-
-const Name = styled(H4).attrs({ as: "h3" })`
-  && {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-`;
-
-const ReservationPeriod = styled.div`
-  margin-top: var(--spacing-xs);
-  @media (min-width: ${breakpoints.s}) {
-    margin-top: 0;
-  }
-`;
-
-const StatusMessage = styled.div`
-  margin-top: var(--spacing-s);
-`;
-
-const CardButton = styled(MediumButton)`
-  width: 100%;
-  align-self: flex-end;
-
-  @media (min-width: ${breakpoints.s}) {
-    justify-self: right;
-    width: max-content;
-  }
-`;
-
-const StyledLink = styled(IconButton)`
-  color: var(--color-black);
-`;
 
 function translateRoundDate(
   t: TFunction,
@@ -113,7 +56,7 @@ const ApplicationRoundCard = ({ applicationRound }: Props): JSX.Element => {
   }
 
   const name = getApplicationRoundName(applicationRound);
-
+  const timeString = translateRoundDate(t, applicationRound);
   const reservationPeriod = t(`applicationRound:card.reservationPeriod`, {
     // TODO check if time is needed
     reservationPeriodBegin: formatDateTime(
@@ -126,37 +69,38 @@ const ApplicationRoundCard = ({ applicationRound }: Props): JSX.Element => {
     ),
   });
 
-  const timeString = translateRoundDate(t, applicationRound);
+  const buttons = [
+    <ButtonLikeLink
+      href={`/criteria/${applicationRound.pk}`}
+      target="_blank"
+      key="criteria"
+    >
+      {t("applicationRound:card.criteria")}
+      <IconLinkExternal />
+    </ButtonLikeLink>,
+  ];
+  if (state === ApplicationRoundStatusChoice.Open) {
+    buttons.push(
+      <ButtonLikeLink
+        key="button"
+        href={searchUrl({ applicationRound: applicationRound.pk ?? null })}
+        onClick={(e) => {
+          e.preventDefault();
+          if (applicationRound.pk) {
+            history.push(searchUrl({ applicationRound: applicationRound.pk }));
+          }
+        }}
+      >
+        {t("application:Intro.startNewApplication")}
+        <IconArrowRight aria-hidden />
+      </ButtonLikeLink>
+    );
+  }
 
   return (
-    <StyledCard aria-label={name} border>
-      <StyledContainer>
-        <Name>{name}</Name>
-        {(state === ApplicationRoundStatusChoice.Open ||
-          state === ApplicationRoundStatusChoice.Upcoming) && (
-          <ReservationPeriod>{reservationPeriod}</ReservationPeriod>
-        )}
-        <StatusMessage>{timeString}</StatusMessage>
-        <StyledLink
-          href={`/criteria/${applicationRound.pk}`}
-          label={t("applicationRound:card.criteria")}
-          icon={<IconArrowRight aria-hidden />}
-        />
-      </StyledContainer>
-      {state === ApplicationRoundStatusChoice.Open && (
-        <CardButton
-          onClick={() => {
-            if (applicationRound.pk) {
-              history.push(
-                searchUrl({ applicationRound: applicationRound.pk })
-              );
-            }
-          }}
-        >
-          {t("application:Intro.startNewApplication")}
-        </CardButton>
-      )}
-    </StyledCard>
+    <Card heading={name} text={timeString} buttons={buttons}>
+      {reservationPeriod}
+    </Card>
   );
 };
 

--- a/apps/ui/components/reservation-unit/RelatedUnits.tsx
+++ b/apps/ui/components/reservation-unit/RelatedUnits.tsx
@@ -2,15 +2,12 @@ import { IconArrowRight, IconGroup, IconTicket } from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import NextImage from "next/image";
-import router from "next/router";
-import Link from "next/link";
 import styled from "styled-components";
 import { useMedia } from "react-use";
 import { breakpoints } from "common/src/common/style";
 import type { RelatedReservationUnitsQuery } from "@gql/gql-types";
 import { reservationUnitPath } from "@/modules/const";
 import { getMainImage, getTranslation } from "@/modules/util";
-import IconWithText from "../common/IconWithText";
 import Carousel from "../Carousel";
 import {
   getActivePricing,
@@ -18,8 +15,9 @@ import {
   getReservationUnitName,
   getUnitName,
 } from "@/modules/reservationUnit";
-import { SupplementaryButton, truncatedText } from "@/styles/util";
 import { getImageSource } from "common/src/helpers";
+import Card from "common/src/components/Card";
+import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
 
 type RelatedQueryT = NonNullable<
   RelatedReservationUnitsQuery["reservationUnits"]
@@ -30,79 +28,14 @@ type PropsType = {
   units: RelatedNodeT[];
 };
 
-const Wrapper = styled.div`
-  margin: 0 var(--spacing-s);
-
-  @media (min-width: ${breakpoints.m}) {
-    margin: 0;
-  }
-`;
-
 const StyledCarousel = styled(Carousel)`
+  &&& {
+    /* Make room for the Carousel controls */
+    margin: 0 auto !important;
+    width: calc(100% - 60px) !important;
+  }
   .slider-list {
     cursor: default !important;
-  }
-`;
-
-const Content = styled.div`
-  padding: var(--spacing-s);
-  height: 180px;
-  position: relative;
-`;
-
-const Unit = styled.div`
-  background-color: var(--color-black-5);
-`;
-
-const Name = styled.div`
-  &:hover {
-    opacity: 0.5;
-  }
-
-  color: var(--color-black-90);
-  cursor: pointer;
-  font-family: var(--font-bold);
-  font-weight: 700;
-  font-size: var(--fontsize-heading-s);
-  margin-bottom: var(--spacing-xs);
-  ${truncatedText};
-`;
-
-const Image = styled.img`
-  width: 100%;
-  height: 205px;
-  object-fit: cover;
-`;
-
-const Building = styled.div`
-  font-family: var(--font-regular);
-  margin: var(--spacing-3-xs) 0 var(--spacing-xs);
-  ${truncatedText};
-`;
-
-const Props = styled.div`
-  font-size: var(--fontsize-body-s);
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0;
-`;
-
-const StyledIconWithText = styled(IconWithText)`
-  margin-top: var(--spacing-xs);
-`;
-
-const Buttons = styled.div`
-  position: absolute;
-  right: 0;
-  bottom: 0;
-`;
-
-const LinkButton = styled(SupplementaryButton)`
-  --color-coat-of-arms: transparent;
-  --color-bus-dark: transparent;
-
-  svg {
-    color: black;
   }
 `;
 
@@ -115,99 +48,83 @@ function RelatedUnits({ units }: PropsType): JSX.Element | null {
     return null;
   }
   return (
-    <Wrapper>
-      <StyledCarousel
-        slidesToShow={isMobile ? 1 : isWideMobile ? 2 : 3}
-        slidesToScroll={isMobile ? 1 : isWideMobile ? 2 : 3}
-        wrapAround={false}
-        hideCenterControls
-        cellSpacing={24}
-      >
-        {units.map((unit) => {
-          const name = getReservationUnitName(unit);
-          const pricing = getActivePricing(unit);
-          const unitPrice =
-            pricing != null ? getPriceString({ pricing }) : undefined;
-          const reservationUnitTypeName =
-            unit.reservationUnitType != null
-              ? getTranslation(unit.reservationUnitType, "name")
-              : undefined;
-          const img = getMainImage(unit);
-          const imgSrc = getImageSource(img, "medium");
-          return (
-            <Unit key={unit.pk}>
-              <Image src={imgSrc} alt={name} style={{ marginTop: 0 }} />
-              <Content>
-                {unit.pk != null ? (
-                  <Link href={reservationUnitPath(unit.pk)}>
-                    <Name>{name}</Name>
-                  </Link>
-                ) : (
-                  <Name>{name}</Name>
-                )}
-                <Building>
-                  {unit.unit != null ? getUnitName(unit.unit) : ""}
-                </Building>
-                <Props>
-                  {reservationUnitTypeName && (
-                    <StyledIconWithText
-                      icon={
-                        <NextImage
-                          src="/icons/icon_premises.svg"
-                          alt=""
-                          width="24"
-                          height="24"
-                          aria-hidden="true"
-                        />
-                      }
-                      text={reservationUnitTypeName}
-                    />
-                  )}
-                  {unit.maxPersons && (
-                    <StyledIconWithText
-                      icon={
-                        <IconGroup
-                          aria-label={t("reservationUnitCard:maxPersons", {
-                            maxPersons: unit.maxPersons,
-                          })}
-                        />
-                      }
-                      text={t("reservationUnitCard:maxPersons", {
-                        count: unit.maxPersons,
-                      })}
-                    />
-                  )}
-                  {unitPrice && (
-                    <StyledIconWithText
-                      icon={
-                        <IconTicket
-                          aria-label={t("prices:reservationUnitPriceLabel")}
-                        />
-                      }
-                      text={unitPrice}
-                    />
-                  )}
-                </Props>
-                <Buttons>
-                  <LinkButton
-                    onClick={() => {
-                      if (unit.pk != null) {
-                        router.push(reservationUnitPath(unit.pk));
-                      }
-                    }}
-                  >
-                    <IconArrowRight
-                      size="l"
-                      aria-label={getReservationUnitName(unit)}
-                    />
-                  </LinkButton>
-                </Buttons>
-              </Content>
-            </Unit>
-          );
-        })}
-      </StyledCarousel>
-    </Wrapper>
+    <StyledCarousel
+      slidesToShow={isMobile ? 1 : isWideMobile ? 2 : 3}
+      slidesToScroll={isMobile ? 1 : isWideMobile ? 2 : 3}
+      wrapAround={false}
+      hideCenterControls
+      cellSpacing={24}
+    >
+      {units.map((unit) => {
+        const name = getReservationUnitName(unit);
+        const pricing = getActivePricing(unit);
+        const unitPrice =
+          pricing != null ? getPriceString({ pricing }) : undefined;
+        const reservationUnitTypeName =
+          unit.reservationUnitType != null
+            ? getTranslation(unit.reservationUnitType, "name")
+            : undefined;
+        const img = getMainImage(unit);
+        const imgSrc = getImageSource(img, "medium");
+        const infos = [];
+        if (reservationUnitTypeName) {
+          infos.push({
+            icon: (
+              <NextImage
+                src="/icons/icon_premises.svg"
+                alt=""
+                width="24"
+                height="24"
+                aria-hidden="true"
+              />
+            ),
+            value: reservationUnitTypeName,
+          });
+        }
+        if (unit.maxPersons) {
+          infos.push({
+            icon: (
+              <IconGroup
+                aria-label={t("reservationUnitCard:maxPersons", {
+                  maxPersons: unit.maxPersons,
+                })}
+              />
+            ),
+            value: t("reservationUnitCard:maxPersons", {
+              count: unit.maxPersons,
+            }),
+          });
+        }
+        if (unitPrice) {
+          infos.push({
+            icon: (
+              <IconTicket aria-label={t("prices:reservationUnitPriceLabel")} />
+            ),
+            value: unitPrice,
+          });
+        }
+        const buttons = [
+          <ButtonLikeLink
+            href={reservationUnitPath(unit.pk ?? 0)}
+            key={unit.pk ?? 0}
+          >
+            {t("reservationUnitCard:seeMore")}
+            <IconArrowRight aria-hidden="true" />
+          </ButtonLikeLink>,
+        ];
+        return (
+          <Card
+            variant="vertical"
+            key={unit.pk}
+            heading={name ?? ""}
+            text={getUnitName(unit.unit) ?? ""}
+            infos={infos}
+            buttons={buttons}
+            imageSrc={imgSrc}
+          />
+        );
+      })}
+    </StyledCarousel>
   );
 }
 

--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -2,20 +2,16 @@ import React from "react";
 import { IconEuroSign, IconCross, IconArrowRight } from "hds-react";
 import { useTranslation } from "next-i18next";
 import { differenceInMinutes } from "date-fns";
-import styled from "styled-components";
 import { getReservationPrice } from "common";
 import { trim } from "lodash";
-import { breakpoints } from "common/src/common/style";
 import {
   type ListReservationsQuery,
   ReservationStateChoice,
-  OrderStatus,
 } from "@gql/gql-types";
 import {
   capitalize,
   formatDateTimeRange,
   getMainImage,
-  getTranslation,
   reservationsUrl,
 } from "@/modules/util";
 import {
@@ -27,152 +23,13 @@ import {
   getReservationUnitPrice,
   getUnitName,
 } from "@/modules/reservationUnit";
-import { JustForDesktop, JustForMobile } from "@/modules/style/layout";
-import IconWithText from "@/components/common/IconWithText";
 import { ReservationOrderStatus } from "./ReservationOrderStatus";
 import { ReservationStatus } from "./ReservationStatus";
 import { ButtonLikeLink } from "../common/ButtonLikeLink";
 import { getImageSource } from "common/src/helpers";
+import Card from "common/src/components/Card";
 
 type CardType = "upcoming" | "past" | "cancelled";
-
-const Container = styled.div`
-  display: block;
-  background-color: var(--color-silver-light);
-  margin-top: var(--spacing-s);
-  min-height: 150px;
-
-  @media (min-width: ${breakpoints.s}) {
-    display: grid;
-    grid-template-columns: 226px auto;
-  }
-`;
-
-const MainContent = styled.div`
-  display: grid;
-  margin: var(--spacing-s);
-
-  @media (min-width: ${breakpoints.s}) and (max-width: ${breakpoints.m}) {
-    margin-bottom: 0;
-  }
-`;
-
-const Top = styled.div`
-  display: flex;
-  gap: var(--spacing-m);
-  justify-content: space-between;
-`;
-
-const StatusContainer = styled.div`
-  display: flex;
-  gap: var(--spacing-m);
-  align-self: flex-end;
-  align-items: flex-start;
-`;
-
-const Name = styled.span`
-  font-size: var(--fontsize-heading-m);
-  font-family: var(--font-bold);
-  font-weight: 700;
-  margin-bottom: 0;
-
-  a,
-  a:visited {
-    color: var(--color-black-90);
-    text-decoration: none;
-  }
-`;
-
-const Bottom = styled.span`
-  display: block;
-
-  @media (min-width: ${breakpoints.m}) {
-    display: grid;
-    grid-template-columns: 2fr 1fr;
-    gap: var(--spacing-l);
-  }
-`;
-
-const Props = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-`;
-
-const TimeStrip = styled.div``;
-
-const Price = styled(IconWithText)`
-  span {
-    margin-left: var(--spacing-2-xs);
-  }
-`;
-
-const Actions = styled.div`
-  display: block;
-  padding: var(--spacing-s) var(--spacing-s) var(--spacing-s) 0;
-  white-space: nowrap;
-
-  > button {
-    white-space: nowrap;
-  }
-
-  @media (min-width: ${breakpoints.m}) {
-    display: flex;
-    flex-direction: column;
-    place-self: flex-end;
-    padding: 0;
-  }
-`;
-
-const ActionButtons = styled.div`
-  display: flex;
-  gap: var(--spacing-s);
-`;
-
-const Image = styled.img`
-  width: 100%;
-  height: 50vw;
-  object-fit: cover;
-  max-width: 100%;
-
-  @media (min-width: ${breakpoints.s}) {
-    max-height: 250px;
-    height: 100%;
-  }
-
-  @media (min-width: ${breakpoints.m}) {
-    max-height: 182px;
-  }
-
-  @media (min-width: ${breakpoints.l}) {
-    max-height: 150px;
-  }
-`;
-
-function StatusTags({
-  state,
-  orderStatus,
-  statusType = "desktop",
-}: {
-  state: ReservationStateChoice;
-  orderStatus: OrderStatus | null;
-  statusType: "desktop" | "mobile";
-}) {
-  return (
-    <StatusContainer>
-      {orderStatus != null && (
-        <ReservationOrderStatus
-          orderStatus={orderStatus}
-          testId={`reservation-card__payment-status-${statusType}`}
-        />
-      )}
-      <ReservationStatus
-        testId={`reservation-card__status-${statusType}`}
-        state={state}
-      />
-    </StatusContainer>
-  );
-}
 
 // TODO use a fragment
 type QueryT = NonNullable<ListReservationsQuery["reservations"]>;
@@ -221,68 +78,70 @@ function ReservationCard({ reservation, type }: PropsT): JSX.Element {
   const normalizedOrderStatus =
     getNormalizedReservationOrderStatus(reservation);
 
-  const name = reservationUnit ? getTranslation(reservationUnit, "name") : "-";
   const img = getMainImage(reservationUnit);
   const imgSrc = getImageSource(img, "medium");
+  const tags = [];
+  if (normalizedOrderStatus != null)
+    tags.push(
+      <ReservationOrderStatus
+        orderStatus={normalizedOrderStatus}
+        data-testid="reservation-card__order-status"
+        key="order-status"
+      />
+    );
+  tags.push(
+    <ReservationStatus
+      data-testid="reservation-card__status"
+      state={reservation.state ?? ReservationStateChoice.Confirmed}
+      key="status"
+    />
+  );
+
+  const infos = [
+    {
+      icon: <IconEuroSign aria-label={t("reservationUnit:price")} />,
+      value: price ?? "",
+    },
+  ];
+
+  const buttons = [];
+  if (type === "upcoming" && canUserCancelReservation(reservation)) {
+    buttons.push(
+      <ButtonLikeLink
+        href={`${reservationsUrl}${reservation.pk}/cancel`}
+        data-testid="reservation-card__button--cancel-reservation"
+        key={t("reservations:cancelReservationAbbreviated")}
+      >
+        {t("reservations:cancelReservationAbbreviated")}
+        <IconCross aria-hidden />
+      </ButtonLikeLink>
+    );
+  }
+  buttons.push(
+    <ButtonLikeLink
+      href={link}
+      data-testid="reservation-card__button--goto-reservation"
+      key={t("reservationList:seeMore")}
+    >
+      {t("reservationList:seeMore")}
+      <IconArrowRight aria-hidden />
+    </ButtonLikeLink>
+  );
 
   return (
-    <Container data-testid="reservation-card__container">
-      <Image alt={name} src={imgSrc} />
-      <MainContent>
-        <Top>
-          <Name data-testid="reservation-card__name">{title}</Name>
-          <JustForDesktop customBreakpoint={breakpoints.l}>
-            {StatusTags({
-              state: reservation.state ?? ReservationStateChoice.Confirmed,
-              orderStatus: normalizedOrderStatus,
-              statusType: "desktop",
-            })}
-          </JustForDesktop>
-        </Top>
-        <Bottom>
-          <Props>
-            <TimeStrip data-testid="reservation-card__time">
-              {timeString}
-            </TimeStrip>
-            <JustForMobile
-              customBreakpoint={breakpoints.l}
-              style={{ marginTop: "var(--spacing-s)" }}
-            >
-              {StatusTags({
-                state: reservation.state ?? ReservationStateChoice.Confirmed,
-                orderStatus: normalizedOrderStatus,
-                statusType: "mobile",
-              })}
-            </JustForMobile>
-            <Price
-              icon={<IconEuroSign aria-label={t("reservationUnit:price")} />}
-              text={price}
-              data-testid="reservation-card__price"
-            />
-          </Props>
-          <Actions>
-            <ActionButtons>
-              {type === "upcoming" && canUserCancelReservation(reservation) && (
-                <ButtonLikeLink
-                  href={`${reservationsUrl}${reservation.pk}/cancel`}
-                  data-testid="reservation-card__button--cancel-reservation"
-                >
-                  {t("reservations:cancelReservationAbbreviated")}
-                  <IconCross aria-hidden />
-                </ButtonLikeLink>
-              )}
-              <ButtonLikeLink
-                href={link}
-                data-testid="reservation-card__button--goto-reservation"
-              >
-                {t("reservationList:seeMore")}
-                <IconArrowRight aria-hidden />
-              </ButtonLikeLink>
-            </ActionButtons>
-          </Actions>
-        </Bottom>
-      </MainContent>
-    </Container>
+    <Card
+      heading={title}
+      headingTestId="reservation-card__name"
+      headingLevel={2}
+      text={timeString}
+      textTestId="reservation-card__time"
+      imageSrc={imgSrc}
+      link={link}
+      testId="reservation-card__container"
+      tags={tags}
+      infos={infos}
+      buttons={buttons}
+    />
   );
 }
 

--- a/apps/ui/components/reservation/ReservationOrderStatus.tsx
+++ b/apps/ui/components/reservation/ReservationOrderStatus.tsx
@@ -3,9 +3,8 @@ import React, { useMemo } from "react";
 import { useTranslation } from "next-i18next";
 import { OrderStatus } from "@/gql/gql-types";
 import { IconEuroSign } from "hds-react";
-import StatusLabel, {
-  StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 export type Props = {
   orderStatus: OrderStatus;
@@ -37,7 +36,7 @@ export function ReservationOrderStatus({
   const statusText = t(`reservations:orderStatus.${camelCase(orderStatus)}`);
 
   return (
-    <StatusLabel type={labelType} icon={<IconEuroSign />} dataTestId={testId}>
+    <StatusLabel type={labelType} icon={<IconEuroSign />} testId={testId}>
       {statusText}
     </StatusLabel>
   );

--- a/apps/ui/components/reservation/ReservationStatus.tsx
+++ b/apps/ui/components/reservation/ReservationStatus.tsx
@@ -10,9 +10,8 @@ import {
   IconPen,
   IconQuestionCircle,
 } from "hds-react";
-import StatusLabel, {
-  StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 export type Props = {
   state: ReservationStateChoice;
@@ -71,7 +70,7 @@ export function ReservationStatus({ state, testId }: Props): JSX.Element {
     <StatusLabel
       type={statusProps.type}
       icon={statusProps.icon}
-      dataTestId={testId}
+      testId={testId}
     >
       {statusText}
     </StatusLabel>

--- a/apps/ui/components/search/ReservationUnitCard.tsx
+++ b/apps/ui/components/search/ReservationUnitCard.tsx
@@ -9,15 +9,13 @@ import React from "react";
 import { useTranslation } from "next-i18next";
 import NextImage from "next/image";
 import styled from "styled-components";
-import { breakpoints } from "common/src/common/style";
-import { H5, fontMedium } from "common/src/common/typography";
+import { fontMedium } from "common/src/common/typography";
 import type { ReservationUnitCardFieldsFragment } from "@gql/gql-types";
 import { getMainImage, getTranslation } from "@/modules/util";
-import IconWithText from "@/components/common/IconWithText";
-import { truncatedText } from "@/styles/util";
 import { reservationUnitPrefix } from "@/modules/const";
 import { getReservationUnitName, getUnitName } from "@/modules/reservationUnit";
 import { getImageSource } from "common/src/helpers";
+import Card from "common/src/components/Card";
 
 type Node = ReservationUnitCardFieldsFragment;
 interface IProps {
@@ -26,120 +24,6 @@ interface IProps {
   containsReservationUnit: (reservationUnit: Node) => boolean;
   removeReservationUnit: (reservationUnit: Node) => void;
 }
-
-const Container = styled.div`
-  display: block;
-  background-color: var(--color-white);
-  margin-top: var(--spacing-m);
-
-  @media (min-width: ${breakpoints.s}) {
-    display: grid;
-    grid-template-columns: 226px auto;
-  }
-`;
-
-const MainContent = styled.div`
-  display: grid;
-  margin: var(--spacing-s);
-
-  @media (min-width: ${breakpoints.s}) and (max-width: ${breakpoints.m}) {
-    margin-bottom: 0;
-  }
-`;
-
-const Name = styled(H5).attrs({ as: "h2" })`
-  font-family: var(--font-bold);
-  font-weight: 700;
-  margin: 0 0 var(--spacing-2-xs);
-  line-height: var(--lineheight-m);
-
-  @media (min-width: ${breakpoints.s}) {
-    ${truncatedText};
-  }
-`;
-
-const Description = styled.span`
-  font-family: var(--font-regular);
-  font-size: var(--fontsize-body-m);
-  flex-grow: 1;
-`;
-
-const Bottom = styled.div`
-  display: flex;
-
-  > div {
-    :last-child {
-      flex-grow: 1;
-    }
-  }
-
-  flex-direction: column;
-  align-items: flex-start;
-
-  @media (min-width: ${breakpoints.s}) {
-    flex-direction: row;
-    align-items: center;
-  }
-`;
-
-const Props = styled.div`
-  display: block;
-
-  @media (min-width: ${breakpoints.m}) {
-    display: flex;
-    gap: var(--spacing-l);
-  }
-`;
-
-const Actions = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding: var(--spacing-s) 0 var(--spacing-s) 0;
-  gap: var(--spacing-s);
-  flex-grow: 1;
-  width: 100%;
-
-  > button {
-    white-space: nowrap;
-  }
-
-  @media (min-width: ${breakpoints.m}) {
-    flex-direction: row;
-    width: auto;
-    padding: 0;
-    justify-content: flex-end;
-  }
-`;
-
-const Image = styled.img`
-  width: 100%;
-  height: 50vw;
-  object-fit: cover;
-  max-width: 100%;
-
-  @media (min-width: ${breakpoints.s}) {
-    max-height: 250px;
-    height: 100%;
-  }
-
-  @media (min-width: ${breakpoints.m}) {
-    max-height: 182px;
-  }
-
-  @media (min-width: ${breakpoints.l}) {
-    max-height: 150px;
-  }
-`;
-
-const StyledIconWithText = styled(IconWithText)`
-  margin-top: var(--spacing-xs);
-
-  span {
-    margin-left: var(--spacing-2-xs);
-    font-size: var(--fontsize-body-s);
-    ${truncatedText}
-  }
-`;
 
 /* TODO something is overriding button font-family to be bold */
 const StyledButton = styled(Button).attrs({ size: "small" })`
@@ -173,74 +57,81 @@ export function ReservationUnitCard({
   const img = getMainImage(reservationUnit);
   const imgSrc = getImageSource(img, "small");
 
+  const infos = [];
+  if (reservationUnitTypeName) {
+    infos.push({
+      icon: (
+        <NextImage
+          src="/icons/icon_premises.svg"
+          alt=""
+          width="24"
+          height="24"
+          aria-hidden="true"
+        />
+      ),
+      value: reservationUnitTypeName,
+    });
+  }
+  if (reservationUnit.maxPersons) {
+    infos.push({
+      icon: (
+        <IconGroup
+          aria-label={t("reservationUnitCard:maxPersons", {
+            maxPersons: reservationUnit.maxPersons,
+          })}
+          size="s"
+        />
+      ),
+      value: t("reservationUnitCard:maxPersons", {
+        count: reservationUnit.maxPersons,
+      }),
+    });
+  }
+
+  const buttons = [];
+  if (containsReservationUnit(reservationUnit)) {
+    buttons.push(
+      <StyledButton
+        iconRight={<IconCheck aria-hidden />}
+        onClick={() => removeReservationUnit(reservationUnit)}
+        data-testid="reservation-unit-card__button--select"
+        key={t("common:removeReservationUnit")}
+      >
+        {t("common:removeReservationUnit")}
+      </StyledButton>
+    );
+  } else {
+    buttons.push(
+      <StyledButton
+        variant="secondary"
+        iconRight={<IconPlus aria-hidden />}
+        onClick={() => selectReservationUnit(reservationUnit)}
+        data-testid="reservation-unit-card__button--select"
+        key={t("common:selectReservationUnit")}
+      >
+        {t("common:selectReservationUnit")}
+      </StyledButton>
+    );
+  }
+  buttons.push(
+    <StyledButton
+      variant="secondary"
+      iconRight={<IconLinkExternal aria-hidden />}
+      onClick={() => window.open(link, "_blank")}
+      data-testid="reservation-unit-card__button--link"
+      key={t("reservationUnitCard:seeMore")}
+    >
+      {t("reservationUnitCard:seeMore")}
+    </StyledButton>
+  );
+
   return (
-    <Container>
-      <Image alt={name} src={imgSrc} />
-      <MainContent>
-        <Name>{name}</Name>
-        <Description>{unitName}</Description>
-        <Bottom>
-          <Props>
-            {reservationUnitTypeName && (
-              <StyledIconWithText
-                icon={
-                  <NextImage
-                    src="/icons/icon_premises.svg"
-                    alt=""
-                    width="24"
-                    height="24"
-                    aria-hidden="true"
-                  />
-                }
-                text={reservationUnitTypeName}
-              />
-            )}
-            {reservationUnit.maxPersons ? (
-              <StyledIconWithText
-                icon={
-                  <IconGroup
-                    aria-label={t("reservationUnitCard:maxPersons", {
-                      maxPersons: reservationUnit.maxPersons,
-                    })}
-                    size="s"
-                  />
-                }
-                text={t("reservationUnitCard:maxPersons", {
-                  count: reservationUnit.maxPersons,
-                })}
-              />
-            ) : null}
-          </Props>
-          <Actions>
-            {containsReservationUnit(reservationUnit) ? (
-              <StyledButton
-                iconRight={<IconCheck />}
-                onClick={() => removeReservationUnit(reservationUnit)}
-                data-testid="reservation-unit-card__button--select"
-              >
-                {t("common:removeReservationUnit")}
-              </StyledButton>
-            ) : (
-              <StyledButton
-                variant="secondary"
-                iconRight={<IconPlus />}
-                onClick={() => selectReservationUnit(reservationUnit)}
-                data-testid="reservation-unit-card__button--select"
-              >
-                {t("common:selectReservationUnit")}
-              </StyledButton>
-            )}
-            <StyledButton
-              variant="secondary"
-              iconRight={<IconLinkExternal aria-hidden />}
-              onClick={() => window.open(link, "_blank")}
-              data-testid="reservation-unit-card__button--link"
-            >
-              {t("reservationUnitCard:seeMore")}
-            </StyledButton>
-          </Actions>
-        </Bottom>
-      </MainContent>
-    </Container>
+    <Card
+      imageSrc={imgSrc}
+      heading={name ?? ""}
+      text={unitName ?? ""}
+      infos={infos}
+      buttons={buttons}
+    />
   );
 }

--- a/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
+++ b/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
@@ -1,11 +1,8 @@
 import { IconArrowRight, IconEuroSign, IconGroup, Tag } from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
-import Link from "next/link";
 import NextImage from "next/image";
 import styled from "styled-components";
-import { H5 } from "common/src/common/typography";
-import { breakpoints } from "common/src/common/style";
 import type {
   ReservationUnitNode,
   SearchReservationUnitsQuery,
@@ -13,8 +10,6 @@ import type {
 import { format, isToday, isTomorrow } from "date-fns";
 import { toUIDate } from "common/src/common/util";
 import { getMainImage, getTranslation } from "@/modules/util";
-import IconWithText from "../common/IconWithText";
-import { truncatedText } from "@/styles/util";
 import {
   getActivePricing,
   getPriceString,
@@ -25,6 +20,7 @@ import { reservationUnitPrefix } from "@/modules/const";
 import { ButtonLikeLink } from "../common/ButtonLikeLink";
 import { useSearchParams } from "next/navigation";
 import { getImageSource, isBrowser } from "common/src/helpers";
+import Card from "common/src/components/Card";
 
 type QueryT = NonNullable<SearchReservationUnitsQuery["reservationUnits"]>;
 type Edge = NonNullable<NonNullable<QueryT["edges"]>[0]>;
@@ -33,154 +29,8 @@ interface PropsT {
   reservationUnit: Node;
 }
 
-const Container = styled.div`
-  display: block;
-  background-color: var(--color-white);
-  margin-top: var(--spacing-m);
-
-  @media (min-width: ${breakpoints.s}) {
-    display: grid;
-    grid-template-columns: 226px auto;
-  }
-`;
-
-const MainContent = styled.div`
-  display: grid;
-  margin: var(--spacing-s);
-  position: relative;
-
-  @media (min-width: ${breakpoints.s}) and (max-width: ${breakpoints.m}) {
-    margin-bottom: 0;
-  }
-`;
-
-const Name = styled(H5).attrs({ as: "h2" })`
-  font-family: var(--font-bold);
-  font-weight: 700;
-  margin: 0 0 var(--spacing-2-xs);
-  line-height: var(--lineheight-m);
-
-  @media (min-width: ${breakpoints.s}) {
-    ${truncatedText};
-  }
-`;
-
-const Description = styled.span`
-  font-family: var(--font-regular);
-  font-size: var(--fontsize-body-m);
-  flex-grow: 1;
-  margin-bottom: var(--spacing-s);
-
-  @media (min-width: ${breakpoints.l}) {
-    margin-bottom: 0;
-  }
-`;
-
-const Bottom = styled.span`
-  display: block;
-
-  > div {
-    :last-child {
-      flex-grow: 1;
-    }
-  }
-
-  @media (min-width: ${breakpoints.m}) {
-    display: grid;
-    grid-template-columns: 2fr 1fr;
-    gap: var(--spacing-l);
-  }
-`;
-
-const Props = styled.div`
-  display: flex;
-  gap: var(--spacing-s);
-  flex-direction: column;
-  align-items: start;
-
-  @media (min-width: ${breakpoints.s}) {
-    gap: var(--spacing-3-xs);
-  }
-
-  @media (min-width: ${breakpoints.l}) {
-    flex-direction: row;
-    gap: var(--spacing-l);
-    align-items: end;
-  }
-`;
-
-const Actions = styled.div`
-  display: flex;
-  padding: var(--spacing-m) var(--spacing-s) var(--spacing-s) 0;
-  width: 100%;
-
-  /* ButtonLikeLink doesn't scale to max-width on mobile */
-  & > a {
-    display: flex;
-    flex-grow: 1;
-  }
-
-  @media (min-width: ${breakpoints.s}) {
-    padding-top: var(--spacing-s);
-  }
-
-  @media (min-width: ${breakpoints.m}) {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    padding: 0;
-  }
-`;
-
-const Image = styled.img`
-  width: 100%;
-  height: 50vw;
-  object-fit: cover;
-  max-width: 100%;
-
-  @media (min-width: ${breakpoints.s}) {
-    max-height: 250px;
-    height: 100%;
-  }
-
-  @media (min-width: ${breakpoints.m}) {
-    max-height: 182px;
-  }
-
-  @media (min-width: ${breakpoints.l}) {
-    max-height: 150px;
-  }
-`;
-
-const StyledLink = styled(Link)`
-  color: var(--color-black-90);
-  display: flex;
-`;
-
-const StyledInlineLink = styled(StyledLink)`
-  display: inline;
-`;
-
-const StyledIconWithText = styled(IconWithText)`
-  margin: 0;
-
-  span {
-    margin-left: var(--spacing-2-xs);
-    font-size: var(--fontsize-body-s);
-    ${truncatedText}
-  }
-`;
-
 const StyledTag = styled(Tag)<{ $status: "available" | "no-times" | "closed" }>`
   margin-bottom: var(--spacing-s);
-
-  @media (min-width: ${breakpoints.s}) {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 1;
-    margin: 0;
-  }
 
   && {
     --tag-background: ${({ $status }) => {
@@ -239,7 +89,7 @@ const StatusTag = ({
 };
 
 // TODO SSR version (and remove the use hook)
-function useConstrucLink(
+function useConstructLink(
   reservationUnit: Pick<ReservationUnitNode, "pk">
 ): string {
   const params = useSearchParams();
@@ -261,16 +111,15 @@ function useConstrucLink(
   if (duration != null) linkURL.searchParams.set("duration", duration);
   if (date != null) linkURL.searchParams.set("date", date);
   if (time != null) linkURL.searchParams.set("time", time);
-  const link = linkURL.toString();
 
-  return link;
+  return linkURL.toString();
 }
 
 function ReservationUnitCard({ reservationUnit }: PropsT): JSX.Element {
   const { t } = useTranslation();
   const name = getReservationUnitName(reservationUnit);
 
-  const link = useConstrucLink(reservationUnit);
+  const link = useConstructLink(reservationUnit);
   const unitName = getUnitName(reservationUnit.unit ?? undefined);
 
   const pricing = getActivePricing(reservationUnit);
@@ -283,77 +132,69 @@ function ReservationUnitCard({ reservationUnit }: PropsT): JSX.Element {
 
   const img = getMainImage(reservationUnit);
   const imgSrc = getImageSource(img, "small");
-
+  const tags = [
+    <StatusTag
+      data={{
+        closed: reservationUnit.isClosed ?? false,
+        availableAt: reservationUnit.firstReservableDatetime ?? "",
+      }}
+      id={`status-tag-${reservationUnit.pk}`}
+      key={`status-tag-${reservationUnit.pk}`}
+    />,
+  ];
+  const infos = [];
+  if (reservationUnitTypeName) {
+    infos.push({
+      icon: (
+        <NextImage
+          src="/icons/icon_premises.svg"
+          alt=""
+          width="24"
+          height="24"
+          aria-hidden="true"
+        />
+      ),
+      value: reservationUnitTypeName,
+    });
+  }
+  if (unitPrice) {
+    infos.push({
+      icon: <IconEuroSign aria-label={t("prices:reservationUnitPriceLabel")} />,
+      value: unitPrice,
+    });
+  }
+  if (reservationUnit.maxPersons) {
+    infos.push({
+      icon: (
+        <IconGroup
+          aria-label={t("reservationUnitCard:maxPersons", {
+            maxPersons: reservationUnit.maxPersons,
+          })}
+          size="s"
+        />
+      ),
+      value: t("reservationUnitCard:maxPersons", {
+        count: reservationUnit.maxPersons,
+      }),
+    });
+  }
+  const button = (
+    <ButtonLikeLink href={link}>
+      {t("reservationUnitCard:seeMore")}
+      <IconArrowRight aria-hidden="true" />
+    </ButtonLikeLink>
+  );
   return (
-    <Container>
-      <StyledLink href={link}>
-        <Image alt={name} src={imgSrc} />
-      </StyledLink>
-      <MainContent>
-        <Name>
-          <StyledInlineLink href={link}>{name}</StyledInlineLink>
-        </Name>
-        <Description>{unitName}</Description>
-        <div>
-          <StatusTag
-            data={{
-              closed: reservationUnit.isClosed ?? false,
-              availableAt: reservationUnit.firstReservableDatetime ?? "",
-            }}
-            id={`status-tag-${reservationUnit.pk}`}
-          />
-        </div>
-        <Bottom>
-          <Props>
-            {reservationUnitTypeName && (
-              <StyledIconWithText
-                icon={
-                  <NextImage
-                    src="/icons/icon_premises.svg"
-                    alt=""
-                    width="24"
-                    height="24"
-                    aria-hidden="true"
-                  />
-                }
-                text={reservationUnitTypeName}
-              />
-            )}
-            {unitPrice && (
-              <StyledIconWithText
-                icon={
-                  <IconEuroSign
-                    aria-label={t("prices:reservationUnitPriceLabel")}
-                  />
-                }
-                text={unitPrice}
-              />
-            )}
-            {reservationUnit.maxPersons ? (
-              <StyledIconWithText
-                icon={
-                  <IconGroup
-                    aria-label={t("reservationUnitCard:maxPersons", {
-                      maxPersons: reservationUnit.maxPersons,
-                    })}
-                    size="s"
-                  />
-                }
-                text={t("reservationUnitCard:maxPersons", {
-                  count: reservationUnit.maxPersons,
-                })}
-              />
-            ) : null}
-          </Props>
-          <Actions>
-            <ButtonLikeLink href={link}>
-              {t("reservationUnitCard:seeMore")}
-              <IconArrowRight aria-hidden="true" />
-            </ButtonLikeLink>
-          </Actions>
-        </Bottom>
-      </MainContent>
-    </Container>
+    <Card
+      heading={name ?? ""}
+      headingLevel={2}
+      text={unitName ?? ""}
+      link={link}
+      imageSrc={imgSrc}
+      tags={tags}
+      infos={infos}
+      buttons={[button]}
+    />
   );
 }
 

--- a/apps/ui/pages/applications.tsx
+++ b/apps/ui/pages/applications.tsx
@@ -69,7 +69,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {
     props: {
       ...getCommonServerSideProps(),
-      overrideBackgroundColor: "var(--tilavaraus-gray)",
       ...(await serverSideTranslations(locale ?? "fi")),
       data: appData,
     },

--- a/apps/ui/pages/recurring/index.tsx
+++ b/apps/ui/pages/recurring/index.tsx
@@ -80,6 +80,9 @@ const Content = styled.div`
 `;
 
 const RoundList = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--spacing-m);
   margin-bottom: var(--spacing-layout-l);
 `;
 
@@ -106,7 +109,7 @@ const RecurringLander = ({ applicationRounds }: Props): JSX.Element => {
   );
 
   return (
-    <div>
+    <>
       <Head>
         <H2 as="h1">{t("recurringLander:heading")}</H2>
         <HeroSubheading>{t("recurringLander:subHeading")}</HeroSubheading>
@@ -159,7 +162,7 @@ const RecurringLander = ({ applicationRounds }: Props): JSX.Element => {
           </RoundList>
         )}
       </Content>
-    </div>
+    </>
   );
 };
 

--- a/apps/ui/pages/reservations/index.tsx
+++ b/apps/ui/pages/reservations/index.tsx
@@ -65,6 +65,9 @@ const StyledTab = styled(Tab)`
 `;
 
 const StyledTabPanel = styled(TabPanel)`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--spacing-m);
   margin-top: var(--spacing-m);
 `;
 

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -70,7 +70,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {
     props: {
       ...commonProps,
-      overrideBackgroundColor: "var(--tilavaraus-gray)",
       ...opts,
       data: searchData,
       applicationRounds,
@@ -81,7 +80,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
 const Wrapper = styled.div`
   margin-bottom: var(--spacing-layout-l);
-  background-color: var(--tilavaraus-gray);
 `;
 
 const StyledContainer = styled(Container)`

--- a/apps/ui/pages/search/single.tsx
+++ b/apps/ui/pages/search/single.tsx
@@ -28,8 +28,7 @@ import { useSearchValues } from "@/hooks/useSearchValues";
 import { useSearchQuery } from "@/hooks/useSearchQuery";
 
 const Wrapper = styled.div`
-  margin-bottom: var(--spacing-layout-l);
-  background-color: var(--tilavaraus-gray);
+  padding-bottom: var(--spacing-layout-l);
 `;
 
 const StyledContainer = styled(Container)`
@@ -41,7 +40,6 @@ const StyledContainer = styled(Container)`
 `;
 
 const HeadContainer = styled.div`
-  background-color: white;
   padding-top: var(--spacing-m);
 `;
 
@@ -49,6 +47,15 @@ const Heading = styled(H2).attrs({ as: "h1" })``;
 
 const BottomWrapper = styled(Container)`
   padding-top: var(--spacing-l);
+  > div > :first-child {
+    padding: var(--spacing-m);
+    background-color: var(--color-black-5);
+  }
+  [class*="ListContainer"] {
+    display: flex;
+    flex-flow: column nowrap;
+    gap: var(--spacing-m);
+  }
 `;
 
 const StyledSorting = styled(Sorting)`
@@ -81,7 +88,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {
     props: {
       ...getCommonServerSideProps(),
-      overrideBackgroundColor: "var(--tilavaraus-gray)",
       ...(await serverSideTranslations(locale ?? "fi")),
       ...opts,
       data,

--- a/apps/ui/public/locales/en/reservationUnitCard.json
+++ b/apps/ui/public/locales/en/reservationUnitCard.json
@@ -11,5 +11,6 @@
   "seeMore": "Show",
   "available": "Available",
   "noTimes": "No available times",
-  "closed": "Closed"
+  "closed": "Closed",
+  "firstAvailableTime": "First available time"
 }

--- a/apps/ui/public/locales/fi/reservationUnitCard.json
+++ b/apps/ui/public/locales/fi/reservationUnitCard.json
@@ -12,5 +12,6 @@
   "seeMore": "Näytä",
   "available": "Vapaa",
   "noTimes": "Ei vapaita aikoja",
-  "closed": "Suljettu"
+  "closed": "Suljettu",
+  "firstAvailableTime": "Ensimmäinen vapaa aika"
 }

--- a/apps/ui/public/locales/sv/reservationUnitCard.json
+++ b/apps/ui/public/locales/sv/reservationUnitCard.json
@@ -11,5 +11,6 @@
   "seeMore": "Visa",
   "available": "Ledigt",
   "noTimes": "Inga lediga tider",
-  "closed": "Stängt"
+  "closed": "Stängt",
+  "firstAvailableTime": "Första lediga tid"
 }

--- a/packages/common/src/components/Card.tsx
+++ b/packages/common/src/components/Card.tsx
@@ -1,0 +1,445 @@
+import React, { ElementType } from "react";
+import styled from "styled-components";
+import { breakpoints } from "../common/style";
+import Link from "next/link";
+import { fontMedium } from "../common/typography";
+
+type CardVariant = "default" | "vertical";
+
+export type CardProps = {
+  heading: string;
+  headingTestId?: string;
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  text: string;
+  textTestId?: string;
+  variant?: CardVariant;
+  backgroundColor?: string;
+  testId?: string;
+  link?: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  tags?: JSX.Element[];
+  infos?: { value: string; icon?: JSX.Element; testId?: string }[];
+  buttons?: JSX.Element[];
+  children?: React.ReactNode;
+};
+
+const Wrapper = styled.div<{ $bgColor: string }>`
+  &,
+  * {
+    box-sizing: border-box;
+  }
+  background-color: ${(props) => props.$bgColor};
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  align-items: stretch;
+
+  &.card--with-link {
+    img {
+      cursor: pointer;
+    }
+    &:has(img:hover) .card__header {
+      text-decoration: underline;
+    }
+  }
+  @media (min-width: ${breakpoints.m}) {
+    &.card--default {
+      flex-direction: row;
+    }
+  }
+`;
+
+const ImageWrapper = styled.div`
+  display: flex;
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+  max-height: 220px;
+  background: var(--color-black-20);
+  align-items: center;
+  justify-content: center;
+  a {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+  @media (min-width: ${breakpoints.m}) {
+    width: 100%;
+    max-height: 205px;
+    .card--default & {
+      max-width: 200px;
+      max-height: unset;
+      height: unset;
+    }
+  }
+
+  @media (min-width: ${breakpoints.l}) {
+    width: 100%;
+    max-height: 205px;
+    .card--default & {
+      max-width: 220px;
+      max-height: 160px;
+    }
+  }
+`;
+
+const Image = styled.img`
+  display: block;
+  object-fit: cover;
+  object-position: center;
+  width: 100%;
+  height: 100%;
+  @media (max-width: ${breakpoints.m}) {
+    min-height: 220px;
+  }
+`;
+
+const CardContent = styled.div<{ $itemCount: number }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--spacing-s);
+  position: relative;
+  width: 100%;
+  height: 100%;
+  padding: var(--spacing-s) var(--spacing-m);
+  flex-grow: 1;
+  font-size: var(--fontsize-body-m);
+
+  @media (min-width: ${breakpoints.m}) {
+    .card--default & {
+      display: grid;
+      grid-template-rows: repeat(2, 1fr);
+      grid-template-columns: repeat(2, auto);
+      gap: 0;
+      padding: var(--spacing-m);
+    }
+    .card--default.card--with-image.card--with-tags & {
+      margin-top: 0;
+    }
+  }
+
+  @media (min-width: ${breakpoints.l}) {
+    .card--default & {
+      gap: 0;
+    }
+  }
+`;
+
+const ChildContainer = styled.div`
+  grid-column: 1;
+  grid-row: 2;
+`;
+
+// TODO: Replace next/link so that the link doesn't cause page reload in admin-ui
+const WrapWithLink = ({
+  content,
+  link,
+}: {
+  content: string | JSX.Element;
+  link?: string;
+}) => {
+  if (!link) return <>{content}</>;
+  return <Link href={link}>{content}</Link>;
+};
+
+/**
+ * @name Card
+ * @description Card component that displays a plain card with a heading and main text. It may also contain an image and tags/status labels, infos, and buttons. Any child elements are rendered after the main text.
+ * @param {string} heading - The heading text of the card.
+ * @param {string} [headingTestId] - The test ID of the heading element.
+ * @param {string} [headingLevel=3] - The level of the heading element (1-6)
+ * @param {string} text - The main text content of the card.
+ * @param {string} [textTestId] - The test ID of the text element.
+ * @param {"default" | "vertical"} [variant="default"] - The variant of the card, either "default" or "vertical".
+ * @param {string} [backgroundColor="var(--color-black-5)"] - The background color of the card.
+ * @param {string} [testId] - The test ID of the card component.
+ * @param {string} [link] - The URL to navigate to when the card is clicked.
+ * @param {string} [imageSrc] - The URL of the image to display in the card.
+ * @param {string} [imageAlt=""] - The alt text of the image.
+ * @param {Array<JSX.Element>} [tags] - An array of JSX elements (should be either Tag or StatusLabel) to display in the card.
+ * @param {Array<{ value: string; icon?: JSX.Element, testId?: string }>} [infos] - An array of info objects (icon & text) to display in the card.
+ * @param {Array<JSX.Element>} [buttons] - An array of button elements to display in the card.
+ * @param {ReactNode} [children] - Additional children elements to render in the card, after the main text.
+ *
+ * @returns {JSX.Element} The rendered Card component.
+ */
+export default function Card({
+  heading,
+  headingTestId,
+  headingLevel = 3,
+  text,
+  textTestId,
+  variant = "default",
+  backgroundColor = "var(--color-black-5)",
+  testId,
+  link,
+  imageSrc,
+  imageAlt = "",
+  tags,
+  infos,
+  buttons,
+  children,
+}: Readonly<CardProps>): JSX.Element {
+  const wrapperClasses = [`card--${variant ?? "default"}`];
+  let itemCount = 1; // Texts are always present
+  if (imageSrc) wrapperClasses.push("card--with-image");
+  if (link) wrapperClasses.push("card--with-link");
+  if (tags) {
+    wrapperClasses.push("card--with-tags");
+    itemCount++;
+  }
+  if (infos) itemCount++;
+  if (buttons) itemCount++;
+
+  return (
+    <Wrapper
+      $bgColor={backgroundColor}
+      className={wrapperClasses.join(" ")}
+      data-testid={testId}
+    >
+      {imageSrc && (
+        <ImageWrapper>
+          <WrapWithLink
+            content={
+              <Image
+                src={imageSrc}
+                alt={imageAlt}
+                aria-hidden="true"
+                tabIndex={-1}
+              />
+            }
+            link={link}
+          />
+        </ImageWrapper>
+      )}
+      <CardContent $itemCount={itemCount}>
+        <Texts
+          heading={heading}
+          headingTestId={headingTestId}
+          headingLevel={headingLevel}
+          text={text}
+          textTestId={textTestId}
+          link={link}
+        />
+        {children && <ChildContainer>{children}</ChildContainer>}
+        {infos && <Infos infos={infos} />}
+        {tags && <Tags tags={tags} />}
+        {buttons && <Buttons buttons={buttons} />}
+      </CardContent>
+    </Wrapper>
+  );
+}
+
+// For all Containers the base (==mobile) styling is close to identical with the card--vertical styles,
+// thus we only need to define the desktop styles for the default card variant
+const TextContainer = styled.div`
+  grid-column: 1;
+  grid-row: 1;
+  gap: var(--spacing-s);
+  a {
+    text-decoration-color: var(--color-black);
+    &:not(:hover) {
+      text-decoration: none;
+    }
+  }
+
+  @media (min-width: ${breakpoints.m}) {
+    .card--default & {
+      grid-column: 1;
+      grid-row: 1;
+    }
+  }
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  gap: var(--spacing-xs);
+  grid-column: 1;
+  grid-row: 1;
+  order: -1;
+  justify-content: flex-start;
+  margin: 0 var(--spacing-2-xs);
+
+  /* display the tags on top of the image */
+  .card--with-image & {
+    margin-top: calc(0px - var(--spacing-layout-l));
+  }
+
+  @media (min-width: ${breakpoints.m}) {
+    .card--default & {
+      grid-column: 2;
+      align-items: flex-start;
+      justify-content: flex-end;
+      margin-top: unset;
+    }
+  }
+`;
+
+const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  grid-row: 2;
+  gap: var(--spacing-3-xs);
+  margin-right: auto;
+  justify-content: space-evenly;
+  font-size: var(--fontsize-body-s);
+
+  @media (min-width: ${breakpoints.m}) {
+    .card--default & {
+      grid-row: 2;
+    }
+  }
+
+  @media (min-width: ${breakpoints.l}) {
+    .card--default & {
+      grid-row: 2;
+      flex-direction: row;
+      gap: var(--spacing-l);
+    }
+  }
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  grid-row: 3;
+  width: 100%;
+  gap: var(--spacing-xs);
+  flex-direction: column;
+  align-items: flex-end;
+  > * {
+    --background-color: var(--color-white) !important;
+    --background-color-disabled: var(--color-white) !important;
+    --border-color: var(--color-black) !important;
+    color: var(--color-black);
+    background: var(--color-white);
+    width: 100%;
+  }
+
+  @media (min-width: ${breakpoints.m}) {
+    .card--default & {
+      max-width: 100%;
+      grid-column: 2;
+      grid-row: 2;
+      flex-direction: row;
+      justify-content: flex-end;
+      gap: var(--spacing-s);
+      > * {
+        width: auto;
+      }
+    }
+  }
+`;
+
+const Text = styled.p`
+  font-size: var(--fontsize-body-m);
+  margin: 0;
+`;
+
+const Header = styled.h3`
+  ${fontMedium};
+  font-size: var(--fontsize-heading-s);
+  margin: 0;
+  .card--with-link a & {
+    text-decoration: none;
+    color: var(--color-black);
+  }
+`;
+
+function Texts({
+  heading,
+  headingTestId,
+  headingLevel,
+  text,
+  textTestId,
+  link,
+}: Readonly<{
+  heading: string;
+  headingTestId?: string;
+  headingLevel: number;
+  text: string;
+  textTestId?: string;
+  link?: string;
+}>) {
+  const headingElement = `h${headingLevel.toString()}` as ElementType;
+  return (
+    <TextContainer>
+      <WrapWithLink
+        content={
+          <Header
+            className="card__header"
+            as={headingElement}
+            data-test-id={headingTestId ?? "card__heading"}
+          >
+            {heading}
+          </Header>
+        }
+        link={link}
+      />
+      <Text data-test-id={textTestId ?? "card__content"}>{text}</Text>
+    </TextContainer>
+  );
+}
+
+const addKey = (Component: JSX.Element, key: number): JSX.Element => {
+  return React.cloneElement(Component, {
+    key: Component.props.key ?? key,
+  });
+};
+
+function Tags({ tags }: Readonly<{ tags?: JSX.Element[] }>) {
+  if (!tags) return null;
+  return (
+    <TagContainer data-test-id="card__tags">
+      {tags.map((tag, i) => addKey(tag, i))}
+    </TagContainer>
+  );
+}
+
+const InfoItem = styled.div`
+  display: flex;
+  gap: var(--spacing-2-xs);
+  align-items: center;
+  font-size: var(--fontsize-body-s);
+  margin-top: auto;
+`;
+
+function Infos({
+  infos,
+}: Readonly<{
+  infos?: { value: string; icon?: JSX.Element; testId?: string }[];
+}>) {
+  if (!infos) return null;
+  return (
+    <InfoContainer data-testId="data-testId">
+      {infos.map((info) => (
+        <Info
+          key={info.value}
+          value={info.value}
+          icon={info.icon}
+          data-test-id={info.testId}
+        />
+      ))}
+    </InfoContainer>
+  );
+}
+
+function Info({
+  value,
+  icon,
+}: Readonly<{ value: string; icon?: JSX.Element }>) {
+  return (
+    <InfoItem>
+      {icon}
+      <span>{value}</span>
+    </InfoItem>
+  );
+}
+
+function Buttons({ buttons }: Readonly<{ buttons?: JSX.Element[] }>) {
+  if (!buttons) return null;
+  return (
+    <ButtonContainer>{buttons.map((btn, i) => addKey(btn, i))}</ButtonContainer>
+  );
+}

--- a/packages/common/src/components/StatusLabel.tsx
+++ b/packages/common/src/components/StatusLabel.tsx
@@ -1,37 +1,33 @@
 import React from "react";
-import {
-  StatusLabel as HDSStatusLabel,
-  type StatusLabelType as HDSStatusLabelType,
-} from "hds-react";
+import { StatusLabel as HDSStatusLabel } from "hds-react";
 import styled from "styled-components";
+import {
+  type StatusLabelType,
+  getStatusBorderColor,
+  getStatusBackgroundColor,
+} from "../tags";
 
-export type StatusLabelType = HDSStatusLabelType | "draft";
-
-const handleColorType = ($type: StatusLabelType) => {
-  switch ($type) {
-    case "info":
-      return "var(--color-coat-of-arms-light)";
-    case "alert":
-      return "var(--color-engel-medium-light)";
-    case "success":
-      return "var(--color-tram-light)";
-    case "error":
-      return "var(--color-metro-medium-light)";
-    case "draft":
-      return "var(--color-suomenlinna-medium-light)";
-    case "neutral":
-    default:
-      return "var(--color-silver)";
-  }
+type StatusLabelProps = {
+  type: StatusLabelType;
+  icon: JSX.Element;
+  testId?: string;
+  children: React.ReactNode;
 };
 
 const ColoredLabel = styled(HDSStatusLabel)<{
   $type: StatusLabelType;
 }>`
   && {
-    --status-label-background: ${(props) => handleColorType(props.$type)};
+    --status-label-background: ${(props) =>
+      getStatusBackgroundColor(props.$type)} !important;
     --status-label-color: var(--color-black);
+    border-width: 1px;
+    border-style: solid;
+    border-color: ${(props) => getStatusBorderColor(props.$type)};
     white-space: nowrap;
+  }
+  svg {
+    scale: 0.8;
   }
 `;
 
@@ -46,19 +42,14 @@ const ColoredLabel = styled(HDSStatusLabel)<{
 function StatusLabel({
   type,
   icon,
-  dataTestId,
+  testId,
   children,
-}: {
-  type: StatusLabelType;
-  icon: JSX.Element;
-  dataTestId?: string;
-  children: React.ReactNode;
-}) {
+}: Readonly<StatusLabelProps>): JSX.Element {
   return (
     <ColoredLabel
       type={type === "draft" ? "neutral" : type} // HDS StatusLabel does not support "draft" type - so convert it to "neutral"
       iconLeft={icon}
-      dataTestId={dataTestId}
+      dataTestId={testId}
       $type={type}
     >
       {children}

--- a/packages/common/src/components/Tag.tsx
+++ b/packages/common/src/components/Tag.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  getStatusBackgroundColor,
+  getStatusBorderColor,
+  StatusLabelType,
+  StyledTag,
+} from "../tags";
+import styled from "styled-components";
+
+type TagPropsType = {
+  ariaLabel: string;
+  type: StatusLabelType;
+  onClick?: () => void;
+  id?: string;
+  children: React.ReactNode;
+} & Pick<React.HTMLAttributes<HTMLDivElement>, "role">;
+
+const ColoredTag = styled(StyledTag)<{ $type: StatusLabelType }>`
+  && {
+    --tag-background: ${(props) =>
+      getStatusBackgroundColor(props.$type)} !important;
+    --tag-color: var(--color-black);
+    border-width: 1px;
+    border-style: solid;
+    border-color: ${(props) => getStatusBorderColor(props.$type)};
+    white-space: nowrap;
+  }
+`;
+
+function Tag({
+  ariaLabel,
+  type = "neutral",
+  id,
+  children,
+  onClick,
+}: TagPropsType): JSX.Element {
+  return (
+    <ColoredTag $type={type} id={id} aria-label={ariaLabel} onClick={onClick}>
+      {children}
+    </ColoredTag>
+  );
+}
+
+export default Tag;

--- a/packages/common/src/tags.tsx
+++ b/packages/common/src/tags.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { Tag } from "hds-react";
+import type { StatusLabelType as HDSStatusLabelType } from "hds-react";
 
 export const FilterTags = styled.div`
   display: flex;
@@ -44,3 +45,42 @@ export const ResetButton = styled(StyledTag).attrs({
     background: var(--color-black-10);
   }
 `;
+
+export type StatusLabelType = HDSStatusLabelType | "draft";
+
+export const getStatusBorderColor = ($type: StatusLabelType) => {
+  switch ($type) {
+    case "info":
+      return "var(--color-coat-of-arms)";
+    case "alert":
+      return "var(--color-engel)";
+    case "success":
+      return "var(--color-tram)";
+    case "error":
+      // using custom value since there is no suitable color in the HDS color palette for this (--color-metro is too dark)
+      return "#FBA782";
+    case "draft":
+      return "var(--color-suomenlinna)";
+    case "neutral":
+    default:
+      return "var(--color-silver-dark)";
+  }
+};
+
+export const getStatusBackgroundColor = ($type: StatusLabelType) => {
+  switch ($type) {
+    case "info":
+      return "var(--color-coat-of-arms-medium-light)";
+    case "alert":
+      return "var(--color-engel-medium-light)";
+    case "success":
+      return "var(--color-tram-medium-light)";
+    case "error":
+      return "var(--color-metro-medium-light)";
+    case "draft":
+      return "var(--color-suomenlinna-medium-light)";
+    case "neutral":
+    default:
+      return "var(--color-silver)";
+  }
+};


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

Adds a `Card` component to common components, which displays a plain card with `heading` and `text`.
It can also display:
  - an image (if given an `imageSrc). The image uses `heading`as `alt` text by default, but `imageAlt` allows the use of a any value.
  - `infos` (a `value` with an optional `icon` and `testId`)
  - `tags` ((== `JSX.Element`s, like `StatusLabel`s and `Tag`s)
  - `buttons` (== `JSX.Element`s, like `Button`s, `ButtonLikeLink`s etc)
  - child elements, for the moment with the same positioning as `infos`, as our use-cases are mutually exclusive between the two
- if given a `link`, it is used with the image and heading text
- any child elements will be displayed after the main `text`

Use `margin` to apply one on the entire card, `backgroundColor` for a custom background color, and `testId`/`headingTestId`/`textTestId` to provide `data-test-id`s for each element respectively. To use `data-test-id`s for `tags` and `buttons` they should be included in JSX.Elements you provide)

The replaced cards:
 - Single reservation: search result card and my reservations listing cards
 - Recurring reservations: application round card and my applications cards
 - Reservation unit page: related units cards, on the bottom of the screen
 - Admin pages reservation unit card, on a unit's page

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing of the different cards in different screen sizes.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3522
