### PR TITLE
fix: graphql key errors from api change

### DIFF
--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -118,7 +118,7 @@ function createMockReservation({
     paymentOrder: [],
     begin: start.toISOString(),
     end: end.toISOString(),
-    reservationUnit: [reservationUnit ?? createMockReservationUnit({})],
+    reservationUnits: [reservationUnit ?? createMockReservationUnit({})],
     handlingDetails: "",
     isHandled,
   };

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -119,18 +119,13 @@ type IsWithinCancellationPeriodReservationT = Pick<
   ReservationNodeT,
   "begin"
 > & {
-  reservationUnit?: Array<{
-    cancellationRule?: Pick<
-      NonNullable<ReservationUnitNode["cancellationRule"]>,
-      "canBeCancelledTimeBefore" | "needsHandling"
-    > | null;
-  }> | null;
+  reservationUnits?: Maybe<Array<CancellationRuleFieldsFragment>> | undefined;
 };
 
 function isTooCloseToCancel(
   reservation: IsWithinCancellationPeriodReservationT
 ): boolean {
-  const reservationUnit = reservation.reservationUnit?.[0];
+  const reservationUnit = reservation.reservationUnits?.[0];
   const begin = new Date(reservation.begin);
 
   const { canBeCancelledTimeBefore } = reservationUnit?.cancellationRule ?? {};
@@ -144,12 +139,12 @@ type CanUserCancelReservationProps = Pick<
   NonNullable<ReservationNodeT>,
   "state" | "begin"
 > & {
-  reservationUnit?: Maybe<Array<CancellationRuleFieldsFragment>> | undefined;
+  reservationUnits?: Maybe<Array<CancellationRuleFieldsFragment>> | undefined;
 };
 export function isReservationCancellable(
   reservation: CanUserCancelReservationProps
 ): boolean {
-  const reservationUnit = reservation.reservationUnit?.[0];
+  const reservationUnit = reservation.reservationUnits?.[0];
   const isReservationCancelled =
     reservation.state === ReservationStateChoice.Cancelled;
   const isBeingHandled =
@@ -278,7 +273,7 @@ export function getWhyReservationCantBeChanged(
     return "RESERVATION_BEGIN_IN_PAST";
   }
 
-  const reservationUnit = reservation.reservationUnit?.[0];
+  const reservationUnit = reservation.reservationUnits?.[0];
   if (
     reservationUnit?.cancellationRule == null ||
     reservationUnit.cancellationRule.needsHandling

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -382,20 +382,20 @@ function Reservation({
   }, [reservation, reservationUnit]);
 
   const paymentTermsContent =
-    reservationUnit?.paymentTerms != null
-      ? getTranslation(reservationUnit?.paymentTerms, "text")
+    reservationUnit.paymentTerms != null
+      ? getTranslation(reservationUnit.paymentTerms, "text")
       : undefined;
   const cancellationTermsContent =
-    reservationUnit?.cancellationTerms != null
-      ? getTranslation(reservationUnit?.cancellationTerms, "text")
+    reservationUnit.cancellationTerms != null
+      ? getTranslation(reservationUnit.cancellationTerms, "text")
       : undefined;
   const pricingTermsContent =
     reservationUnit?.pricingTerms != null
       ? getTranslation(reservationUnit?.pricingTerms, "text")
       : undefined;
   const serviceSpecificTermsContent =
-    reservationUnit?.serviceSpecificTerms != null
-      ? getTranslation(reservationUnit?.serviceSpecificTerms, "text")
+    reservationUnit.serviceSpecificTerms != null
+      ? getTranslation(reservationUnit.serviceSpecificTerms, "text")
       : undefined;
 
   const modifyTimeReason = getWhyReservationCantBeChanged({ reservation });


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1470
- Fix: not being able to cancel a reservation because incorrectly using old GQL key.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

-

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
