### PR TITLE
fix: sort purposes by reservationPurpose.rank

### DIFF
--- a/apps/admin-ui/src/hooks/useOptions.tsx
+++ b/apps/admin-ui/src/hooks/useOptions.tsx
@@ -6,7 +6,7 @@ export function useOptions() {
 
   const purpose = sortBy(
     optionsData?.reservationPurposes?.edges || [],
-    "node.nameFi"
+    "node.rank"
   ).map((purposeType) => ({
     label: purposeType?.node?.nameFi ?? "",
     value: Number(purposeType?.node?.pk),

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5418,6 +5418,7 @@ export type OptionsQuery = {
         nameFi?: string | null;
         nameEn?: string | null;
         nameSv?: string | null;
+        rank: number;
       } | null;
     } | null>;
   } | null;
@@ -8718,6 +8719,7 @@ export const OptionsDocument = gql`
           nameFi
           nameEn
           nameSv
+          rank
         }
       }
     }

--- a/apps/ui/hooks/useOptions.ts
+++ b/apps/ui/hooks/useOptions.ts
@@ -39,6 +39,7 @@ export const OPTIONS_QUERY = gql`
           nameFi
           nameEn
           nameSv
+          rank
         }
       }
     }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- adds `rank` to the `reservationPurpose` query, and uses it as sorting criteria

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that the purposes are ordered by rank when making a new reservation

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3553](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3553)
- [TILA-3554](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3554)


[TILA-3553]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3554]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ