### PR TITLE
fix: include space hierarchy when checking collisions

### DIFF
--- a/apps/ui/components/reservation-unit/utils.test.ts
+++ b/apps/ui/components/reservation-unit/utils.test.ts
@@ -220,6 +220,7 @@ describe("getNextAvailableTime", () => {
       },
       reservableTimes,
       activeApplicationRounds: activeApplicationRounds ?? [],
+      blockingReservations: [],
     };
   }
 

--- a/apps/ui/components/reservation-unit/utils.ts
+++ b/apps/ui/components/reservation-unit/utils.ts
@@ -7,6 +7,7 @@ import {
   startOfDay,
 } from "date-fns";
 import type {
+  BlockingReservationFieldsFragment,
   ReservationUnitNode,
   ReservationUnitPageQuery,
 } from "@gql/gql-types";
@@ -63,6 +64,7 @@ type AvailableTimesProps = {
   reservationUnit: QueryT;
   reservableTimes: ReservableMap;
   activeApplicationRounds: readonly RoundPeriod[];
+  blockingReservations: readonly BlockingReservationFieldsFragment[];
   fromStartOfDay?: boolean;
 };
 
@@ -74,6 +76,7 @@ function getAvailableTimesForDay({
   reservationUnit,
   reservableTimes,
   activeApplicationRounds,
+  blockingReservations,
 }: AvailableTimesProps): string[] {
   if (!reservationUnit) {
     return [];
@@ -89,6 +92,7 @@ function getAvailableTimesForDay({
     reservationUnit,
     activeApplicationRounds,
     durationValue: duration,
+    blockingReservations,
   })
     .map((n) => {
       const [slotHours, slotMinutes] = n.label.split(":").map(Number);
@@ -105,6 +109,7 @@ function getAvailableTimesForDay({
         reservationUnit,
         reservableTimes,
         activeApplicationRounds,
+        blockingReservations,
       });
 
       return isReservable && !isBefore(startDate, startTime) ? n.label : null;

--- a/apps/ui/components/reservation/ReservationTimePicker.tsx
+++ b/apps/ui/components/reservation/ReservationTimePicker.tsx
@@ -1,6 +1,7 @@
 import React, { Children, useEffect, useMemo, useState } from "react";
 import classNames from "classnames";
 import {
+  BlockingReservationFieldsFragment,
   ReservationNode,
   ReservationTypeChoice,
   ReservationUnitPageQuery,
@@ -105,6 +106,7 @@ type Props = {
   reservationUnit: NonNullable<ReservationUnitPageQuery["reservationUnit"]>;
   reservableTimes: ReservableMap;
   activeApplicationRounds: readonly RoundPeriod[];
+  blockingReservations: readonly BlockingReservationFieldsFragment[];
   reservationForm: UseFormReturn<PendingReservationFormType>;
   isReservationQuotaReached: boolean;
   submitReservation: (d: PendingReservationFormType) => void;
@@ -147,8 +149,10 @@ function useSlotPropGetter({
 function useCalendarEventChange({
   reservationUnit,
   focusSlot,
+  blockingReservations,
 }: Pick<Props, "reservationUnit"> & {
   focusSlot: ReturnType<typeof convertFormToFocustimeSlot>;
+  blockingReservations: readonly BlockingReservationFieldsFragment[];
 }): Array<CalendarEventBuffer | CalendarEvent<ReservationNode>> {
   const { t } = useTranslation();
   // TODO this doesn't optimize anything
@@ -156,9 +160,7 @@ function useCalendarEventChange({
   const calendarEvents: Array<
     CalendarEventBuffer | CalendarEvent<ReservationNode>
   > = useMemo(() => {
-    const existingReservations = filterNonNullable(
-      reservationUnit.reservations
-    );
+    const existingReservations = blockingReservations;
 
     const shouldDisplayFocusSlot = focusSlot.isReservable;
 
@@ -214,7 +216,7 @@ function useCalendarEventChange({
         ...(pendingReservation != null ? [pendingReservation] : []),
       ]),
     ];
-  }, [reservationUnit, t, focusSlot]);
+  }, [reservationUnit, t, focusSlot, blockingReservations]);
 
   return calendarEvents;
 }
@@ -228,6 +230,7 @@ export function ReservationTimePicker({
   loginAndSubmitButton,
   submitReservation,
   startingTimeOptions,
+  blockingReservations,
 }: Props) {
   const { t, i18n } = useTranslation();
   const [calendarViewType, setCalendarViewType] = useState<WeekOptions>("week");
@@ -248,11 +251,13 @@ export function ReservationTimePicker({
     reservationUnit,
     activeApplicationRounds,
     reservableTimes,
+    blockingReservations,
   });
 
   const calendarEvents = useCalendarEventChange({
     reservationUnit,
     focusSlot,
+    blockingReservations,
   });
   const slotPropGetter = useSlotPropGetter({
     reservableTimes,
@@ -294,6 +299,7 @@ export function ReservationTimePicker({
       reservationUnit,
       reservableTimes,
       activeApplicationRounds,
+      blockingReservations,
     });
 
     if (!isReservable) {
@@ -351,6 +357,7 @@ export function ReservationTimePicker({
       reservationUnit,
       reservableTimes,
       activeApplicationRounds,
+      blockingReservations,
     });
     if (!isReservable) {
       return false;

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -6515,19 +6515,6 @@ export type IsReservableFieldsFragment = {
   reservationsMinDaysBefore?: number | null;
   reservationBegins?: string | null;
   reservationEnds?: string | null;
-  reservations?: Array<{
-    pk?: number | null;
-    id: string;
-    state?: ReservationStateChoice | null;
-    isBlocked?: boolean | null;
-    begin: string;
-    end: string;
-    numPersons?: number | null;
-    calendarUrl?: string | null;
-    bufferTimeBefore: number;
-    bufferTimeAfter: number;
-    affectedReservationUnits?: Array<number | null> | null;
-  }> | null;
   reservableTimeSpans?: Array<{
     startDatetime?: string | null;
     endDatetime?: string | null;
@@ -6626,19 +6613,6 @@ export type ReservationUnitPageQuery = {
         nameSv?: string | null;
       };
     }>;
-    reservations?: Array<{
-      pk?: number | null;
-      id: string;
-      state?: ReservationStateChoice | null;
-      isBlocked?: boolean | null;
-      begin: string;
-      end: string;
-      numPersons?: number | null;
-      calendarUrl?: string | null;
-      bufferTimeBefore: number;
-      bufferTimeAfter: number;
-      affectedReservationUnits?: Array<number | null> | null;
-    }> | null;
     reservableTimeSpans?: Array<{
       startDatetime?: string | null;
       endDatetime?: string | null;
@@ -8001,9 +7975,6 @@ export const BlockingReservationFieldsFragmentDoc = gql`
 `;
 export const IsReservableFieldsFragmentDoc = gql`
   fragment IsReservableFields on ReservationUnitNode {
-    reservations(state: $state) {
-      ...BlockingReservationFields
-    }
     bufferTimeBefore
     bufferTimeAfter
     reservableTimeSpans(startDate: $beginDate, endDate: $endDate) {
@@ -8018,7 +7989,6 @@ export const IsReservableFieldsFragmentDoc = gql`
     reservationBegins
     reservationEnds
   }
-  ${BlockingReservationFieldsFragmentDoc}
 `;
 export const ReservationUnitNameFieldsFragmentDoc = gql`
   fragment ReservationUnitNameFields on ReservationUnitNode {

--- a/apps/ui/modules/__tests__/reservable.test.ts
+++ b/apps/ui/modules/__tests__/reservable.test.ts
@@ -14,6 +14,7 @@ import {
   isStartTimeValid,
 } from "../reservable";
 import {
+  BlockingReservationFieldsFragment,
   type IsReservableFieldsFragment,
   ReservationStartInterval,
   ReservationStateChoice,
@@ -322,7 +323,7 @@ describe("isRangeReservable", () => {
     bufferTimeBefore?: number;
     bufferTimeAfter?: number;
     reservableTimes?: ReservableMap;
-    reservations?: IsReservableFieldsFragment["reservations"];
+    reservations?: BlockingReservationFieldsFragment[];
     interval?: ReservationStartInterval;
     maxReservationDuration?: IsReservableFieldsFragment["maxReservationDuration"];
     minReservationDuration?: IsReservableFieldsFragment["minReservationDuration"];
@@ -338,6 +339,7 @@ describe("isRangeReservable", () => {
       reservationUnit: createMockReservationUnit(rest),
       activeApplicationRounds: activeApplicationRounds ?? [],
       reservableTimes: reservableTimes ?? mockReservableTimes(),
+      blockingReservations: rest.reservations ?? [],
     };
   }
 

--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -601,6 +601,7 @@ describe("canReservationBeChanged", () => {
       },
       reservationUnit: baseUnit,
       activeApplicationRounds: [],
+      blockingReservations: [],
     };
   }
 

--- a/apps/ui/modules/__tests__/reservationUnit.test.ts
+++ b/apps/ui/modules/__tests__/reservationUnit.test.ts
@@ -99,6 +99,7 @@ describe("getPossibleTimesForDay", () => {
       activeApplicationRounds: [] as const,
       reservableTimes: reservableTimes ?? mockReservableTimes(),
       durationValue: duration ?? 30,
+      blockingReservations: [] as const,
     };
   }
 

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -120,9 +120,6 @@ export const RESERVATION_UNIT_PARAMS_PAGE_QUERY = gql`
 const IS_RESERVABLE_FRAGMENT = gql`
   ${BLOCKING_RESERVATION_FRAGMENT}
   fragment IsReservableFields on ReservationUnitNode {
-    reservations(state: $state) {
-      ...BlockingReservationFields
-    }
     bufferTimeBefore
     bufferTimeAfter
     reservableTimeSpans(startDate: $beginDate, endDate: $endDate) {

--- a/apps/ui/modules/reservable.ts
+++ b/apps/ui/modules/reservable.ts
@@ -9,8 +9,9 @@ import {
   type ReservableTimeSpanType,
   ReservationStateChoice,
   type Maybe,
+  BlockingReservationFieldsFragment,
 } from "@/gql/gql-types";
-import { dayMax, dayMin, filterNonNullable } from "common/src/helpers";
+import { dayMax, dayMin } from "common/src/helpers";
 import {
   differenceInSeconds,
   isValid,
@@ -156,6 +157,7 @@ type ReservationUnitReservableProps = {
   };
   reservationUnit: Omit<IsReservableFieldsFragment, "reservableTimeSpans">;
   reservableTimes: ReservableMap;
+  blockingReservations: readonly BlockingReservationFieldsFragment[];
   activeApplicationRounds: readonly RoundPeriod[];
 };
 
@@ -166,9 +168,9 @@ export function isRangeReservable({
   reservationUnit,
   activeApplicationRounds,
   reservableTimes,
+  blockingReservations,
 }: ReservationUnitReservableProps): boolean {
   const {
-    reservations,
     bufferTimeBefore,
     bufferTimeAfter,
     maxReservationDuration,
@@ -240,7 +242,7 @@ export function isRangeReservable({
 
   // This is the slowest part of the function => run it last
   // because the reservationSet includes every reservation not just for the selected day
-  const others = filterNonNullable(reservations)
+  const others = blockingReservations
     .filter(shouldReservationBlock)
     .filter((r) => {
       const rStart = new Date(r.begin);

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -20,6 +20,7 @@ import {
   OrderStatus,
   type ReservationOrderStatusFragment,
   type CancellationRuleFieldsFragment,
+  BlockingReservationFieldsFragment,
 } from "@gql/gql-types";
 import { getReservationApplicationFields } from "common/src/reservation-form/util";
 import { getIntervalMinutes } from "common/src/conversion";
@@ -252,6 +253,7 @@ export type CanReservationBeChangedProps = {
   newReservation: PendingReservation;
   reservationUnit: IsReservableFieldsFragment;
   activeApplicationRounds: readonly RoundPeriod[];
+  blockingReservations: readonly BlockingReservationFieldsFragment[];
 };
 
 export function getWhyReservationCantBeChanged(
@@ -314,6 +316,7 @@ export function canReservationTimeBeChanged({
   reservableTimes,
   reservationUnit,
   activeApplicationRounds,
+  blockingReservations,
 }: CanReservationBeChangedProps): boolean {
   if (reservation == null) {
     return false;
@@ -338,6 +341,7 @@ export function canReservationTimeBeChanged({
 
   //  new reservation is valid
   return isRangeReservable({
+    blockingReservations,
     range: {
       start: new Date(newReservation.begin),
       end: new Date(newReservation.end),
@@ -515,11 +519,13 @@ export function convertFormToFocustimeSlot({
   reservationUnit,
   reservableTimes,
   activeApplicationRounds,
+  blockingReservations,
 }: {
   data: PendingReservationFormType;
   reservationUnit: Omit<IsReservableFieldsFragment, "reservableTimeSpans">;
   reservableTimes: ReservableMap;
   activeApplicationRounds: readonly RoundPeriod[];
+  blockingReservations: readonly BlockingReservationFieldsFragment[];
 }): FocusTimeSlot | { isReservable: false } {
   const [hours, minutes]: Array<number | undefined> = data.time
     .split(":")
@@ -538,6 +544,7 @@ export function convertFormToFocustimeSlot({
 
   const end = addMinutes(start, data.duration);
   const isReservable = isRangeReservable({
+    blockingReservations,
     range: {
       start,
       end,

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -29,6 +29,7 @@ import {
   type IsReservableFieldsFragment,
   ReservationStartInterval,
   Maybe,
+  BlockingReservationFieldsFragment,
 } from "@gql/gql-types";
 import { capitalize, getTranslation } from "./util";
 import {
@@ -421,6 +422,7 @@ export function getPossibleTimesForDay({
   reservationUnit,
   activeApplicationRounds,
   durationValue,
+  blockingReservations,
 }: {
   reservableTimes: ReservableMap;
   interval: ReservationUnitNode["reservationStartInterval"];
@@ -428,6 +430,7 @@ export function getPossibleTimesForDay({
   reservationUnit: Omit<IsReservableFieldsFragment, "reservableTimeSpans">;
   activeApplicationRounds: readonly RoundPeriod[];
   durationValue: number;
+  blockingReservations: readonly BlockingReservationFieldsFragment[];
 }): { label: string; value: string }[] {
   const allTimes: Array<{ h: number; m: number }> = [];
   const slotsForDay = reservableTimes.get(dateToKey(date)) ?? [];
@@ -462,6 +465,7 @@ export function getPossibleTimesForDay({
         return false;
       }
       const isReservable = isRangeReservable({
+        blockingReservations,
         range: {
           start: slotDate,
           end: addMinutes(slotDate, durationValue),

--- a/apps/ui/test/testUtils.tsx
+++ b/apps/ui/test/testUtils.tsx
@@ -35,7 +35,6 @@ type MockReservationUnitProps = {
   bufferTimeBefore?: number;
   bufferTimeAfter?: number;
   reservableTimes?: ReservableMap;
-  reservations?: IsReservableFieldsFragment["reservations"];
   interval?: ReservationStartInterval;
   maxReservationDuration?: IsReservableFieldsFragment["maxReservationDuration"];
   minReservationDuration?: IsReservableFieldsFragment["minReservationDuration"];
@@ -47,7 +46,6 @@ type MockReservationUnitProps = {
 export function createMockReservationUnit({
   bufferTimeBefore = 0,
   bufferTimeAfter = 0,
-  reservations = [],
   interval = ReservationStartInterval.Interval_15Mins,
   maxReservationDuration = 0,
   minReservationDuration = 0,
@@ -55,7 +53,6 @@ export function createMockReservationUnit({
   reservationsMaxDaysBefore = null,
 }: MockReservationUnitProps): ReservationUnitType {
   const reservationUnit: ReservationUnitType = {
-    reservations,
     bufferTimeBefore: 60 * 60 * bufferTimeBefore,
     bufferTimeAfter: 60 * 60 * bufferTimeAfter,
     maxReservationDuration,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: space hierarchy wasn't showing in the customer ui calendar.
- Refactor: dont double query reservations (only affecting is needed for collision checks).
- Refactor: remove GQL object modifications that broke type checking.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: space hierarchy should correctly show in `customer` ui calendars.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3657](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3657)


[TILA-3657]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ