### PR TITLE
Order applications based on `application.sentDate` in each category

### DIFF
--- a/apps/ui/components/applications/ApplicationsGroup.tsx
+++ b/apps/ui/components/applications/ApplicationsGroup.tsx
@@ -37,6 +37,11 @@ function ApplicationsGroup({
   if (roundPk == null) {
     return null;
   }
+  applications.sort((a, b) => {
+    return (
+      new Date(a.sentDate ?? 0).getTime() - new Date(b.sentDate ?? 0).getTime()
+    );
+  });
 
   return (
     <Wrapper data-testid="applications__group--wrapper">

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5584,6 +5584,7 @@ export type ApplicationsQuery = {
         pk?: number | null;
         status?: ApplicationStatusChoice | null;
         lastModifiedDate: string;
+        sentDate?: string | null;
         applicantType?: ApplicantTypeChoice | null;
         applicationRound: {
           pk?: number | null;
@@ -8921,6 +8922,7 @@ export const ApplicationsDocument = gql`
           status
           ...ApplicationName
           lastModifiedDate
+          sentDate
         }
       }
     }

--- a/apps/ui/modules/queries/application.tsx
+++ b/apps/ui/modules/queries/application.tsx
@@ -93,6 +93,7 @@ export const APPLICATIONS = gql`
           status
           ...ApplicationName
           lastModifiedDate
+          sentDate
         }
       }
     }

--- a/packages/common/src/components/Card.tsx
+++ b/packages/common/src/components/Card.tsx
@@ -260,7 +260,6 @@ const TagContainer = styled.div`
   grid-row: 1;
   order: -1;
   justify-content: flex-start;
-  margin: 0 var(--spacing-2-xs);
 
   /* display the tags on top of the image */
   .card--with-image & {
@@ -272,7 +271,7 @@ const TagContainer = styled.div`
       grid-column: 2;
       align-items: flex-start;
       justify-content: flex-end;
-      margin-top: unset;
+      margin-top: 0;
     }
   }
 `;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- adds `sentDate` to the applications query
- sorts the items in "omat hakemukset" page based on `sentDate` - within each category respectively
- also: removes the extraneous inline-margin from TagContainer, to line up the status labels with other content properly

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check that the applications are ordered by their sentDate values (the `sentDate` values for applications can be found in django)
- Check that the tags/statusLabels line up with the content properly (TagContainer shouldn't have any horizontal margins)

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3572