### PR TITLE
Fix check access on page load

### DIFF
--- a/apps/ui/pages/applications/index.tsx
+++ b/apps/ui/pages/applications/index.tsx
@@ -38,6 +38,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const commonProps = getCommonServerSideProps();
   const client = createApolloClient(commonProps.apiBaseUrl, ctx);
 
+  // NOTE have to be done with double query because applications returns everything the user has access to (not what he owns)
   const { data: userData } = await client.query<CurrentUserQuery>({
     query: CurrentUserDocument,
   });

--- a/apps/ui/pages/reservations/[id]/cancel.tsx
+++ b/apps/ui/pages/reservations/[id]/cancel.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { GetServerSidePropsContext } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import {
-  CurrentUserQuery,
   ReservationCancelReasonsDocument,
   type ReservationCancelReasonsQuery,
   type ReservationCancelReasonsQueryVariables,
@@ -15,7 +14,6 @@ import { getCommonServerSideProps } from "@/modules/serverUtils";
 import { createApolloClient } from "@/modules/apolloClient";
 import { base64encode, filterNonNullable } from "common/src/helpers";
 import { isReservationCancellable } from "@/modules/reservation";
-import { CURRENT_USER } from "@/modules/queries/user";
 import { getReservationPath } from "@/modules/urls";
 
 type PropsNarrowed = Exclude<Props, { notFound: boolean }>;
@@ -47,12 +45,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     });
     const { reservation } = reservationData || {};
 
-    const { data: userData } = await client.query<CurrentUserQuery>({
-      query: CURRENT_USER,
-      fetchPolicy: "no-cache",
-    });
-    const user = userData?.currentUser;
-
     const { data: cancelReasonsData } = await client.query<
       ReservationCancelReasonsQuery,
       ReservationCancelReasonsQueryVariables
@@ -67,16 +59,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       )
     );
 
-    if (reservation?.user?.pk !== user?.pk) {
-      return {
-        notFound: true,
-        props: {
-          notFound: true,
-          ...commonProps,
-          ...(await serverSideTranslations(locale ?? "fi")),
-        },
-      };
-    }
     const canCancel =
       reservation != null && isReservationCancellable(reservation);
     if (canCancel) {

--- a/apps/ui/pages/reservations/[id]/confirmation.tsx
+++ b/apps/ui/pages/reservations/[id]/confirmation.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  CurrentUserQuery,
   ReservationDocument,
   type ReservationQuery,
   type ReservationQueryVariables,
@@ -18,7 +17,6 @@ import { getCommonServerSideProps } from "@/modules/serverUtils";
 import { base64encode } from "common/src/helpers";
 import { CenterSpinner } from "@/components/common/common";
 import Error from "next/error";
-import { CURRENT_USER } from "@/modules/queries/user";
 import { createApolloClient } from "@/modules/apolloClient";
 
 // TODO styles are copies from [...params].tsx
@@ -118,13 +116,7 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
     });
     const { reservation } = reservationData || {};
 
-    const { data: userData } = await client.query<CurrentUserQuery>({
-      query: CURRENT_USER,
-      fetchPolicy: "no-cache",
-    });
-    const user = userData?.currentUser;
-
-    if (user != null && user.pk === reservation?.user?.pk) {
+    if (reservation) {
       return {
         props: {
           ...getCommonServerSideProps(),

--- a/apps/ui/pages/reservations/[id]/edit.tsx
+++ b/apps/ui/pages/reservations/[id]/edit.tsx
@@ -12,7 +12,6 @@ import {
   ReservationDocument,
   type ReservationQuery,
   type ReservationQueryVariables,
-  type CurrentUserQuery,
   type Mutation,
   type MutationAdjustReservationTimeArgs,
   useAdjustReservationTimeMutation,
@@ -21,7 +20,6 @@ import { base64encode, filterNonNullable } from "common/src/helpers";
 import { toApiDate } from "common/src/common/util";
 import { addYears } from "date-fns";
 import { RELATED_RESERVATION_STATES } from "common/src/const";
-import { CURRENT_USER } from "@/modules/queries/user";
 import { type FetchResult } from "@apollo/client";
 import { useRouter } from "next/router";
 import { StepState, Stepper } from "hds-react";
@@ -289,12 +287,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     });
     const { reservationUnit } = reservationUnitData;
 
-    const { data: userData } = await client.query<CurrentUserQuery>({
-      query: CURRENT_USER,
-      fetchPolicy: "no-cache",
-    });
-    const user = userData?.currentUser;
-
     const options = await queryOptions(client, locale ?? "");
 
     const timespans = filterNonNullable(reservationUnit?.reservableTimeSpans);
@@ -302,11 +294,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       reservationUnitData?.affectingReservations
     );
 
-    if (
-      reservation != null &&
-      reservationUnit != null &&
-      reservation.user?.pk === user?.pk
-    ) {
+    if (reservation != null && reservationUnit != null) {
       return {
         props: {
           ...commonProps,

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -21,8 +21,6 @@ import {
   ReservationDocument,
   type ReservationQuery,
   type ReservationQueryVariables,
-  CurrentUserDocument,
-  type CurrentUserQuery,
   OrderStatus,
 } from "@gql/gql-types";
 import Link from "next/link";
@@ -647,7 +645,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
     // NOTE errors will fallback to 404
     const id = base64encode(`ReservationNode:${pk}`);
-    const { data, error } = await apolloClient.query<
+    const { data } = await apolloClient.query<
       ReservationQuery,
       ReservationQueryVariables
     >({
@@ -656,24 +654,8 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       variables: { id },
     });
 
-    const { data: userData } = await apolloClient.query<CurrentUserQuery>({
-      query: CurrentUserDocument,
-      fetchPolicy: "no-cache",
-    });
-    const user = userData?.currentUser;
-
-    if (error) {
-      // eslint-disable-next-line no-console
-      console.error("Error while fetching reservation", error);
-    }
-
     const { reservation } = data ?? {};
-    // Return 404 for unauthorized access
-    if (
-      reservation != null &&
-      user != null &&
-      reservation.user?.pk === user.pk
-    ) {
+    if (reservation != null) {
       return {
         props: {
           ...commonProps,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: block seeing other users applications in `customer` application (url access) even if the user has access to the data.
- Refactor: replace per page checks from reservations with middleware so any pages under `/reservations` path will always be protected with same rules.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: in the `customer` app users with `admin` (or other roles with access) are blocked seeing other users reservations and applications (similar to regular users) and receive 404 error. This works for all paths related to reservations and applications (i.e. user specific data).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3426](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3426)


[TILA-3426]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ