### PR TITLE
use fast mutation to update reservation series

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -1246,7 +1246,6 @@ export type Mutation = {
   createEquipment?: Maybe<EquipmentCreateMutationPayload>;
   createEquipmentCategory?: Maybe<EquipmentCategoryCreateMutationPayload>;
   createPurpose?: Maybe<PurposeCreateMutationPayload>;
-  createRecurringReservation?: Maybe<RecurringReservationCreateMutationPayload>;
   createReservation?: Maybe<ReservationCreateMutationPayload>;
   createReservationSeries?: Maybe<ReservationSeriesCreateMutationPayload>;
   createReservationUnit?: Maybe<ReservationUnitCreateMutationPayload>;
@@ -1269,6 +1268,7 @@ export type Mutation = {
   rejectAllApplicationOptions?: Maybe<RejectAllApplicationOptionsMutationPayload>;
   rejectAllSectionOptions?: Maybe<RejectAllSectionOptionsMutationPayload>;
   requireHandlingForReservation?: Maybe<ReservationRequiresHandlingMutationPayload>;
+  rescheduleReservationSeries?: Maybe<ReservationSeriesRescheduleMutationPayload>;
   restoreAllApplicationOptions?: Maybe<RestoreAllApplicationOptionsMutationPayload>;
   restoreAllSectionOptions?: Maybe<RestoreAllSectionOptionsMutationPayload>;
   sendApplication?: Maybe<ApplicationSendMutationPayload>;
@@ -1281,8 +1281,8 @@ export type Mutation = {
   updateEquipment?: Maybe<EquipmentUpdateMutationPayload>;
   updateEquipmentCategory?: Maybe<EquipmentCategoryUpdateMutationPayload>;
   updatePurpose?: Maybe<PurposeUpdateMutationPayload>;
-  updateRecurringReservation?: Maybe<RecurringReservationUpdateMutationPayload>;
   updateReservation?: Maybe<ReservationUpdateMutationPayload>;
+  updateReservationSeries?: Maybe<ReservationSeriesUpdateMutationPayload>;
   updateReservationUnit?: Maybe<ReservationUnitUpdateMutationPayload>;
   updateReservationUnitImage?: Maybe<ReservationUnitImageUpdateMutationPayload>;
   updateReservationUnitOption?: Maybe<ReservationUnitOptionUpdateMutationPayload>;
@@ -1339,10 +1339,6 @@ export type MutationCreateEquipmentCategoryArgs = {
 
 export type MutationCreatePurposeArgs = {
   input: PurposeCreateMutationInput;
-};
-
-export type MutationCreateRecurringReservationArgs = {
-  input: RecurringReservationCreateMutationInput;
 };
 
 export type MutationCreateReservationArgs = {
@@ -1433,6 +1429,10 @@ export type MutationRequireHandlingForReservationArgs = {
   input: ReservationRequiresHandlingMutationInput;
 };
 
+export type MutationRescheduleReservationSeriesArgs = {
+  input: ReservationSeriesRescheduleMutationInput;
+};
+
 export type MutationRestoreAllApplicationOptionsArgs = {
   input: RestoreAllApplicationOptionsMutationInput;
 };
@@ -1481,12 +1481,12 @@ export type MutationUpdatePurposeArgs = {
   input: PurposeUpdateMutationInput;
 };
 
-export type MutationUpdateRecurringReservationArgs = {
-  input: RecurringReservationUpdateMutationInput;
-};
-
 export type MutationUpdateReservationArgs = {
   input: ReservationUpdateMutationInput;
+};
+
+export type MutationUpdateReservationSeriesArgs = {
+  input: ReservationSeriesUpdateMutationInput;
 };
 
 export type MutationUpdateReservationUnitArgs = {
@@ -2479,36 +2479,6 @@ export type QueryUserArgs = {
   id: Scalars["ID"]["input"];
 };
 
-export type RecurringReservationCreateMutationInput = {
-  abilityGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  beginDate: Scalars["Date"]["input"];
-  beginTime: Scalars["Time"]["input"];
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  endDate: Scalars["Date"]["input"];
-  endTime: Scalars["Time"]["input"];
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  pk?: InputMaybe<Scalars["Int"]["input"]>;
-  recurrenceInDays: Scalars["Int"]["input"];
-  reservationUnit: Scalars["Int"]["input"];
-  weekdays: Array<InputMaybe<Scalars["Int"]["input"]>>;
-};
-
-export type RecurringReservationCreateMutationPayload = {
-  abilityGroup?: Maybe<Scalars["Int"]["output"]>;
-  ageGroup?: Maybe<Scalars["Int"]["output"]>;
-  beginDate?: Maybe<Scalars["Date"]["output"]>;
-  beginTime?: Maybe<Scalars["Time"]["output"]>;
-  description?: Maybe<Scalars["String"]["output"]>;
-  endDate?: Maybe<Scalars["Date"]["output"]>;
-  endTime?: Maybe<Scalars["Time"]["output"]>;
-  name?: Maybe<Scalars["String"]["output"]>;
-  pk?: Maybe<Scalars["Int"]["output"]>;
-  recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
-  reservationUnit?: Maybe<Scalars["Int"]["output"]>;
-  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-};
-
 export type RecurringReservationNode = Node & {
   abilityGroup?: Maybe<AbilityGroupNode>;
   ageGroup?: Maybe<AgeGroupNode>;
@@ -2613,36 +2583,6 @@ export enum RecurringReservationOrderingChoices {
   UnitNameSvAsc = "unitNameSvAsc",
   UnitNameSvDesc = "unitNameSvDesc",
 }
-
-export type RecurringReservationUpdateMutationInput = {
-  abilityGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  beginDate?: InputMaybe<Scalars["Date"]["input"]>;
-  beginTime?: InputMaybe<Scalars["Time"]["input"]>;
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  endDate?: InputMaybe<Scalars["Date"]["input"]>;
-  endTime?: InputMaybe<Scalars["Time"]["input"]>;
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  pk: Scalars["Int"]["input"];
-  recurrenceInDays?: InputMaybe<Scalars["Int"]["input"]>;
-  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
-  weekdays?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-};
-
-export type RecurringReservationUpdateMutationPayload = {
-  abilityGroup?: Maybe<Scalars["Int"]["output"]>;
-  ageGroup?: Maybe<Scalars["Int"]["output"]>;
-  beginDate?: Maybe<Scalars["Date"]["output"]>;
-  beginTime?: Maybe<Scalars["Time"]["output"]>;
-  description?: Maybe<Scalars["String"]["output"]>;
-  endDate?: Maybe<Scalars["Date"]["output"]>;
-  endTime?: Maybe<Scalars["Time"]["output"]>;
-  name?: Maybe<Scalars["String"]["output"]>;
-  pk?: Maybe<Scalars["Int"]["output"]>;
-  recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
-  reservationUnit?: Maybe<Scalars["Int"]["output"]>;
-  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-};
 
 export type RefreshOrderMutationInput = {
   orderUuid: Scalars["String"]["input"];
@@ -3269,7 +3209,7 @@ export type ReservationSeriesCreateMutationInput = {
   name?: InputMaybe<Scalars["String"]["input"]>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
   recurrenceInDays: Scalars["Int"]["input"];
-  reservationDetails: ReservationSeriesReservationSerializerInput;
+  reservationDetails: ReservationSeriesReservationCreateSerializerInput;
   reservationUnit: Scalars["Int"]["input"];
   skipDates?: InputMaybe<Array<InputMaybe<Scalars["Date"]["input"]>>>;
   weekdays: Array<InputMaybe<Scalars["Int"]["input"]>>;
@@ -3290,7 +3230,29 @@ export type ReservationSeriesCreateMutationPayload = {
   weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
 };
 
-export type ReservationSeriesReservationSerializerInput = {
+export type ReservationSeriesRescheduleMutationInput = {
+  beginDate?: InputMaybe<Scalars["Date"]["input"]>;
+  beginTime?: InputMaybe<Scalars["Time"]["input"]>;
+  bufferTimeAfter?: InputMaybe<Scalars["String"]["input"]>;
+  bufferTimeBefore?: InputMaybe<Scalars["String"]["input"]>;
+  endDate?: InputMaybe<Scalars["Date"]["input"]>;
+  endTime?: InputMaybe<Scalars["Time"]["input"]>;
+  pk: Scalars["Int"]["input"];
+  skipDates?: InputMaybe<Array<InputMaybe<Scalars["Date"]["input"]>>>;
+  weekdays?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+};
+
+export type ReservationSeriesRescheduleMutationPayload = {
+  beginDate?: Maybe<Scalars["Date"]["output"]>;
+  beginTime?: Maybe<Scalars["Time"]["output"]>;
+  endDate?: Maybe<Scalars["Date"]["output"]>;
+  endTime?: Maybe<Scalars["Time"]["output"]>;
+  pk?: Maybe<Scalars["Int"]["output"]>;
+  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
+};
+
+export type ReservationSeriesReservationCreateSerializerInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
   applyingForFreeOfCharge?: InputMaybe<Scalars["Boolean"]["input"]>;
   billingAddressCity?: InputMaybe<Scalars["String"]["input"]>;
   billingAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
@@ -3325,6 +3287,22 @@ export type ReservationSeriesReservationSerializerInput = {
   type: ReservationTypeStaffChoice;
   user: Scalars["Int"]["input"];
   workingMemo?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type ReservationSeriesUpdateMutationInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  pk: Scalars["Int"]["input"];
+  reservationDetails?: InputMaybe<UpdateReservationSeriesReservationUpdateSerializerInput>;
+  skipReservations?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+};
+
+export type ReservationSeriesUpdateMutationPayload = {
+  ageGroup?: Maybe<Scalars["Int"]["output"]>;
+  description?: Maybe<Scalars["String"]["output"]>;
+  name?: Maybe<Scalars["String"]["output"]>;
+  pk?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type ReservationStaffAdjustTimeMutationInput = {
@@ -5224,6 +5202,37 @@ export type UpdatePersonSerializerInput = {
   lastName?: InputMaybe<Scalars["String"]["input"]>;
   phoneNumber?: InputMaybe<Scalars["String"]["input"]>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type UpdateReservationSeriesReservationUpdateSerializerInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
+  applyingForFreeOfCharge?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billingAddressCity?: InputMaybe<Scalars["String"]["input"]>;
+  billingAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
+  billingAddressZip?: InputMaybe<Scalars["String"]["input"]>;
+  billingEmail?: InputMaybe<Scalars["String"]["input"]>;
+  billingFirstName?: InputMaybe<Scalars["String"]["input"]>;
+  billingLastName?: InputMaybe<Scalars["String"]["input"]>;
+  billingPhone?: InputMaybe<Scalars["String"]["input"]>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  freeOfChargeReason?: InputMaybe<Scalars["String"]["input"]>;
+  homeCity?: InputMaybe<Scalars["Int"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  numPersons?: InputMaybe<Scalars["Int"]["input"]>;
+  purpose?: InputMaybe<Scalars["Int"]["input"]>;
+  reserveeAddressCity?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeAddressZip?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeEmail?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeFirstName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeId?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeIsUnregisteredAssociation?: InputMaybe<Scalars["Boolean"]["input"]>;
+  reserveeLanguage?: InputMaybe<ReserveeLanguage>;
+  reserveeLastName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeOrganisationName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveePhone?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeType?: InputMaybe<ReserveeType>;
+  workingMemo?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type UpdateReservationUnitImageFieldSerializerInput = {
@@ -8593,11 +8602,11 @@ export type UpdateStaffReservationMutation = {
 };
 
 export type UpdateRecurringReservationMutationVariables = Exact<{
-  input: RecurringReservationUpdateMutationInput;
+  input: ReservationSeriesUpdateMutationInput;
 }>;
 
 export type UpdateRecurringReservationMutation = {
-  updateRecurringReservation?: { pk?: number | null } | null;
+  updateReservationSeries?: { pk?: number | null } | null;
 };
 
 export type ReservationsQueryVariables = Exact<{
@@ -15192,9 +15201,9 @@ export type UpdateStaffReservationMutationOptions = Apollo.BaseMutationOptions<
 >;
 export const UpdateRecurringReservationDocument = gql`
   mutation UpdateRecurringReservation(
-    $input: RecurringReservationUpdateMutationInput!
+    $input: ReservationSeriesUpdateMutationInput!
   ) {
-    updateRecurringReservation(input: $input) {
+    updateReservationSeries(input: $input) {
       pk
     }
   }

--- a/apps/admin-ui/src/spa/my-units/recurring/hooks/useCreateRecurringReservation.tsx
+++ b/apps/admin-ui/src/spa/my-units/recurring/hooks/useCreateRecurringReservation.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import get from "lodash/get";
 import {
-  type ReservationSeriesReservationSerializerInput,
   ReservationStateChoice,
   ReservationTypeChoice,
   ReservationTypeStaffChoice,
@@ -79,7 +78,7 @@ export function useCreateRecurringReservation() {
       throw new Error("Current user pk missing");
     }
 
-    const reservationDetails: ReservationSeriesReservationSerializerInput = {
+    const reservationDetails = {
       ...flattenedMetadataSetValues,
       type: transformReservationTypeStaffChoice(data.type),
       bufferTimeBefore: buffers.before,

--- a/apps/admin-ui/src/spa/reservations/[id]/edit.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/edit.tsx
@@ -148,14 +148,13 @@ function EditReservation({
       reservationUnit.metadataSet?.supportedFields
     );
 
+    // TODO this removes all type information
     const flattenedMetadataSetValues = flattenMetadata(
       values,
       metadataSetFields
     );
 
     const toSubmit = {
-      pk: reservation.pk,
-      reservationUnitPks: [reservationUnit.pk],
       seriesName: values.seriesName !== "" ? values.seriesName : undefined,
       workingMemo: values.comments,
       type: values.type,

--- a/apps/admin-ui/src/spa/reservations/hooks/hooks.test.tsx
+++ b/apps/admin-ui/src/spa/reservations/hooks/hooks.test.tsx
@@ -29,7 +29,6 @@ function TestComponent({
   const input: MutationInputParams = {
     ...MUTATION_DATA.input,
     ...MUTATION_DATA.workingMemo,
-    pk: reservation.pk ?? 0,
     seriesName,
   };
 
@@ -64,26 +63,6 @@ describe("edit mutation hook single reservation", () => {
     await user.click(btn);
 
     await waitFor(() => expect(successCb).toHaveBeenCalled());
-  });
-
-  test("reservation failing with network error gets retried once", async () => {
-    const view = wrappedRender(101, successCb);
-    const btn = view.getByRole("button", { name: /mutate/i });
-    expect(btn).toBeInTheDocument();
-    const user = userEvent.setup();
-    await user.click(btn);
-
-    await waitFor(() => expect(successCb).toHaveBeenCalled());
-  });
-
-  test("reservation failing with network error twice fails", async () => {
-    const view = wrappedRender(102, successCb);
-    const btn = view.getByRole("button", { name: /mutate/i });
-    expect(btn).toBeInTheDocument();
-    const user = userEvent.setup();
-    await user.click(btn);
-
-    expect(successCb).not.toHaveBeenCalled();
   });
 
   // FIXME fails with missing pk 111 in the mocks

--- a/apps/admin-ui/src/spa/reservations/hooks/queries.tsx
+++ b/apps/admin-ui/src/spa/reservations/hooks/queries.tsx
@@ -16,9 +16,9 @@ export const UPDATE_STAFF_RESERVATION = gql`
 
 export const UPDATE_STAFF_RECURRING_RESERVATION = gql`
   mutation UpdateRecurringReservation(
-    $input: RecurringReservationUpdateMutationInput!
+    $input: ReservationSeriesUpdateMutationInput!
   ) {
-    updateRecurringReservation(input: $input) {
+    updateReservationSeries(input: $input) {
       pk
     }
   }

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -1246,7 +1246,6 @@ export type Mutation = {
   createEquipment?: Maybe<EquipmentCreateMutationPayload>;
   createEquipmentCategory?: Maybe<EquipmentCategoryCreateMutationPayload>;
   createPurpose?: Maybe<PurposeCreateMutationPayload>;
-  createRecurringReservation?: Maybe<RecurringReservationCreateMutationPayload>;
   createReservation?: Maybe<ReservationCreateMutationPayload>;
   createReservationSeries?: Maybe<ReservationSeriesCreateMutationPayload>;
   createReservationUnit?: Maybe<ReservationUnitCreateMutationPayload>;
@@ -1269,6 +1268,7 @@ export type Mutation = {
   rejectAllApplicationOptions?: Maybe<RejectAllApplicationOptionsMutationPayload>;
   rejectAllSectionOptions?: Maybe<RejectAllSectionOptionsMutationPayload>;
   requireHandlingForReservation?: Maybe<ReservationRequiresHandlingMutationPayload>;
+  rescheduleReservationSeries?: Maybe<ReservationSeriesRescheduleMutationPayload>;
   restoreAllApplicationOptions?: Maybe<RestoreAllApplicationOptionsMutationPayload>;
   restoreAllSectionOptions?: Maybe<RestoreAllSectionOptionsMutationPayload>;
   sendApplication?: Maybe<ApplicationSendMutationPayload>;
@@ -1281,8 +1281,8 @@ export type Mutation = {
   updateEquipment?: Maybe<EquipmentUpdateMutationPayload>;
   updateEquipmentCategory?: Maybe<EquipmentCategoryUpdateMutationPayload>;
   updatePurpose?: Maybe<PurposeUpdateMutationPayload>;
-  updateRecurringReservation?: Maybe<RecurringReservationUpdateMutationPayload>;
   updateReservation?: Maybe<ReservationUpdateMutationPayload>;
+  updateReservationSeries?: Maybe<ReservationSeriesUpdateMutationPayload>;
   updateReservationUnit?: Maybe<ReservationUnitUpdateMutationPayload>;
   updateReservationUnitImage?: Maybe<ReservationUnitImageUpdateMutationPayload>;
   updateReservationUnitOption?: Maybe<ReservationUnitOptionUpdateMutationPayload>;
@@ -1339,10 +1339,6 @@ export type MutationCreateEquipmentCategoryArgs = {
 
 export type MutationCreatePurposeArgs = {
   input: PurposeCreateMutationInput;
-};
-
-export type MutationCreateRecurringReservationArgs = {
-  input: RecurringReservationCreateMutationInput;
 };
 
 export type MutationCreateReservationArgs = {
@@ -1433,6 +1429,10 @@ export type MutationRequireHandlingForReservationArgs = {
   input: ReservationRequiresHandlingMutationInput;
 };
 
+export type MutationRescheduleReservationSeriesArgs = {
+  input: ReservationSeriesRescheduleMutationInput;
+};
+
 export type MutationRestoreAllApplicationOptionsArgs = {
   input: RestoreAllApplicationOptionsMutationInput;
 };
@@ -1481,12 +1481,12 @@ export type MutationUpdatePurposeArgs = {
   input: PurposeUpdateMutationInput;
 };
 
-export type MutationUpdateRecurringReservationArgs = {
-  input: RecurringReservationUpdateMutationInput;
-};
-
 export type MutationUpdateReservationArgs = {
   input: ReservationUpdateMutationInput;
+};
+
+export type MutationUpdateReservationSeriesArgs = {
+  input: ReservationSeriesUpdateMutationInput;
 };
 
 export type MutationUpdateReservationUnitArgs = {
@@ -2479,36 +2479,6 @@ export type QueryUserArgs = {
   id: Scalars["ID"]["input"];
 };
 
-export type RecurringReservationCreateMutationInput = {
-  abilityGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  beginDate: Scalars["Date"]["input"];
-  beginTime: Scalars["Time"]["input"];
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  endDate: Scalars["Date"]["input"];
-  endTime: Scalars["Time"]["input"];
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  pk?: InputMaybe<Scalars["Int"]["input"]>;
-  recurrenceInDays: Scalars["Int"]["input"];
-  reservationUnit: Scalars["Int"]["input"];
-  weekdays: Array<InputMaybe<Scalars["Int"]["input"]>>;
-};
-
-export type RecurringReservationCreateMutationPayload = {
-  abilityGroup?: Maybe<Scalars["Int"]["output"]>;
-  ageGroup?: Maybe<Scalars["Int"]["output"]>;
-  beginDate?: Maybe<Scalars["Date"]["output"]>;
-  beginTime?: Maybe<Scalars["Time"]["output"]>;
-  description?: Maybe<Scalars["String"]["output"]>;
-  endDate?: Maybe<Scalars["Date"]["output"]>;
-  endTime?: Maybe<Scalars["Time"]["output"]>;
-  name?: Maybe<Scalars["String"]["output"]>;
-  pk?: Maybe<Scalars["Int"]["output"]>;
-  recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
-  reservationUnit?: Maybe<Scalars["Int"]["output"]>;
-  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-};
-
 export type RecurringReservationNode = Node & {
   abilityGroup?: Maybe<AbilityGroupNode>;
   ageGroup?: Maybe<AgeGroupNode>;
@@ -2613,36 +2583,6 @@ export enum RecurringReservationOrderingChoices {
   UnitNameSvAsc = "unitNameSvAsc",
   UnitNameSvDesc = "unitNameSvDesc",
 }
-
-export type RecurringReservationUpdateMutationInput = {
-  abilityGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  beginDate?: InputMaybe<Scalars["Date"]["input"]>;
-  beginTime?: InputMaybe<Scalars["Time"]["input"]>;
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  endDate?: InputMaybe<Scalars["Date"]["input"]>;
-  endTime?: InputMaybe<Scalars["Time"]["input"]>;
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  pk: Scalars["Int"]["input"];
-  recurrenceInDays?: InputMaybe<Scalars["Int"]["input"]>;
-  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
-  weekdays?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-};
-
-export type RecurringReservationUpdateMutationPayload = {
-  abilityGroup?: Maybe<Scalars["Int"]["output"]>;
-  ageGroup?: Maybe<Scalars["Int"]["output"]>;
-  beginDate?: Maybe<Scalars["Date"]["output"]>;
-  beginTime?: Maybe<Scalars["Time"]["output"]>;
-  description?: Maybe<Scalars["String"]["output"]>;
-  endDate?: Maybe<Scalars["Date"]["output"]>;
-  endTime?: Maybe<Scalars["Time"]["output"]>;
-  name?: Maybe<Scalars["String"]["output"]>;
-  pk?: Maybe<Scalars["Int"]["output"]>;
-  recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
-  reservationUnit?: Maybe<Scalars["Int"]["output"]>;
-  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-};
 
 export type RefreshOrderMutationInput = {
   orderUuid: Scalars["String"]["input"];
@@ -3269,7 +3209,7 @@ export type ReservationSeriesCreateMutationInput = {
   name?: InputMaybe<Scalars["String"]["input"]>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
   recurrenceInDays: Scalars["Int"]["input"];
-  reservationDetails: ReservationSeriesReservationSerializerInput;
+  reservationDetails: ReservationSeriesReservationCreateSerializerInput;
   reservationUnit: Scalars["Int"]["input"];
   skipDates?: InputMaybe<Array<InputMaybe<Scalars["Date"]["input"]>>>;
   weekdays: Array<InputMaybe<Scalars["Int"]["input"]>>;
@@ -3290,7 +3230,29 @@ export type ReservationSeriesCreateMutationPayload = {
   weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
 };
 
-export type ReservationSeriesReservationSerializerInput = {
+export type ReservationSeriesRescheduleMutationInput = {
+  beginDate?: InputMaybe<Scalars["Date"]["input"]>;
+  beginTime?: InputMaybe<Scalars["Time"]["input"]>;
+  bufferTimeAfter?: InputMaybe<Scalars["String"]["input"]>;
+  bufferTimeBefore?: InputMaybe<Scalars["String"]["input"]>;
+  endDate?: InputMaybe<Scalars["Date"]["input"]>;
+  endTime?: InputMaybe<Scalars["Time"]["input"]>;
+  pk: Scalars["Int"]["input"];
+  skipDates?: InputMaybe<Array<InputMaybe<Scalars["Date"]["input"]>>>;
+  weekdays?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+};
+
+export type ReservationSeriesRescheduleMutationPayload = {
+  beginDate?: Maybe<Scalars["Date"]["output"]>;
+  beginTime?: Maybe<Scalars["Time"]["output"]>;
+  endDate?: Maybe<Scalars["Date"]["output"]>;
+  endTime?: Maybe<Scalars["Time"]["output"]>;
+  pk?: Maybe<Scalars["Int"]["output"]>;
+  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
+};
+
+export type ReservationSeriesReservationCreateSerializerInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
   applyingForFreeOfCharge?: InputMaybe<Scalars["Boolean"]["input"]>;
   billingAddressCity?: InputMaybe<Scalars["String"]["input"]>;
   billingAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
@@ -3325,6 +3287,22 @@ export type ReservationSeriesReservationSerializerInput = {
   type: ReservationTypeStaffChoice;
   user: Scalars["Int"]["input"];
   workingMemo?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type ReservationSeriesUpdateMutationInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  pk: Scalars["Int"]["input"];
+  reservationDetails?: InputMaybe<UpdateReservationSeriesReservationUpdateSerializerInput>;
+  skipReservations?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+};
+
+export type ReservationSeriesUpdateMutationPayload = {
+  ageGroup?: Maybe<Scalars["Int"]["output"]>;
+  description?: Maybe<Scalars["String"]["output"]>;
+  name?: Maybe<Scalars["String"]["output"]>;
+  pk?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type ReservationStaffAdjustTimeMutationInput = {
@@ -5224,6 +5202,37 @@ export type UpdatePersonSerializerInput = {
   lastName?: InputMaybe<Scalars["String"]["input"]>;
   phoneNumber?: InputMaybe<Scalars["String"]["input"]>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type UpdateReservationSeriesReservationUpdateSerializerInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
+  applyingForFreeOfCharge?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billingAddressCity?: InputMaybe<Scalars["String"]["input"]>;
+  billingAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
+  billingAddressZip?: InputMaybe<Scalars["String"]["input"]>;
+  billingEmail?: InputMaybe<Scalars["String"]["input"]>;
+  billingFirstName?: InputMaybe<Scalars["String"]["input"]>;
+  billingLastName?: InputMaybe<Scalars["String"]["input"]>;
+  billingPhone?: InputMaybe<Scalars["String"]["input"]>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  freeOfChargeReason?: InputMaybe<Scalars["String"]["input"]>;
+  homeCity?: InputMaybe<Scalars["Int"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  numPersons?: InputMaybe<Scalars["Int"]["input"]>;
+  purpose?: InputMaybe<Scalars["Int"]["input"]>;
+  reserveeAddressCity?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeAddressZip?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeEmail?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeFirstName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeId?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeIsUnregisteredAssociation?: InputMaybe<Scalars["Boolean"]["input"]>;
+  reserveeLanguage?: InputMaybe<ReserveeLanguage>;
+  reserveeLastName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeOrganisationName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveePhone?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeType?: InputMaybe<ReserveeType>;
+  workingMemo?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type UpdateReservationUnitImageFieldSerializerInput = {

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -1246,7 +1246,6 @@ export type Mutation = {
   createEquipment?: Maybe<EquipmentCreateMutationPayload>;
   createEquipmentCategory?: Maybe<EquipmentCategoryCreateMutationPayload>;
   createPurpose?: Maybe<PurposeCreateMutationPayload>;
-  createRecurringReservation?: Maybe<RecurringReservationCreateMutationPayload>;
   createReservation?: Maybe<ReservationCreateMutationPayload>;
   createReservationSeries?: Maybe<ReservationSeriesCreateMutationPayload>;
   createReservationUnit?: Maybe<ReservationUnitCreateMutationPayload>;
@@ -1269,6 +1268,7 @@ export type Mutation = {
   rejectAllApplicationOptions?: Maybe<RejectAllApplicationOptionsMutationPayload>;
   rejectAllSectionOptions?: Maybe<RejectAllSectionOptionsMutationPayload>;
   requireHandlingForReservation?: Maybe<ReservationRequiresHandlingMutationPayload>;
+  rescheduleReservationSeries?: Maybe<ReservationSeriesRescheduleMutationPayload>;
   restoreAllApplicationOptions?: Maybe<RestoreAllApplicationOptionsMutationPayload>;
   restoreAllSectionOptions?: Maybe<RestoreAllSectionOptionsMutationPayload>;
   sendApplication?: Maybe<ApplicationSendMutationPayload>;
@@ -1281,8 +1281,8 @@ export type Mutation = {
   updateEquipment?: Maybe<EquipmentUpdateMutationPayload>;
   updateEquipmentCategory?: Maybe<EquipmentCategoryUpdateMutationPayload>;
   updatePurpose?: Maybe<PurposeUpdateMutationPayload>;
-  updateRecurringReservation?: Maybe<RecurringReservationUpdateMutationPayload>;
   updateReservation?: Maybe<ReservationUpdateMutationPayload>;
+  updateReservationSeries?: Maybe<ReservationSeriesUpdateMutationPayload>;
   updateReservationUnit?: Maybe<ReservationUnitUpdateMutationPayload>;
   updateReservationUnitImage?: Maybe<ReservationUnitImageUpdateMutationPayload>;
   updateReservationUnitOption?: Maybe<ReservationUnitOptionUpdateMutationPayload>;
@@ -1339,10 +1339,6 @@ export type MutationCreateEquipmentCategoryArgs = {
 
 export type MutationCreatePurposeArgs = {
   input: PurposeCreateMutationInput;
-};
-
-export type MutationCreateRecurringReservationArgs = {
-  input: RecurringReservationCreateMutationInput;
 };
 
 export type MutationCreateReservationArgs = {
@@ -1433,6 +1429,10 @@ export type MutationRequireHandlingForReservationArgs = {
   input: ReservationRequiresHandlingMutationInput;
 };
 
+export type MutationRescheduleReservationSeriesArgs = {
+  input: ReservationSeriesRescheduleMutationInput;
+};
+
 export type MutationRestoreAllApplicationOptionsArgs = {
   input: RestoreAllApplicationOptionsMutationInput;
 };
@@ -1481,12 +1481,12 @@ export type MutationUpdatePurposeArgs = {
   input: PurposeUpdateMutationInput;
 };
 
-export type MutationUpdateRecurringReservationArgs = {
-  input: RecurringReservationUpdateMutationInput;
-};
-
 export type MutationUpdateReservationArgs = {
   input: ReservationUpdateMutationInput;
+};
+
+export type MutationUpdateReservationSeriesArgs = {
+  input: ReservationSeriesUpdateMutationInput;
 };
 
 export type MutationUpdateReservationUnitArgs = {
@@ -2479,36 +2479,6 @@ export type QueryUserArgs = {
   id: Scalars["ID"]["input"];
 };
 
-export type RecurringReservationCreateMutationInput = {
-  abilityGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  beginDate: Scalars["Date"]["input"];
-  beginTime: Scalars["Time"]["input"];
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  endDate: Scalars["Date"]["input"];
-  endTime: Scalars["Time"]["input"];
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  pk?: InputMaybe<Scalars["Int"]["input"]>;
-  recurrenceInDays: Scalars["Int"]["input"];
-  reservationUnit: Scalars["Int"]["input"];
-  weekdays: Array<InputMaybe<Scalars["Int"]["input"]>>;
-};
-
-export type RecurringReservationCreateMutationPayload = {
-  abilityGroup?: Maybe<Scalars["Int"]["output"]>;
-  ageGroup?: Maybe<Scalars["Int"]["output"]>;
-  beginDate?: Maybe<Scalars["Date"]["output"]>;
-  beginTime?: Maybe<Scalars["Time"]["output"]>;
-  description?: Maybe<Scalars["String"]["output"]>;
-  endDate?: Maybe<Scalars["Date"]["output"]>;
-  endTime?: Maybe<Scalars["Time"]["output"]>;
-  name?: Maybe<Scalars["String"]["output"]>;
-  pk?: Maybe<Scalars["Int"]["output"]>;
-  recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
-  reservationUnit?: Maybe<Scalars["Int"]["output"]>;
-  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-};
-
 export type RecurringReservationNode = Node & {
   abilityGroup?: Maybe<AbilityGroupNode>;
   ageGroup?: Maybe<AgeGroupNode>;
@@ -2613,36 +2583,6 @@ export enum RecurringReservationOrderingChoices {
   UnitNameSvAsc = "unitNameSvAsc",
   UnitNameSvDesc = "unitNameSvDesc",
 }
-
-export type RecurringReservationUpdateMutationInput = {
-  abilityGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
-  beginDate?: InputMaybe<Scalars["Date"]["input"]>;
-  beginTime?: InputMaybe<Scalars["Time"]["input"]>;
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  endDate?: InputMaybe<Scalars["Date"]["input"]>;
-  endTime?: InputMaybe<Scalars["Time"]["input"]>;
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  pk: Scalars["Int"]["input"];
-  recurrenceInDays?: InputMaybe<Scalars["Int"]["input"]>;
-  reservationUnit?: InputMaybe<Scalars["Int"]["input"]>;
-  weekdays?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-};
-
-export type RecurringReservationUpdateMutationPayload = {
-  abilityGroup?: Maybe<Scalars["Int"]["output"]>;
-  ageGroup?: Maybe<Scalars["Int"]["output"]>;
-  beginDate?: Maybe<Scalars["Date"]["output"]>;
-  beginTime?: Maybe<Scalars["Time"]["output"]>;
-  description?: Maybe<Scalars["String"]["output"]>;
-  endDate?: Maybe<Scalars["Date"]["output"]>;
-  endTime?: Maybe<Scalars["Time"]["output"]>;
-  name?: Maybe<Scalars["String"]["output"]>;
-  pk?: Maybe<Scalars["Int"]["output"]>;
-  recurrenceInDays?: Maybe<Scalars["Int"]["output"]>;
-  reservationUnit?: Maybe<Scalars["Int"]["output"]>;
-  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
-};
 
 export type RefreshOrderMutationInput = {
   orderUuid: Scalars["String"]["input"];
@@ -3269,7 +3209,7 @@ export type ReservationSeriesCreateMutationInput = {
   name?: InputMaybe<Scalars["String"]["input"]>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
   recurrenceInDays: Scalars["Int"]["input"];
-  reservationDetails: ReservationSeriesReservationSerializerInput;
+  reservationDetails: ReservationSeriesReservationCreateSerializerInput;
   reservationUnit: Scalars["Int"]["input"];
   skipDates?: InputMaybe<Array<InputMaybe<Scalars["Date"]["input"]>>>;
   weekdays: Array<InputMaybe<Scalars["Int"]["input"]>>;
@@ -3290,7 +3230,29 @@ export type ReservationSeriesCreateMutationPayload = {
   weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
 };
 
-export type ReservationSeriesReservationSerializerInput = {
+export type ReservationSeriesRescheduleMutationInput = {
+  beginDate?: InputMaybe<Scalars["Date"]["input"]>;
+  beginTime?: InputMaybe<Scalars["Time"]["input"]>;
+  bufferTimeAfter?: InputMaybe<Scalars["String"]["input"]>;
+  bufferTimeBefore?: InputMaybe<Scalars["String"]["input"]>;
+  endDate?: InputMaybe<Scalars["Date"]["input"]>;
+  endTime?: InputMaybe<Scalars["Time"]["input"]>;
+  pk: Scalars["Int"]["input"];
+  skipDates?: InputMaybe<Array<InputMaybe<Scalars["Date"]["input"]>>>;
+  weekdays?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+};
+
+export type ReservationSeriesRescheduleMutationPayload = {
+  beginDate?: Maybe<Scalars["Date"]["output"]>;
+  beginTime?: Maybe<Scalars["Time"]["output"]>;
+  endDate?: Maybe<Scalars["Date"]["output"]>;
+  endTime?: Maybe<Scalars["Time"]["output"]>;
+  pk?: Maybe<Scalars["Int"]["output"]>;
+  weekdays?: Maybe<Array<Maybe<Scalars["Int"]["output"]>>>;
+};
+
+export type ReservationSeriesReservationCreateSerializerInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
   applyingForFreeOfCharge?: InputMaybe<Scalars["Boolean"]["input"]>;
   billingAddressCity?: InputMaybe<Scalars["String"]["input"]>;
   billingAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
@@ -3325,6 +3287,22 @@ export type ReservationSeriesReservationSerializerInput = {
   type: ReservationTypeStaffChoice;
   user: Scalars["Int"]["input"];
   workingMemo?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type ReservationSeriesUpdateMutationInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  pk: Scalars["Int"]["input"];
+  reservationDetails?: InputMaybe<UpdateReservationSeriesReservationUpdateSerializerInput>;
+  skipReservations?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+};
+
+export type ReservationSeriesUpdateMutationPayload = {
+  ageGroup?: Maybe<Scalars["Int"]["output"]>;
+  description?: Maybe<Scalars["String"]["output"]>;
+  name?: Maybe<Scalars["String"]["output"]>;
+  pk?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type ReservationStaffAdjustTimeMutationInput = {
@@ -5224,6 +5202,37 @@ export type UpdatePersonSerializerInput = {
   lastName?: InputMaybe<Scalars["String"]["input"]>;
   phoneNumber?: InputMaybe<Scalars["String"]["input"]>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type UpdateReservationSeriesReservationUpdateSerializerInput = {
+  ageGroup?: InputMaybe<Scalars["Int"]["input"]>;
+  applyingForFreeOfCharge?: InputMaybe<Scalars["Boolean"]["input"]>;
+  billingAddressCity?: InputMaybe<Scalars["String"]["input"]>;
+  billingAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
+  billingAddressZip?: InputMaybe<Scalars["String"]["input"]>;
+  billingEmail?: InputMaybe<Scalars["String"]["input"]>;
+  billingFirstName?: InputMaybe<Scalars["String"]["input"]>;
+  billingLastName?: InputMaybe<Scalars["String"]["input"]>;
+  billingPhone?: InputMaybe<Scalars["String"]["input"]>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  freeOfChargeReason?: InputMaybe<Scalars["String"]["input"]>;
+  homeCity?: InputMaybe<Scalars["Int"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  numPersons?: InputMaybe<Scalars["Int"]["input"]>;
+  purpose?: InputMaybe<Scalars["Int"]["input"]>;
+  reserveeAddressCity?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeAddressStreet?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeAddressZip?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeEmail?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeFirstName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeId?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeIsUnregisteredAssociation?: InputMaybe<Scalars["Boolean"]["input"]>;
+  reserveeLanguage?: InputMaybe<ReserveeLanguage>;
+  reserveeLastName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeOrganisationName?: InputMaybe<Scalars["String"]["input"]>;
+  reserveePhone?: InputMaybe<Scalars["String"]["input"]>;
+  reserveeType?: InputMaybe<ReserveeType>;
+  workingMemo?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type UpdateReservationUnitImageFieldSerializerInput = {

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -1483,9 +1483,6 @@ type Mutation {
   createPurpose(
     input: PurposeCreateMutationInput!
   ): PurposeCreateMutationPayload
-  createRecurringReservation(
-    input: RecurringReservationCreateMutationInput!
-  ): RecurringReservationCreateMutationPayload
   createReservation(
     input: ReservationCreateMutationInput!
   ): ReservationCreateMutationPayload
@@ -1546,6 +1543,9 @@ type Mutation {
   requireHandlingForReservation(
     input: ReservationRequiresHandlingMutationInput!
   ): ReservationRequiresHandlingMutationPayload
+  rescheduleReservationSeries(
+    input: ReservationSeriesRescheduleMutationInput!
+  ): ReservationSeriesRescheduleMutationPayload
   restoreAllApplicationOptions(
     input: RestoreAllApplicationOptionsMutationInput!
   ): RestoreAllApplicationOptionsMutationPayload
@@ -1582,12 +1582,12 @@ type Mutation {
   updatePurpose(
     input: PurposeUpdateMutationInput!
   ): PurposeUpdateMutationPayload
-  updateRecurringReservation(
-    input: RecurringReservationUpdateMutationInput!
-  ): RecurringReservationUpdateMutationPayload
   updateReservation(
     input: ReservationUpdateMutationInput!
   ): ReservationUpdateMutationPayload
+  updateReservationSeries(
+    input: ReservationSeriesUpdateMutationInput!
+  ): ReservationSeriesUpdateMutationPayload
   updateReservationUnit(
     input: ReservationUnitUpdateMutationInput!
   ): ReservationUnitUpdateMutationPayload
@@ -2681,36 +2681,6 @@ type Query {
   ): UserNode
 }
 
-input RecurringReservationCreateMutationInput {
-  abilityGroup: Int
-  ageGroup: Int
-  beginDate: Date!
-  beginTime: Time!
-  description: String
-  endDate: Date!
-  endTime: Time!
-  name: String
-  pk: Int
-  recurrenceInDays: Int!
-  reservationUnit: Int!
-  weekdays: [Int]!
-}
-
-type RecurringReservationCreateMutationPayload {
-  abilityGroup: Int
-  ageGroup: Int
-  beginDate: Date
-  beginTime: Time
-  description: String
-  endDate: Date
-  endTime: Time
-  name: String
-  pk: Int
-  recurrenceInDays: Int
-  reservationUnit: Int
-  weekdays: [Int]
-}
-
 type RecurringReservationNode implements Node {
   abilityGroup: AbilityGroupNode
   ageGroup: AgeGroupNode
@@ -2830,36 +2800,6 @@ enum RecurringReservationOrderingChoices {
   unitNameFiDesc
   unitNameSvAsc
   unitNameSvDesc
-}
-
-input RecurringReservationUpdateMutationInput {
-  abilityGroup: Int
-  ageGroup: Int
-  beginDate: Date
-  beginTime: Time
-  description: String
-  endDate: Date
-  endTime: Time
-  name: String
-  pk: Int!
-  recurrenceInDays: Int
-  reservationUnit: Int
-  weekdays: [Int]
-}
-
-type RecurringReservationUpdateMutationPayload {
-  abilityGroup: Int
-  ageGroup: Int
-  beginDate: Date
-  beginTime: Time
-  description: String
-  endDate: Date
-  endTime: Time
-  name: String
-  pk: Int
-  recurrenceInDays: Int
-  reservationUnit: Int
-  weekdays: [Int]
 }
 
 input RefreshOrderMutationInput {
@@ -3591,7 +3531,7 @@ input ReservationSeriesCreateMutationInput {
   name: String
   pk: Int
   recurrenceInDays: Int!
-  reservationDetails: ReservationSeriesReservationSerializerInput!
+  reservationDetails: ReservationSeriesReservationCreateSerializerInput!
   reservationUnit: Int!
   skipDates: [Date]
   weekdays: [Int]!
@@ -3612,7 +3552,29 @@ type ReservationSeriesCreateMutationPayload {
   weekdays: [Int]
 }
 
-input ReservationSeriesReservationSerializerInput {
+input ReservationSeriesRescheduleMutationInput {
+  beginDate: Date
+  beginTime: Time
+  bufferTimeAfter: String
+  bufferTimeBefore: String
+  endDate: Date
+  endTime: Time
+  pk: Int!
+  skipDates: [Date]
+  weekdays: [Int]
+}
+
+type ReservationSeriesRescheduleMutationPayload {
+  beginDate: Date
+  beginTime: Time
+  endDate: Date
+  endTime: Time
+  pk: Int
+  weekdays: [Int]
+}
+
+input ReservationSeriesReservationCreateSerializerInput {
+  ageGroup: Int
   applyingForFreeOfCharge: Boolean
   billingAddressCity: String
   billingAddressStreet: String
@@ -3647,6 +3609,22 @@ input ReservationSeriesReservationSerializerInput {
   type: ReservationTypeStaffChoice!
   user: Int!
   workingMemo: String
+}
+
+input ReservationSeriesUpdateMutationInput {
+  ageGroup: Int
+  description: String
+  name: String
+  pk: Int!
+  reservationDetails: UpdateReservationSeriesReservationUpdateSerializerInput
+  skipReservations: [Int]
+}
+
+type ReservationSeriesUpdateMutationPayload {
+  ageGroup: Int
+  description: String
+  name: String
+  pk: Int
 }
 
 input ReservationStaffAdjustTimeMutationInput {
@@ -5835,6 +5813,37 @@ input UpdatePersonSerializerInput {
   lastName: String
   phoneNumber: String
   pk: Int
+}
+
+input UpdateReservationSeriesReservationUpdateSerializerInput {
+  ageGroup: Int
+  applyingForFreeOfCharge: Boolean
+  billingAddressCity: String
+  billingAddressStreet: String
+  billingAddressZip: String
+  billingEmail: String
+  billingFirstName: String
+  billingLastName: String
+  billingPhone: String
+  description: String
+  freeOfChargeReason: String
+  homeCity: Int
+  name: String
+  numPersons: Int
+  purpose: Int
+  reserveeAddressCity: String
+  reserveeAddressStreet: String
+  reserveeAddressZip: String
+  reserveeEmail: String
+  reserveeFirstName: String
+  reserveeId: String
+  reserveeIsUnregisteredAssociation: Boolean
+  reserveeLanguage: ReserveeLanguage
+  reserveeLastName: String
+  reserveeOrganisationName: String
+  reserveePhone: String
+  reserveeType: ReserveeType
+  workingMemo: String
 }
 
 input UpdateReservationUnitImageFieldSerializerInput {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Replace frontend N mutations to update a series of reservations with a single mutation.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: changing form values for both series and single reservation should work as before (but faster) `admin-ui`. 

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3515](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3515)


[TILA-3515]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ