### PR TITLE
Sort reservationPurposes by rank (admin)

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -7739,7 +7739,12 @@ export type CreateStaffReservationMutation = {
   createStaffReservation?: { pk?: number | null } | null;
 };
 
-export type OptionsQueryVariables = Exact<{ [key: string]: never }>;
+export type OptionsQueryVariables = Exact<{
+  reservationPurposesOrderBy?: InputMaybe<
+    | Array<InputMaybe<ReservationPurposeOrderingChoices>>
+    | InputMaybe<ReservationPurposeOrderingChoices>
+  >;
+}>;
 
 export type OptionsQuery = {
   reservationPurposes?: {
@@ -13703,8 +13708,10 @@ export type CreateStaffReservationMutationOptions = Apollo.BaseMutationOptions<
   CreateStaffReservationMutationVariables
 >;
 export const OptionsDocument = gql`
-  query Options {
-    reservationPurposes {
+  query Options(
+    $reservationPurposesOrderBy: [ReservationPurposeOrderingChoices]
+  ) {
+    reservationPurposes(orderBy: $reservationPurposesOrderBy) {
       edges {
         node {
           id
@@ -13747,6 +13754,7 @@ export const OptionsDocument = gql`
  * @example
  * const { data, loading, error } = useOptionsQuery({
  *   variables: {
+ *      reservationPurposesOrderBy: // value for 'reservationPurposesOrderBy'
  *   },
  * });
  */

--- a/apps/admin-ui/src/hooks/useOptions.tsx
+++ b/apps/admin-ui/src/hooks/useOptions.tsx
@@ -1,12 +1,19 @@
 import { sortBy } from "lodash";
-import { useOptionsQuery } from "@gql/gql-types";
+import {
+  ReservationPurposeOrderingChoices,
+  useOptionsQuery,
+} from "@gql/gql-types";
+import { filterNonNullable } from "common/src/helpers";
 
 export function useOptions() {
-  const { data: optionsData } = useOptionsQuery();
+  const { data: optionsData } = useOptionsQuery({
+    variables: {
+      reservationPurposesOrderBy: [ReservationPurposeOrderingChoices.RankAsc],
+    },
+  });
 
-  const purpose = sortBy(
-    optionsData?.reservationPurposes?.edges || [],
-    "node.nameFi"
+  const purpose = filterNonNullable(
+    optionsData?.reservationPurposes?.edges
   ).map((purposeType) => ({
     label: purposeType?.node?.nameFi ?? "",
     value: Number(purposeType?.node?.pk),

--- a/apps/admin-ui/src/spa/my-units/[id]/hooks/queries.tsx
+++ b/apps/admin-ui/src/spa/my-units/[id]/hooks/queries.tsx
@@ -6,8 +6,10 @@ import {
 import { LOCATION_FRAGMENT } from "common/src/queries/fragments";
 
 export const OPTIONS_QUERY = gql`
-  query Options {
-    reservationPurposes {
+  query Options(
+    $reservationPurposesOrderBy: [ReservationPurposeOrderingChoices]
+  ) {
+    reservationPurposes(orderBy: $reservationPurposesOrderBy) {
       edges {
         node {
           id


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Sort reservationPurposes by rank in the admin view
- Client pages have this same change as part of `search-filters-fixes-client` in #1553

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check from the "Varaustarkoitukset" list that the order corresponds to the one in the "Käyttötarkoitus"-select, when making a reservation. To make sure you can edit some ranks, and see that the changes are reflected in the order of options.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3554
