### PR TITLE
fix: tag and status label borders

### DIFF
--- a/apps/admin-ui/src/spa/ReservationUnit/edit/tags.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/tags.tsx
@@ -13,9 +13,8 @@ import {
   IconQuestionCircle,
 } from "hds-react";
 import { useTranslation } from "react-i18next";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 type StatusPropsType = {
   type: StatusLabelType;

--- a/apps/admin-ui/src/spa/application-rounds/ApplicationRoundStatusLabel.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/ApplicationRoundStatusLabel.tsx
@@ -9,9 +9,8 @@ import {
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { ApplicationRoundStatusChoice, type Maybe } from "@gql/gql-types";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 type RoundStatus = {
   type: StatusLabelType;

--- a/apps/admin-ui/src/spa/notifications/page.tsx
+++ b/apps/admin-ui/src/spa/notifications/page.tsx
@@ -49,9 +49,8 @@ import { base64encode } from "common/src/helpers";
 import { ControlledDateInput } from "common/src/components/form";
 import ControlledTimeInput from "@/component/ControlledTimeInput";
 import { errorToast, successToast } from "common/src/common/toast";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 const RichTextInput = dynamic(() => import("@/component/RichTextInput"), {
   ssr: false,

--- a/apps/admin-ui/src/spa/reservations/[id]/ReservationTitleSection.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/ReservationTitleSection.tsx
@@ -16,9 +16,8 @@ import { formatDateTime } from "@/common/util";
 import { getApplicationUrl } from "@/common/urls";
 import { gql } from "@apollo/client";
 import { ExternalLink } from "@/component/ExternalLink";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 const Dot = styled.div`
   display: inline-block;

--- a/apps/ui/components/applications/ApplicationCard.tsx
+++ b/apps/ui/components/applications/ApplicationCard.tsx
@@ -24,9 +24,8 @@ import { BlackButton } from "@/styles/util";
 import { getApplicationRoundName } from "@/modules/applicationRound";
 import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
 import { ConfirmationDialog } from "common/src/components/ConfirmationDialog";
-import StatusLabel, {
-  type StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 const Card = styled(HdsCard)`
   border-width: 0;

--- a/apps/ui/components/reservation/ReservationOrderStatus.tsx
+++ b/apps/ui/components/reservation/ReservationOrderStatus.tsx
@@ -3,9 +3,8 @@ import React, { useMemo } from "react";
 import { useTranslation } from "next-i18next";
 import { OrderStatus } from "@/gql/gql-types";
 import { IconEuroSign } from "hds-react";
-import StatusLabel, {
-  StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 export type Props = {
   orderStatus: OrderStatus;
@@ -37,7 +36,7 @@ export function ReservationOrderStatus({
   const statusText = t(`reservations:orderStatus.${camelCase(orderStatus)}`);
 
   return (
-    <StatusLabel type={labelType} icon={<IconEuroSign />} dataTestId={testId}>
+    <StatusLabel type={labelType} icon={<IconEuroSign />} testId={testId}>
       {statusText}
     </StatusLabel>
   );

--- a/apps/ui/components/reservation/ReservationStatus.tsx
+++ b/apps/ui/components/reservation/ReservationStatus.tsx
@@ -10,9 +10,8 @@ import {
   IconPen,
   IconQuestionCircle,
 } from "hds-react";
-import StatusLabel, {
-  StatusLabelType,
-} from "common/src/components/StatusLabel";
+import StatusLabel from "common/src/components/StatusLabel";
+import { type StatusLabelType } from "common/src/tags";
 
 export type Props = {
   state: ReservationStateChoice;
@@ -71,7 +70,7 @@ export function ReservationStatus({ state, testId }: Props): JSX.Element {
     <StatusLabel
       type={statusProps.type}
       icon={statusProps.icon}
-      dataTestId={testId}
+      testId={testId}
     >
       {statusText}
     </StatusLabel>

--- a/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
+++ b/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
@@ -1,4 +1,4 @@
-import { IconArrowRight, IconEuroSign, IconGroup, Tag } from "hds-react";
+import { IconArrowRight, IconEuroSign, IconGroup } from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
@@ -13,7 +13,6 @@ import type {
 import { format, isToday, isTomorrow } from "date-fns";
 import { toUIDate } from "common/src/common/util";
 import { getMainImage, getTranslation } from "@/modules/util";
-import IconWithText from "../common/IconWithText";
 import { truncatedText } from "@/styles/util";
 import {
   getActivePricing,
@@ -25,6 +24,8 @@ import { reservationUnitPrefix } from "@/modules/const";
 import { ButtonLikeLink } from "../common/ButtonLikeLink";
 import { useSearchParams } from "next/navigation";
 import { getImageSource, isBrowser } from "common/src/helpers";
+import Tag from "common/src/components/Tag";
+import IconWithText from "@/components/common/IconWithText";
 
 type QueryT = NonNullable<SearchReservationUnitsQuery["reservationUnits"]>;
 type Edge = NonNullable<NonNullable<QueryT["edges"]>[0]>;
@@ -171,31 +172,6 @@ const StyledIconWithText = styled(IconWithText)`
   }
 `;
 
-const StyledTag = styled(Tag)<{ $status: "available" | "no-times" | "closed" }>`
-  margin-bottom: var(--spacing-s);
-
-  @media (min-width: ${breakpoints.s}) {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 1;
-    margin: 0;
-  }
-
-  && {
-    --tag-background: ${({ $status }) => {
-      switch ($status) {
-        case "available":
-          return "var(--color-success-light)";
-        case "no-times":
-          return "var(--color-error-light)";
-        case "closed":
-          return "var(--color-black-10)";
-      }
-    }};
-  }
-`;
-
 const StatusTag = ({
   data,
   id,
@@ -208,17 +184,17 @@ const StatusTag = ({
 
   if (closed) {
     return (
-      <StyledTag $status="closed" id={id}>
+      <Tag ariaLabel={t("reservationUnitCard:closed")} type="error" id={id}>
         {t("reservationUnitCard:closed")}
-      </StyledTag>
+      </Tag>
     );
   }
 
   if (!availableAt) {
     return (
-      <StyledTag $status="no-times" id={id}>
+      <Tag ariaLabel={t("reservationUnitCard:noTimes")} type="neutral" id={id}>
         {t("reservationUnitCard:noTimes")}
-      </StyledTag>
+      </Tag>
     );
   }
 
@@ -231,10 +207,11 @@ const StatusTag = ({
   } else dayText = `${toUIDate(new Date(availableAt))} `;
 
   return (
-    <StyledTag
-      $status="available"
+    <Tag
+      ariaLabel={`${t("reservationUnitCard:firstAvailableTime")}: ${dayText} ${timeText}`}
+      type="success"
       id={id}
-    >{`${dayText} ${timeText}`}</StyledTag>
+    >{`${dayText} ${timeText}`}</Tag>
   );
 };
 

--- a/packages/common/src/components/StatusLabel.tsx
+++ b/packages/common/src/components/StatusLabel.tsx
@@ -1,37 +1,33 @@
 import React from "react";
-import {
-  StatusLabel as HDSStatusLabel,
-  type StatusLabelType as HDSStatusLabelType,
-} from "hds-react";
+import { StatusLabel as HDSStatusLabel } from "hds-react";
 import styled from "styled-components";
+import {
+  type StatusLabelType,
+  getStatusBorderColor,
+  getStatusBackgroundColor,
+} from "../tags";
 
-export type StatusLabelType = HDSStatusLabelType | "draft";
-
-const handleColorType = ($type: StatusLabelType) => {
-  switch ($type) {
-    case "info":
-      return "var(--color-coat-of-arms-light)";
-    case "alert":
-      return "var(--color-engel-medium-light)";
-    case "success":
-      return "var(--color-tram-light)";
-    case "error":
-      return "var(--color-metro-medium-light)";
-    case "draft":
-      return "var(--color-suomenlinna-medium-light)";
-    case "neutral":
-    default:
-      return "var(--color-silver)";
-  }
+type StatusLabelProps = {
+  type: StatusLabelType;
+  icon: JSX.Element;
+  testId?: string;
+  children: React.ReactNode;
 };
 
 const ColoredLabel = styled(HDSStatusLabel)<{
   $type: StatusLabelType;
 }>`
   && {
-    --status-label-background: ${(props) => handleColorType(props.$type)};
+    --status-label-background: ${(props) =>
+      getStatusBackgroundColor(props.$type)} !important;
     --status-label-color: var(--color-black);
+    border-width: 1px;
+    border-style: solid;
+    border-color: ${(props) => getStatusBorderColor(props.$type)};
     white-space: nowrap;
+  }
+  svg {
+    scale: 0.8;
   }
 `;
 
@@ -46,19 +42,14 @@ const ColoredLabel = styled(HDSStatusLabel)<{
 function StatusLabel({
   type,
   icon,
-  dataTestId,
+  testId,
   children,
-}: {
-  type: StatusLabelType;
-  icon: JSX.Element;
-  dataTestId?: string;
-  children: React.ReactNode;
-}) {
+}: Readonly<StatusLabelProps>): JSX.Element {
   return (
     <ColoredLabel
       type={type === "draft" ? "neutral" : type} // HDS StatusLabel does not support "draft" type - so convert it to "neutral"
       iconLeft={icon}
-      dataTestId={dataTestId}
+      dataTestId={testId}
       $type={type}
     >
       {children}

--- a/packages/common/src/components/Tag.tsx
+++ b/packages/common/src/components/Tag.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  getStatusBackgroundColor,
+  getStatusBorderColor,
+  StatusLabelType,
+  StyledTag,
+} from "../tags";
+import styled from "styled-components";
+
+type TagPropsType = {
+  ariaLabel: string;
+  type: StatusLabelType;
+  onClick?: () => void;
+  id?: string;
+  children: React.ReactNode;
+} & Pick<React.HTMLAttributes<HTMLDivElement>, "role">;
+
+const ColoredTag = styled(StyledTag)<{ $type: StatusLabelType }>`
+  && {
+    --tag-background: ${(props) =>
+      getStatusBackgroundColor(props.$type)} !important;
+    --tag-color: var(--color-black);
+    border-width: 1px;
+    border-style: solid;
+    border-color: ${(props) => getStatusBorderColor(props.$type)};
+    white-space: nowrap;
+  }
+`;
+
+function Tag({
+  ariaLabel,
+  type = "neutral",
+  id,
+  children,
+  onClick,
+}: TagPropsType): JSX.Element {
+  return (
+    <ColoredTag $type={type} id={id} aria-label={ariaLabel} onClick={onClick}>
+      {children}
+    </ColoredTag>
+  );
+}
+
+export default Tag;

--- a/packages/common/src/tags.tsx
+++ b/packages/common/src/tags.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { Tag } from "hds-react";
+import type { StatusLabelType as HDSStatusLabelType } from "hds-react";
 
 export const FilterTags = styled.div`
   display: flex;
@@ -44,3 +45,42 @@ export const ResetButton = styled(StyledTag).attrs({
     background: var(--color-black-10);
   }
 `;
+
+export type StatusLabelType = HDSStatusLabelType | "draft";
+
+export const getStatusBorderColor = ($type: StatusLabelType) => {
+  switch ($type) {
+    case "info":
+      return "var(--color-coat-of-arms)";
+    case "alert":
+      return "var(--color-engel)";
+    case "success":
+      return "var(--color-tram)";
+    case "error":
+      // using custom value since there is no suitable color in the HDS color palette for this (--color-metro is too dark)
+      return "#FBA782";
+    case "draft":
+      return "var(--color-suomenlinna)";
+    case "neutral":
+    default:
+      return "var(--color-silver-dark)";
+  }
+};
+
+export const getStatusBackgroundColor = ($type: StatusLabelType) => {
+  switch ($type) {
+    case "info":
+      return "var(--color-coat-of-arms-medium-light)";
+    case "alert":
+      return "var(--color-engel-medium-light)";
+    case "success":
+      return "var(--color-tram-medium-light)";
+    case "error":
+      return "var(--color-metro-medium-light)";
+    case "draft":
+      return "var(--color-suomenlinna-medium-light)";
+    case "neutral":
+    default:
+      return "var(--color-silver)";
+  }
+};


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds `Tag.tsx` as a common component. It is a HDS Tag with the same custom types and coloring as `StatusLabel`
- Moves code which is shared by both Tag and StatusLabel (e.g. the color functions based on type) from StatusLabel.tsx to tags.tsx
- renames StatusLabel property `dataTestId` to `testId`, just for consistency

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that StatusLabels and Tags have a border, like specified in the designs
- Check that tags still otherwise work like they did

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
