### PR TITLE
fix: warning from nesting <div> inside <p>

### DIFF
--- a/apps/ui/components/reservation/AcceptTerms.tsx
+++ b/apps/ui/components/reservation/AcceptTerms.tsx
@@ -76,7 +76,9 @@ export function AcceptTerms({
         body={
           serviceSpecificTerms != null ? (
             <Sanitize html={getTranslation(serviceSpecificTerms, "text")} />
-          ) : undefined
+          ) : (
+            <span />
+          )
         }
         links={[
           {

--- a/packages/common/src/termsbox/TermsBox.tsx
+++ b/packages/common/src/termsbox/TermsBox.tsx
@@ -13,7 +13,7 @@ type LinkT = {
 export type Props = {
   id?: string;
   heading: string;
-  body?: string | JSX.Element;
+  body: JSX.Element;
   links?: LinkT[];
   acceptLabel?: string;
   accepted?: boolean;
@@ -105,8 +105,9 @@ const TermsBox = ({
   return (
     <Wrapper {...rest} id={id}>
       <Content>
+        {/* FIXME this is wrong it's hard coded to h6 */}
         <Heading>{heading}</Heading>
-        <p>{body}</p>
+        {body}
         {links && links?.length > 0 && (
           <LinkList>
             {links.map((link) => (

--- a/packages/common/src/termsbox/__tests__/TermsBox.test.tsx
+++ b/packages/common/src/termsbox/__tests__/TermsBox.test.tsx
@@ -2,11 +2,13 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import TermsBox, { Props } from "../TermsBox";
 
+const bodyText = `Excepteur ut veniam minim id. Veniam laboris laborum cupidatat nisi sunt est magna id voluptate. Ullamco elit do tempor et dolore. Sit dolore laborum excepteur laborum qui eiusmod. Nisi proident officia labore sunt sit labore. Non aute ut exercitation elit sint. Aute irure reprehenderit reprehenderit amet sunt velit irure voluptate.`;
+
 const defaultProps = {
   id: "testing",
   heading:
     "A heading with somewhat long text that might wrap to multiple lines",
-  body: `Excepteur ut veniam minim id. Veniam laboris laborum cupidatat nisi sunt est magna id voluptate. Ullamco elit do tempor et dolore. Sit dolore laborum excepteur laborum qui eiusmod. Nisi proident officia labore sunt sit labore. Non aute ut exercitation elit sint. Aute irure reprehenderit reprehenderit amet sunt velit irure voluptate.`,
+  body: <span>{bodyText}</span>,
   links: [
     { href: "https://www.google.com", text: "Google" },
     { href: "https://www.hel.fi", text: "Helsinki" },
@@ -29,7 +31,7 @@ describe("TermsBox", () => {
 
     expect(screen.getByText(defaultProps.heading)).toBeInTheDocument();
 
-    expect(screen.getByText(defaultProps.body)).toBeInTheDocument();
+    expect(screen.getByText(bodyText)).toBeInTheDocument();
 
     expect(link1).toBeInTheDocument();
     expect(link1).toHaveAttribute("href", defaultProps.links[0].href);
@@ -54,9 +56,7 @@ describe("TermsBox", () => {
     renderComponent({ links: undefined });
 
     expect(screen.getByText(defaultProps.heading)).toBeInTheDocument();
-
-    expect(screen.getByText(defaultProps.body)).toBeInTheDocument();
-
+    expect(screen.getByText(bodyText)).toBeInTheDocument();
     expect(screen.getByText(defaultProps.acceptLabel)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: warning from nesting `<div>` inside `<p>`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automation: p -> Fragment change.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
