### PR TITLE
fix: cant find next available day on next month

### DIFF
--- a/apps/ui/components/reservation-unit/utils.test.ts
+++ b/apps/ui/components/reservation-unit/utils.test.ts
@@ -1,4 +1,11 @@
-import { addDays, format, set } from "date-fns";
+import {
+  addDays,
+  addHours,
+  addMonths,
+  format,
+  set,
+  startOfDay,
+} from "date-fns";
 import { getLastPossibleReservationDate, getNextAvailableTime } from "./utils";
 import {
   ReservationKind,
@@ -122,7 +129,7 @@ function constructDate(d: Date, hours: number, minutes: number) {
 // More important when testing error cases.
 // Alternative would be to refactor and reduce inputs to the function.
 // e.g. this is not necessary for a function that takes 2 - 3 parameters.
-/* eslint-disable @typescript-eslint/no-non-null-assertion -- expect breaks on null */
+
 describe("getNextAvailableTime", () => {
   beforeAll(() => {
     jest.useFakeTimers({
@@ -222,9 +229,8 @@ describe("getNextAvailableTime", () => {
       duration: 60,
     });
     const val = getNextAvailableTime(input);
-    expect(val).toBeInstanceOf(Date);
-    expect(val!.getDate()).toBe(today.getDate());
-    expect(val!.getHours()).toBe(11);
+    const d = startOfDay(today);
+    expect(val).toEqual(addHours(d, 11));
   });
 
   // there is earlier times available but they are too short
@@ -235,9 +241,8 @@ describe("getNextAvailableTime", () => {
       duration: 90,
     });
     const val = getNextAvailableTime(input);
-    expect(val).toBeInstanceOf(Date);
-    expect(val!.getHours()).toBe(13);
-    expect(val!.getDate()).toBe(today.getDate());
+    const d = startOfDay(today);
+    expect(val).toEqual(addHours(d, 13));
   });
 
   // today is reservable, has available times but they are too short
@@ -248,9 +253,8 @@ describe("getNextAvailableTime", () => {
       duration: 90,
     });
     const val = getNextAvailableTime(input);
-    expect(val).toBeInstanceOf(Date);
-    expect(val!.getHours()).toBe(10);
-    expect(val!.getDate()).toBe(start.getDate());
+    const d = startOfDay(start);
+    expect(val).toEqual(addHours(d, 10));
   });
 
   test("finds the next available time tomorrow when today has too short times", () => {
@@ -260,9 +264,8 @@ describe("getNextAvailableTime", () => {
       duration: 300,
     });
     const val = getNextAvailableTime(input);
-    expect(val).toBeInstanceOf(Date);
-    expect(val!.getHours()).toBe(10);
-    expect(val!.getDate()).toBe(addDays(new Date(), 1).getDate());
+    const d = startOfDay(addDays(new Date(), 1));
+    expect(val).toEqual(addHours(d, 10));
   });
 
   test("finds no available times if the duration is too long", () => {
@@ -295,12 +298,79 @@ describe("getNextAvailableTime", () => {
       duration: 30,
     });
     const val = getNextAvailableTime(input);
-    expect(val).toBeInstanceOf(Date);
-    expect(val!.getDate()).toBe(date.getDate());
-    expect(val!.getHours()).toBe(10);
+    expect(val).toEqual(addHours(startOfDay(date), 10));
+  });
+
+  test("Finds a single date after two months", () => {
+    const today = new Date();
+    mockOpenTimes(today, 7, []);
+    const date = addMonths(today, 2);
+    reservableTimes.set(format(date, "yyyy-MM-dd"), [
+      {
+        start: constructDate(date, 10, 0),
+        end: constructDate(date, 15, 0),
+      },
+    ]);
+    const input = createInput({
+      start: today,
+      duration: 30,
+    });
+    const val = getNextAvailableTime(input);
+    expect(val).toEqual(addHours(startOfDay(date), 10));
+  });
+
+  test("Finds a date after a requested date", () => {
+    const today = new Date();
+    const date1 = addMonths(today, 1);
+    const date2 = addMonths(today, 6);
+    mockOpenTimes(today, 7, []);
+    reservableTimes.set(format(date1, "yyyy-MM-dd"), [
+      {
+        start: constructDate(date1, 10, 0),
+        end: constructDate(date1, 15, 0),
+      },
+    ]);
+    reservableTimes.set(format(date2, "yyyy-MM-dd"), [
+      {
+        start: constructDate(date2, 10, 0),
+        end: constructDate(date2, 15, 0),
+      },
+    ]);
+    const input = createInput({
+      start: addDays(date1, 1),
+      duration: 30,
+    });
+    const val = getNextAvailableTime(input);
+    expect(val).toEqual(addHours(startOfDay(date2), 10));
   });
 
   describe("reservationsMinDaysBefore check", () => {
+    test("Min days before 0, should find today", () => {
+      const today = new Date();
+      mockOpenTimes(today, 2 * 7);
+      const input = createInput({
+        start: today,
+        duration: 60,
+        reservationsMinDaysBefore: 0,
+      });
+      const val = getNextAvailableTime(input);
+      const d = startOfDay(today);
+      expect(val).toEqual(addHours(d, 10));
+    });
+
+    test("Min days before 1, should find tomorrow", () => {
+      const today = new Date();
+      mockOpenTimes(today, 2 * 7);
+      const input = createInput({
+        start: today,
+        duration: 60,
+        reservationsMinDaysBefore: 1,
+      });
+      const val = getNextAvailableTime(input);
+      const d = startOfDay(addDays(today, 1));
+      expect(val).toEqual(addHours(d, 10));
+    });
+
     test("finds the next available time a week from now", () => {
       const today = new Date();
       mockOpenTimes(today, 2 * 7);
@@ -310,9 +380,8 @@ describe("getNextAvailableTime", () => {
         reservationsMinDaysBefore: 7,
       });
       const val = getNextAvailableTime(input);
-      expect(val).toBeInstanceOf(Date);
-      expect(val!.getDate()).toBe(addDays(today, 7).getDate());
-      expect(val!.getHours()).toBe(10);
+      const d = startOfDay(addDays(today, 7));
+      expect(val).toEqual(addHours(d, 10));
     });
 
     test("NO times if times are only available before reservationsMinDaysBefore", () => {
@@ -332,6 +401,44 @@ describe("getNextAvailableTime", () => {
   });
 
   describe("reservationsMaxDaysBefore check", () => {
+    test("Max days before 0, should find a week from now", () => {
+      const today = new Date();
+      mockOpenTimes(today, 2 * 7);
+      const input = createInput({
+        start: addDays(today, 7),
+        duration: 60,
+        reservationsMaxDaysBefore: 0,
+      });
+      const val = getNextAvailableTime(input);
+      const d = startOfDay(addDays(today, 7));
+      expect(val).toEqual(addHours(d, 10));
+    });
+
+    test("Max days before undefined is equal to 0", () => {
+      const today = new Date();
+      mockOpenTimes(today, 2 * 7);
+      const input = createInput({
+        start: addDays(today, 7),
+        duration: 60,
+        reservationsMaxDaysBefore: undefined,
+      });
+      const val = getNextAvailableTime(input);
+      const d = startOfDay(addDays(today, 7));
+      expect(val).toEqual(addHours(d, 10));
+    });
+
+    test("Max days before 6, should not find a week from now", () => {
+      const today = new Date();
+      mockOpenTimes(today, 2 * 7);
+      const input = createInput({
+        start: addDays(today, 7),
+        duration: 60,
+        reservationsMaxDaysBefore: 6,
+      });
+      const val = getNextAvailableTime(input);
+      expect(val).toBeNull();
+    });
+
     test("NO times if times are only available after reservationsMaxDaysBefore", () => {
       const today = new Date();
       const cpy = new Date(today);
@@ -365,9 +472,8 @@ describe("getNextAvailableTime", () => {
         activeApplicationRounds,
       });
       const val = getNextAvailableTime(input);
-      expect(val).toBeInstanceOf(Date);
-      expect(val!.getDate()).toBe(addDays(end, 1).getDate());
-      expect(val!.getHours()).toBe(10);
+      const d = startOfDay(addDays(end, 1));
+      expect(val).toEqual(addHours(d, 10));
     });
 
     test("multiple overlapping activeApplicationRounds", () => {
@@ -390,9 +496,8 @@ describe("getNextAvailableTime", () => {
         activeApplicationRounds,
       });
       const val = getNextAvailableTime(input);
-      expect(val).toBeInstanceOf(Date);
-      expect(val!.getDate()).toBe(addDays(end, 3).getDate());
-      expect(val!.getHours()).toBe(10);
+      const d = startOfDay(addDays(end, 3));
+      expect(val).toEqual(addHours(d, 10));
     });
 
     test("finds a time between non-overlapping activeApplicationRounds", () => {
@@ -415,9 +520,8 @@ describe("getNextAvailableTime", () => {
         activeApplicationRounds,
       });
       const val = getNextAvailableTime(input);
-      expect(val).toBeInstanceOf(Date);
-      expect(val!.getDate()).toBe(addDays(middle, 1).getDate());
-      expect(val!.getHours()).toBe(10);
+      const d = startOfDay(addDays(middle, 1));
+      expect(val).toEqual(addHours(d, 10));
     });
 
     test("no times available after activeApplicationRound", () => {
@@ -464,4 +568,3 @@ describe("getNextAvailableTime", () => {
     });
   });
 });
-/* eslint-enable @typescript-eslint/no-non-null-assertion */


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: find next available times not finding times if there are month long gaps.
- Fix: find next available times sometimes going backwards (find previous time).
- Refactor: unit tests false positive date matches. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: quick reservation component.
- Automated tests: regression tests for interval find utility.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3530](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3530)
- [TILA-3510](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3510)


[TILA-3530]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TILA-3510]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ