### PR TITLE
fix: dont show profile link if ad user

### DIFF
--- a/apps/ui/components/common/Navigation.tsx
+++ b/apps/ui/components/common/Navigation.tsx
@@ -214,10 +214,12 @@ function ActionBar({ apiBaseUrl, profileLink, languageOptions }: HeaderProps) {
           label={userName ?? ""}
           icon={<IconUser />}
         >
-          <a href={profileLink} target="_blank" rel="noopener norreferrer">
-            {t("navigation:profileLinkLabel")}
-            <IconLinkExternal />
-          </a>
+          {!user?.isAdAuthenticated && (
+            <a href={profileLink} target="_blank" rel="noopener norreferrer">
+              {t("navigation:profileLinkLabel")}
+              <IconLinkExternal />
+            </a>
+          )}
           <button
             type="button"
             aria-label={t("common:logout")}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: don't show profile link for ad users (only suomi.fi).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: both ad and suomi.fi users `customer` app, link should be visible only for suomi.fi logins.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3577](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3577)


[TILA-3577]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ