### PR TITLE
Fix: show all richtext tags that are used in Django

### DIFF
--- a/apps/ui/components/common/Sanitize.tsx
+++ b/apps/ui/components/common/Sanitize.tsx
@@ -21,9 +21,29 @@ const StyledContent = styled.div`
 `;
 
 const config = {
-  allowedTags: ["p", "strong", "a", "br"],
+  allowedTags: [
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+    "br",
+    "div",
+    "span",
+    "ol",
+    "ul",
+    "li",
+    "strong",
+    "em",
+    "u",
+    "a",
+    "pre",
+  ],
   allowedAttributes: {
     a: ["href", "target", "rel"],
+    "*": ["style"],
   },
 };
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- adds all the tags which are usable in the Django rich text editor, to the allowed tags list for the `Sanitizer.tsx`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Try to use some of the tags which weren't in use before (`h1`-`h6`, `div`, `span`, `ol`, `ul`, `li`, `em`, `u`, `pre`) in the Django editor and check the result (used e.g. in reservation-unit description)

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3503
