### PR TITLE
fix: remove prefetch from calendar link

### DIFF
--- a/apps/ui/components/common/ButtonLikeLink.tsx
+++ b/apps/ui/components/common/ButtonLikeLink.tsx
@@ -12,3 +12,9 @@ export const ButtonLikeLink = styled(Link)<ButtonStyleProps>`
   ${fontMedium}
   gap: var(--spacing-s);
 `;
+
+export const ButtonLikeExternalLink = styled.a<ButtonStyleProps>`
+  ${ButtonCss}
+  ${fontMedium}
+  gap: var(--spacing-s);
+`;

--- a/apps/ui/components/reservation/ReservationConfirmation.tsx
+++ b/apps/ui/components/reservation/ReservationConfirmation.tsx
@@ -22,7 +22,7 @@ import { getReservationUnitInstructionsKey } from "@/modules/reservationUnit";
 import { getTranslation } from "@/modules/util";
 import { BlackButton } from "@/styles/util";
 import { Paragraph } from "./styles";
-import { ButtonLikeLink } from "../common/ButtonLikeLink";
+import { ButtonLikeExternalLink } from "../common/ButtonLikeLink";
 import { getReservationUnitPath, reservationsPath } from "@/modules/urls";
 
 type Node = NonNullable<ReservationQuery["reservation"]>;
@@ -140,16 +140,15 @@ function ReservationConfirmation({
       </Paragraph>
       {reservation.state === ReservationStateChoice.Confirmed && (
         <ActionContainer1 style={{ marginBottom: "var(--spacing-2-xl)" }}>
-          <ButtonLikeLink
+          <ButtonLikeExternalLink
             size="large"
             disabled={!reservation.calendarUrl}
             data-testid="reservation__confirmation--button__calendar-url"
             href={reservation.calendarUrl ?? ""}
-            locale={false}
           >
             {t("reservations:saveToCalendar")}
             <IconCalendar aria-hidden />
-          </ButtonLikeLink>
+          </ButtonLikeExternalLink>
           {order?.receiptUrl && (
             <BlackButton
               data-testid="reservation__confirmation--button__receipt-link"

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -57,7 +57,10 @@ import {
 import { base64encode, filterNonNullable } from "common/src/helpers";
 import { containsField, containsNameField } from "common/src/metaFieldsHelpers";
 import { NotModifiableReason } from "@/components/reservation/NotModifiableReason";
-import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
+import {
+  ButtonLikeLink,
+  ButtonLikeExternalLink,
+} from "@/components/common/ButtonLikeLink";
 import { useRouter } from "next/router";
 import { successToast } from "common/src/common/toast";
 import { ReservationPageWrapper } from "@/components/reservations/styles";
@@ -476,16 +479,15 @@ function Reservation({
             <ReservationInfoCard reservation={reservation} type="complete" />
             <SecondaryActions>
               {reservation.state === ReservationStateChoice.Confirmed && (
-                <ButtonLikeLink
+                <ButtonLikeExternalLink
                   size="large"
                   disabled={!reservation.calendarUrl}
                   data-testid="reservation__button--calendar-link"
                   href={reservation.calendarUrl ?? ""}
-                  locale={false}
                 >
                   {t("reservations:saveToCalendar")}
                   <IconCalendar aria-hidden />
-                </ButtonLikeLink>
+                </ButtonLikeExternalLink>
               )}
               {hasReceipt && (
                 <ButtonLikeLink


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1493
- Fix: don't do prefetch requests on api endpoint calendarUrl. Replaces `next/link` with `<a>` to disable prefetch completely.
- Fix: issue that user language would be set Finnish always on reservation and confirmation pages.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: language saving (other than FI).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
