### PR TITLE
fix: incorrect continue reservation url

### DIFF
--- a/apps/ui/modules/urls.ts
+++ b/apps/ui/modules/urls.ts
@@ -79,7 +79,7 @@ export function getReservationInProgressPath(
   if (pk == null || reservationPk == null) {
     return "";
   }
-  return `${reservationsPrefix}/${pk}/reservation/${reservationPk}`;
+  return `${reservationUnitPrefix}/${pk}/reservation/${reservationPk}`;
 }
 
 export function getReservationUnitPath(pk: Maybe<number> | undefined): string {

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -103,6 +103,7 @@ import { useReservableTimes } from "@/hooks/useReservableTimes";
 import { errorToast } from "common/src/common/toast";
 import { ReservationTimePicker } from "@/components/reservation/ReservationTimePicker";
 import { ApolloError } from "@apollo/client";
+import { getReservationInProgressPath } from "@/modules/urls";
 import { ReservationPageWrapper } from "@/components/reservations/styles";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
@@ -491,10 +492,7 @@ function ReservationUnit({
         throw new Error("Reservation creation failed");
       }
       if (reservationUnit.pk != null) {
-        // TODO use url builder
-        router.push(
-          `/reservation-unit/${reservationUnit.pk}/reservation/${pk}`
-        );
+        router.push(getReservationInProgressPath(reservationUnit.pk, pk));
       }
     } catch (error: unknown) {
       const msg =


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: continue reservation notification having incorrect link.
- Regression in https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1443

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: check that incomplete new reservation can be continued from the notification (ex. close the tab and resume in another tab).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
