### PR TITLE
fix: add status labels to the admin side tables

### DIFF
--- a/apps/admin-ui/src/spa/notifications/index.tsx
+++ b/apps/admin-ui/src/spa/notifications/index.tsx
@@ -5,8 +5,9 @@ import styled from "styled-components";
 import {
   type BannerNotificationNode,
   BannerNotificationOrderingChoices,
-  useBannerNotificationsAdminListQuery,
   BannerNotificationsAdminFragment,
+  BannerNotificationState,
+  useBannerNotificationsAdminListQuery,
 } from "@gql/gql-types";
 import { H1 } from "common/src/common/typography";
 import { Container } from "@/styles/layout";
@@ -17,7 +18,14 @@ import { GQL_MAX_RESULTS_PER_QUERY } from "@/common/const";
 import { CustomTable } from "@/component/Table";
 import { filterNonNullable } from "common/src/helpers";
 import { More } from "@/component/More";
-import { TableLink } from "@/styles/util";
+import { TableLink, TableStatusLabel } from "@/styles/util";
+import type { StatusLabelType } from "common/src/tags";
+import {
+  IconCheck,
+  IconClock,
+  IconPen,
+  IconQuestionCircleFill,
+} from "hds-react";
 
 const notificationUrl = (pk: number) => `/messaging/notifications/${pk}`;
 
@@ -27,14 +35,35 @@ const HeaderContainer = styled.div`
   align-items: center;
 `;
 
+const getStatusLabelProps = (
+  state: BannerNotificationState | null | undefined
+): { type: StatusLabelType; icon: JSX.Element } => {
+  switch (state) {
+    case BannerNotificationState.Draft:
+      return { type: "draft", icon: <IconPen ariaHidden /> };
+    case BannerNotificationState.Scheduled:
+      return { type: "info", icon: <IconClock ariaHidden /> };
+    case BannerNotificationState.Active:
+      return { type: "success", icon: <IconCheck ariaHidden /> };
+    default:
+      return { type: "info", icon: <IconQuestionCircleFill ariaHidden /> };
+  }
+};
+
 // Tila, Nimi, Voimassa alk, Voimassa asti, Kohderyhmä, Tyyppi
 const getColConfig = (t: TFunction) => [
   {
     headerName: t("Notifications.headings.state"),
     key: "state",
     isSortable: true,
-    transform: (notification: NonNullable<BannerNotificationNode>) =>
-      t(`Notifications.state.${notification.state ?? "noState"}`),
+    transform: (notification: NonNullable<BannerNotificationNode>) => {
+      const labelProps = getStatusLabelProps(notification.state);
+      return (
+        <TableStatusLabel type={labelProps.type} icon={labelProps.icon}>
+          {t(`Notifications.state.${notification.state ?? "noState"}`)}
+        </TableStatusLabel>
+      );
+    },
   },
   {
     headerName: t("Notifications.headings.name"),

--- a/apps/admin-ui/src/styles/layout.tsx
+++ b/apps/admin-ui/src/styles/layout.tsx
@@ -58,8 +58,6 @@ export const Container = styled.div`
   display: grid;
   gap: var(--spacing-layout-2-xs);
 
-  max-width: var(--container-width-xl);
-
   margin: var(--spacing-layout-2-xs) var(--spacing-layout-m);
 
   @media (max-width: ${breakpoints.m}) {

--- a/apps/admin-ui/src/styles/util.ts
+++ b/apps/admin-ui/src/styles/util.ts
@@ -1,6 +1,7 @@
 import { Dialog } from "hds-react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import StatusLabel from "common/src/components/StatusLabel";
 
 export const Seranwrap = styled.div`
   height: 200%;
@@ -55,4 +56,9 @@ export const Element = styled.div<{ $wide?: boolean; $start?: boolean }>`
   grid-column: ${({ $wide, $start }) =>
     $wide ? "1 / -1" : $start ? "1 / span 1" : "auto / span 1"};
   max-width: var(--prose-width);
+`;
+
+// StatusLabels expand the table cell without this, as they're too high au naturel
+export const TableStatusLabel = styled(StatusLabel)`
+  margin-block: -6px;
 `;

--- a/packages/common/src/components/Tag.tsx
+++ b/packages/common/src/components/Tag.tsx
@@ -13,7 +13,7 @@ type TagPropsType = {
   onClick?: () => void;
   id?: string;
   children: React.ReactNode;
-} & Pick<React.HTMLAttributes<HTMLDivElement>, "role">;
+};
 
 const ColoredTag = styled(StyledTag)<{ $type: StatusLabelType }>`
   && {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Replaces the status-texts with StatusLabel components, within the admin pages tables
- also removes the unnecessary width restriction for the page container

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go view reservations and/or reservation units in the admin-ui. Their status (+ payment status) should be presented with a status label tag now. Also note that the page content width is now "full-page" (== as wide as the header).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3146, TILA-3148, TILA-3149
