### PR TITLE
fix: calendar link 404 with other locales

### DIFF
--- a/apps/ui/components/reservation/ReservationConfirmation.tsx
+++ b/apps/ui/components/reservation/ReservationConfirmation.tsx
@@ -5,7 +5,6 @@ import {
   IconLinkExternal,
   IconSignout,
 } from "hds-react";
-import { useRouter } from "next/router";
 import { Trans, useTranslation } from "next-i18next";
 import Link from "next/link";
 import styled from "styled-components";
@@ -24,6 +23,7 @@ import { getTranslation, reservationsUrl } from "../../modules/util";
 import { BlackButton } from "../../styles/util";
 import { Paragraph } from "./styles";
 import { reservationUnitPath } from "../../modules/const";
+import { ButtonLikeLink } from "../common/ButtonLikeLink";
 
 type Node = NonNullable<ReservationQuery["reservation"]>;
 type Props = {
@@ -106,7 +106,6 @@ function ReservationConfirmation({
   order,
 }: Props): JSX.Element {
   const { t, i18n } = useTranslation();
-  const router = useRouter();
 
   const reservationUnit = reservation.reservationUnit?.[0];
   const instructionsKey = getReservationUnitInstructionsKey(reservation?.state);
@@ -141,14 +140,16 @@ function ReservationConfirmation({
       </Paragraph>
       {reservation.state === ReservationStateChoice.Confirmed && (
         <ActionContainer1 style={{ marginBottom: "var(--spacing-2-xl)" }}>
-          <BlackButton
+          <ButtonLikeLink
+            size="large"
+            disabled={!reservation.calendarUrl}
             data-testid="reservation__confirmation--button__calendar-url"
-            onClick={() => router.push(String(reservation.calendarUrl))}
-            variant="secondary"
-            iconRight={<IconCalendar aria-hidden />}
+            href={reservation.calendarUrl ?? ""}
+            locale={false}
           >
             {t("reservations:saveToCalendar")}
-          </BlackButton>
+            <IconCalendar aria-hidden />
+          </ButtonLikeLink>
           {order?.receiptUrl && (
             <BlackButton
               data-testid="reservation__confirmation--button__receipt-link"

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -485,6 +485,7 @@ function Reservation({
                   disabled={!reservation.calendarUrl}
                   data-testid="reservation__button--calendar-link"
                   href={reservation.calendarUrl ?? ""}
+                  locale={false}
                 >
                   {t("reservations:saveToCalendar")}
                   <IconCalendar aria-hidden />


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: save to calendar link in my reservation not working on other locales than `FI` 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: `Save to Calendar` should work regardless of locale (both after a new reservation and on the reservation page).
- Manually tested on dev because this is not reproducible locally.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3622](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3622)


[TILA-3622]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ