### PR TITLE
Show only selected unit reservationUnits as options in admin search filters

### DIFF
--- a/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
+++ b/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
@@ -5,6 +5,7 @@ import {
   ReservationUnitOrderingChoices,
   useReservationUnitsFilterParamsQuery,
 } from "@gql/gql-types";
+import { useSearchParams } from "react-router-dom";
 
 export const RESERVATION_UNITS_FILTER_PARAMS_QUERY = gql`
   query ReservationUnitsFilterParams(
@@ -35,11 +36,14 @@ export const RESERVATION_UNITS_FILTER_PARAMS_QUERY = gql`
 `;
 
 export function useReservationUnitOptions() {
-  const { data, loading, fetchMore } = useReservationUnitsFilterParamsQuery({
-    variables: {
-      orderBy: [ReservationUnitOrderingChoices.NameFiAsc],
-    },
-  });
+  const [params] = useSearchParams();
+  const { data, loading, fetchMore, refetch } =
+    useReservationUnitsFilterParamsQuery({
+      variables: {
+        unit: params.getAll("unit").map(Number),
+        orderBy: [ReservationUnitOrderingChoices.NameFiAsc],
+      },
+    });
 
   // auto fetch more (there is no limit, expect number of them would be a few hundred, but in theory this might cause problems)
   // NOTE have to useEffect, onComplete stops at 200 items
@@ -53,6 +57,10 @@ export function useReservationUnitOptions() {
       });
     }
   }, [data, fetchMore]);
+
+  useEffect(() => {
+    refetch();
+  }, [params]);
 
   const resUnits = filterNonNullable(
     data?.reservationUnits?.edges.map((x) => x?.node)

--- a/apps/admin-ui/src/spa/reservations/Filters.tsx
+++ b/apps/admin-ui/src/spa/reservations/Filters.tsx
@@ -71,7 +71,9 @@ export function Filters({
   );
 
   const { options: unitOptions } = useUnitOptions();
+
   const { options: reservationUnitOptions } = useReservationUnitOptions();
+
   const recurringOptions = [
     { value: "only", label: t("filters.label.onlyRecurring") },
     { value: "onlyNot", label: t("filters.label.onlyNotRecurring") },


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- If any units are selected in the unit-filter, only reservationUnits from the selected units are shown as options in the reservation unit filter.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Go to the reservation search in the admin pages (varaustoiveet/kaikki varaukset) and check that the reservation unit filter is fully populated (since no units are selected)
- Select a unit from the unit multiselect, and check the reservation unit filter options: they only include options from the selected units

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3508
