### PR TITLE
fix: use : as hour minute separator in finnish

### DIFF
--- a/apps/ui/modules/util.ts
+++ b/apps/ui/modules/util.ts
@@ -307,7 +307,9 @@ function formatTime(t: TFunction, date: Date): string {
       date: {
         hour: "numeric",
         minute: "numeric",
+        // force HH:mm format even for finnish locale
         hour12: false,
+        locale: "en-GB",
       },
     },
   });


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: use `:` as time separator no matter the locale.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

-

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
