### PR TITLE
Show only selected unit reservationUnits as options in admin search filters

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -6627,13 +6627,11 @@ export type ReservationUnitsFilterParamsQueryVariables = Exact<{
 }>;
 
 export type ReservationUnitsFilterParamsQuery = {
-  reservationUnits?: {
-    totalCount?: number | null;
-    edges: Array<{
-      node?: { id: string; nameFi?: string | null; pk?: number | null } | null;
-    } | null>;
-    pageInfo: { endCursor?: string | null; hasNextPage: boolean };
-  } | null;
+  reservationUnitsAll?: Array<{
+    id: string;
+    nameFi?: string | null;
+    pk?: number | null;
+  }> | null;
 };
 
 export type ReservationUnitTypesFilterQueryVariables = Exact<{
@@ -6654,20 +6652,17 @@ export type ReservationUnitTypesFilterQuery = {
 };
 
 export type UnitsFilterQueryVariables = Exact<{
-  after?: InputMaybe<Scalars["String"]["input"]>;
   orderBy?: InputMaybe<
     Array<InputMaybe<UnitOrderingChoices>> | InputMaybe<UnitOrderingChoices>
   >;
 }>;
 
 export type UnitsFilterQuery = {
-  units?: {
-    totalCount?: number | null;
-    edges: Array<{
-      node?: { id: string; nameFi?: string | null; pk?: number | null } | null;
-    } | null>;
-    pageInfo: { endCursor?: string | null; hasNextPage: boolean };
-  } | null;
+  unitsAll?: Array<{
+    id: string;
+    nameFi?: string | null;
+    pk?: number | null;
+  }> | null;
 };
 
 export type CurrentUserQueryVariables = Exact<{ [key: string]: never }>;
@@ -10902,28 +10897,17 @@ export type ReservationDenyReasonsQueryResult = Apollo.QueryResult<
 >;
 export const ReservationUnitsFilterParamsDocument = gql`
   query ReservationUnitsFilterParams(
-    $after: String
     $unit: [Int]
     $orderBy: [ReservationUnitOrderingChoices]
   ) {
-    reservationUnits(
-      after: $after
+    reservationUnitsAll(
       onlyWithPermission: true
       unit: $unit
       orderBy: $orderBy
     ) {
-      edges {
-        node {
-          id
-          nameFi
-          pk
-        }
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-      totalCount
+      id
+      nameFi
+      pk
     }
   }
 `;
@@ -11090,20 +11074,11 @@ export type ReservationUnitTypesFilterQueryResult = Apollo.QueryResult<
   ReservationUnitTypesFilterQueryVariables
 >;
 export const UnitsFilterDocument = gql`
-  query UnitsFilter($after: String, $orderBy: [UnitOrderingChoices]) {
-    units(onlyWithPermission: true, after: $after, orderBy: $orderBy) {
-      edges {
-        node {
-          id
-          nameFi
-          pk
-        }
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-      totalCount
+  query UnitsFilter($orderBy: [UnitOrderingChoices]) {
+    unitsAll(onlyWithPermission: true, orderBy: $orderBy) {
+      id
+      nameFi
+      pk
     }
   }
 `;

--- a/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
+++ b/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
@@ -5,6 +5,7 @@ import {
   ReservationUnitOrderingChoices,
   useReservationUnitsFilterParamsQuery,
 } from "@gql/gql-types";
+import { useSearchParams } from "react-router-dom";
 
 export const RESERVATION_UNITS_FILTER_PARAMS_QUERY = gql`
   query ReservationUnitsFilterParams(
@@ -35,11 +36,14 @@ export const RESERVATION_UNITS_FILTER_PARAMS_QUERY = gql`
 `;
 
 export function useReservationUnitOptions() {
-  const { data, loading, fetchMore } = useReservationUnitsFilterParamsQuery({
-    variables: {
-      orderBy: [ReservationUnitOrderingChoices.NameFiAsc],
-    },
-  });
+  const [params] = useSearchParams();
+  const { data, loading, fetchMore, refetch } =
+    useReservationUnitsFilterParamsQuery({
+      variables: {
+        unit: params.getAll("unit").map(Number),
+        orderBy: [ReservationUnitOrderingChoices.NameFiAsc],
+      },
+    });
 
   // auto fetch more (there is no limit, expect number of them would be a few hundred, but in theory this might cause problems)
   // NOTE have to useEffect, onComplete stops at 200 items
@@ -53,6 +57,10 @@ export function useReservationUnitOptions() {
       });
     }
   }, [data, fetchMore]);
+
+  useEffect(() => {
+    refetch();
+  }, [params]);
 
   const resUnits = filterNonNullable(
     data?.reservationUnits?.edges.map((x) => x?.node)

--- a/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
+++ b/apps/admin-ui/src/hooks/useReservationUnitOptions.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { gql } from "@apollo/client";
 import { filterNonNullable } from "common/src/helpers";
 import {
@@ -9,67 +8,36 @@ import { useSearchParams } from "react-router-dom";
 
 export const RESERVATION_UNITS_FILTER_PARAMS_QUERY = gql`
   query ReservationUnitsFilterParams(
-    $after: String
     $unit: [Int]
     $orderBy: [ReservationUnitOrderingChoices]
   ) {
-    reservationUnits(
-      after: $after
+    reservationUnitsAll(
       onlyWithPermission: true
       unit: $unit
       orderBy: $orderBy
     ) {
-      edges {
-        node {
-          id
-          nameFi
-          pk
-        }
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-      totalCount
+      id
+      nameFi
+      pk
     }
   }
 `;
 
 export function useReservationUnitOptions() {
   const [params] = useSearchParams();
-  const { data, loading, fetchMore, refetch } =
-    useReservationUnitsFilterParamsQuery({
-      variables: {
-        unit: params.getAll("unit").map(Number),
-        orderBy: [ReservationUnitOrderingChoices.NameFiAsc],
-      },
-    });
+  const { data, loading } = useReservationUnitsFilterParamsQuery({
+    variables: {
+      unit: params.getAll("unit").map(Number).filter(Number.isFinite),
+      orderBy: [ReservationUnitOrderingChoices.NameFiAsc],
+    },
+  });
 
-  // auto fetch more (there is no limit, expect number of them would be a few hundred, but in theory this might cause problems)
-  // NOTE have to useEffect, onComplete stops at 200 items
-  useEffect(() => {
-    const { pageInfo } = data?.reservationUnits ?? {};
-    if (pageInfo?.hasNextPage) {
-      fetchMore({
-        variables: {
-          after: pageInfo.endCursor,
-        },
-      });
-    }
-  }, [data, fetchMore]);
-
-  useEffect(() => {
-    refetch();
-  }, [params]);
-
-  const resUnits = filterNonNullable(
-    data?.reservationUnits?.edges.map((x) => x?.node)
+  const options = filterNonNullable(data?.reservationUnitsAll).map(
+    (reservationUnit) => ({
+      label: reservationUnit?.nameFi ?? "",
+      value: reservationUnit?.pk ?? 0,
+    })
   );
-
-  const options = resUnits.map((reservationUnit) => ({
-    label: reservationUnit?.nameFi ?? "",
-    value: reservationUnit?.pk ?? 0,
-  }));
 
   return { options, loading };
 }

--- a/apps/admin-ui/src/hooks/useUnitOptions.tsx
+++ b/apps/admin-ui/src/hooks/useUnitOptions.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { gql } from "@apollo/client";
 import { filterNonNullable } from "common/src/helpers";
 import { UnitOrderingChoices, useUnitsFilterQuery } from "@gql/gql-types";
@@ -6,47 +5,23 @@ import { UnitOrderingChoices, useUnitsFilterQuery } from "@gql/gql-types";
 // exporting so it doesn't get removed
 // TODO combine with other options queries so we only make a single request for all of them
 export const UNITS_QUERY = gql`
-  query UnitsFilter($after: String, $orderBy: [UnitOrderingChoices]) {
-    units(onlyWithPermission: true, after: $after, orderBy: $orderBy) {
-      edges {
-        node {
-          id
-          nameFi
-          pk
-        }
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-      totalCount
+  query UnitsFilter($orderBy: [UnitOrderingChoices]) {
+    unitsAll(onlyWithPermission: true, orderBy: $orderBy) {
+      id
+      nameFi
+      pk
     }
   }
 `;
 
 export function useUnitOptions() {
-  const { data, loading, fetchMore } = useUnitsFilterQuery({
+  const { data, loading } = useUnitsFilterQuery({
     variables: {
       orderBy: [UnitOrderingChoices.NameFiAsc],
     },
   });
 
-  // auto fetch more (there is no limit, expect number of them would be a few hundred, but in theory this might cause problems)
-  // NOTE have to useEffect, onComplete stops at 200 items
-  useEffect(() => {
-    const { pageInfo } = data?.units ?? {};
-    if (pageInfo?.hasNextPage) {
-      fetchMore({
-        variables: {
-          after: pageInfo.endCursor,
-        },
-      });
-    }
-  }, [data, fetchMore]);
-
-  const units = filterNonNullable(data?.units?.edges.map((x) => x?.node));
-
-  const options = units.map((unit) => ({
+  const options = filterNonNullable(data?.unitsAll).map((unit) => ({
     label: unit?.nameFi ?? "",
     value: unit?.pk ?? 0,
   }));

--- a/apps/admin-ui/src/spa/reservations/Filters.tsx
+++ b/apps/admin-ui/src/spa/reservations/Filters.tsx
@@ -71,7 +71,9 @@ export function Filters({
   );
 
   const { options: unitOptions } = useUnitOptions();
+
   const { options: reservationUnitOptions } = useReservationUnitOptions();
+
   const recurringOptions = [
     { value: "only", label: t("filters.label.onlyRecurring") },
     { value: "onlyNot", label: t("filters.label.onlyNotRecurring") },


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- The unit filter and reservation unit filter use the new pageless endpoints when querying for options, so any automatic `fetchMore`s etc are unnecessary even if there's over 100 results
- If any units are selected in the unit-filter, only reservationUnits from the selected units are shown as options in the reservation unit filter.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- The admin page search filters now shows over 100 options if necessary (in practice only unit and reservation unit, but the others are unlikely to have over 100 entries)
- Go to the reservation search in the admin pages (varaustoiveet/kaikki varaukset) and check that the reservation unit filter is fully populated (since no units are selected)
- Select a unit from the unit multiselect, and check the reservation unit filter options: they only include options from the selected units

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3508, TILA-3627
