### PR TITLE
Fix observed bugs in applications

### DIFF
--- a/apps/ui/components/application/ViewApplication.tsx
+++ b/apps/ui/components/application/ViewApplication.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Checkbox } from "hds-react";
 import { useTranslation } from "next-i18next";
-import type {
-  ApplicationQuery,
-  Maybe,
-  TermsOfUseTextFieldsFragment,
+import {
+  type ApplicationQuery,
+  ApplicationStatusChoice,
+  type Maybe,
+  type TermsOfUseTextFieldsFragment,
 } from "@gql/gql-types";
 import { getTranslation } from "@/modules/util";
 import { ApplicantInfoPreview } from "./ApplicantInfoPreview";
@@ -34,7 +35,9 @@ export function ViewApplication({
   const { t } = useTranslation();
 
   const tos2 = application.applicationRound?.termsOfUse;
-
+  const shouldShowNotification =
+    application.status !== ApplicationStatusChoice.ResultsSent &&
+    application.status !== ApplicationStatusChoice.Draft;
   return (
     <>
       <ApplicationSection>
@@ -79,14 +82,16 @@ export function ViewApplication({
           </CheckboxContainer>
         </Accordion>
       )}
-      <div>
-        {/* Wrap the notification in a div, since HDS-notification has <section> as the root element and we need section:last-of-type to hit the last ApplicationSection */}
-        <StyledNotification
-          label={t("application:preview.notification.processing")}
-        >
-          {t("application:preview.notification.body")}
-        </StyledNotification>
-      </div>
+      {shouldShowNotification && (
+        <div>
+          {/* Wrap the notification in a div, since HDS-notification has <section> as the root element and we need section:last-of-type to hit the last ApplicationSection */}
+          <StyledNotification
+            label={t("application:preview.notification.processing")}
+          >
+            {t("application:preview.notification.body")}
+          </StyledNotification>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/ui/components/application/styled.tsx
+++ b/apps/ui/components/application/styled.tsx
@@ -51,6 +51,7 @@ export const ApplicationSectionHeader = styled.h2`
   [class*="statusLabel__"] {
     position: relative;
     transform: translateY(-4px);
+    ${fontRegular};
   }
 `;
 

--- a/apps/ui/components/applications/ApplicationCard.tsx
+++ b/apps/ui/components/applications/ApplicationCard.tsx
@@ -7,7 +7,6 @@ import {
   IconCheck,
   IconCogwheel,
   IconCross,
-  IconEnvelope,
   IconPen,
   IconQuestionCircle,
 } from "hds-react";
@@ -101,16 +100,12 @@ function getApplicationStatusLabelProps(
         type: "success",
         icon: <IconCheck aria-hidden="true" />,
       };
-    case ApplicationStatusChoice.InAllocation:
     case ApplicationStatusChoice.Handled:
+    case ApplicationStatusChoice.InAllocation:
+    case ApplicationStatusChoice.Received:
       return {
         type: "info",
         icon: <IconCogwheel aria-hidden="true" />,
-      };
-    case ApplicationStatusChoice.Received:
-      return {
-        type: "alert",
-        icon: <IconEnvelope aria-hidden="true" />,
       };
     // These two should never be shown to the client, so they are shown as any other unexpected status
     case ApplicationStatusChoice.Cancelled:

--- a/apps/ui/public/locales/fi/applicationCard.json
+++ b/apps/ui/public/locales/fi/applicationCard.json
@@ -15,7 +15,7 @@
     "EXPIRED": "Rauennut",
     "HANDLED": "Käsittelyssä",
     "IN_ALLOCATION": "Käsittelyssä",
-    "RECEIVED": "Lähetetty",
+    "RECEIVED": "Käsittelyssä",
     "RESULTS_SENT": "Käsitelty"
   },
   "reservations": "Varaukset",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fixes status labels styling, categories and translations according to the reported bugs
- the box about receiving a notification when the application is handled is no longer shown when viewing applications that are already handled
- StatusLabel font explicitly weight set to regular, so it doesn't inherit bold from event group heading

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check on my applications page that the status labels are correct (i.e. they correspond to the heading they're under)
- View an application from the second group, "Käsittelyssä", and note the blue notification box on the bottom labelled "Käsittely"
- That box should not be there when viewing applications that have the "Käsitelty" or "Luonnos" statuses
- The StatusLabel components located next to application event group headings have regular font weight

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3680
