### PR TITLE
Fix dropdown options for client

### DIFF
--- a/apps/ui/components/application/Page1.tsx
+++ b/apps/ui/components/application/Page1.tsx
@@ -34,7 +34,7 @@ export function Page1({ applicationRound, onNext }: Props): JSX.Element | null {
   );
   const unitsInApplicationRound = filterNonNullable(uniq(resUnitPks));
   const { data } = useSearchFormParamsUnitQuery();
-  const units = filterNonNullable(data?.units?.edges?.map((e) => e?.node))
+  const units = filterNonNullable(data?.unitsAll)
     .filter((u) => u.pk != null && unitsInApplicationRound.includes(u.pk))
     .map((u) => ({
       pk: u.pk ?? 0,

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -2416,8 +2416,12 @@ export type QueryUnitsAllArgs = {
   nameSv?: InputMaybe<Scalars["String"]["input"]>;
   nameSv_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameSv_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
+  onlyDirectBookable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  onlySeasonalBookable?: InputMaybe<Scalars["Boolean"]["input"]>;
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<UnitOrderingChoices>>>;
+  ownReservations?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedReservationUnits?: InputMaybe<Scalars["Boolean"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
 };
 
@@ -5317,7 +5321,27 @@ export type ReservationInfoCardFragment = {
   }>;
 };
 
-export type OptionsQueryVariables = Exact<{ [key: string]: never }>;
+export type OptionsQueryVariables = Exact<{
+  reservationUnitTypesOrderBy?: InputMaybe<
+    | Array<InputMaybe<ReservationUnitTypeOrderingChoices>>
+    | InputMaybe<ReservationUnitTypeOrderingChoices>
+  >;
+  purposesOrderBy?: InputMaybe<
+    | Array<InputMaybe<PurposeOrderingChoices>>
+    | InputMaybe<PurposeOrderingChoices>
+  >;
+  unitsOrderBy?: InputMaybe<
+    Array<InputMaybe<UnitOrderingChoices>> | InputMaybe<UnitOrderingChoices>
+  >;
+  equipmentsOrderBy?: InputMaybe<
+    | Array<InputMaybe<EquipmentOrderingChoices>>
+    | InputMaybe<EquipmentOrderingChoices>
+  >;
+  reservationPurposesOrderBy?: InputMaybe<
+    | Array<InputMaybe<ReservationPurposeOrderingChoices>>
+    | InputMaybe<ReservationPurposeOrderingChoices>
+  >;
+}>;
 
 export type OptionsQuery = {
   reservationUnitTypes?: {
@@ -5374,17 +5398,20 @@ export type OptionsQuery = {
       } | null;
     } | null>;
   } | null;
-  equipments?: {
-    edges: Array<{
-      node?: {
-        id: string;
-        pk?: number | null;
-        nameFi?: string | null;
-        nameEn?: string | null;
-        nameSv?: string | null;
-      } | null;
-    } | null>;
-  } | null;
+  equipmentsAll?: Array<{
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
+  }> | null;
+  unitsAll?: Array<{
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameSv?: string | null;
+    nameEn?: string | null;
+  }> | null;
 };
 
 export type ApplicationSectionReservationFragment = {
@@ -5991,17 +6018,13 @@ export type SearchFormParamsUnitQueryVariables = Exact<{
 }>;
 
 export type SearchFormParamsUnitQuery = {
-  units?: {
-    edges: Array<{
-      node?: {
-        id: string;
-        pk?: number | null;
-        nameFi?: string | null;
-        nameEn?: string | null;
-        nameSv?: string | null;
-      } | null;
-    } | null>;
-  } | null;
+  unitsAll?: Array<{
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
+  }> | null;
 };
 
 export type ReservationUnitPurposesQueryVariables = Exact<{
@@ -8650,8 +8673,14 @@ export const BannerNotificationCommonFragmentDoc = gql`
   }
 `;
 export const OptionsDocument = gql`
-  query Options {
-    reservationUnitTypes {
+  query Options(
+    $reservationUnitTypesOrderBy: [ReservationUnitTypeOrderingChoices]
+    $purposesOrderBy: [PurposeOrderingChoices]
+    $unitsOrderBy: [UnitOrderingChoices]
+    $equipmentsOrderBy: [EquipmentOrderingChoices]
+    $reservationPurposesOrderBy: [ReservationPurposeOrderingChoices]
+  ) {
+    reservationUnitTypes(orderBy: $reservationUnitTypesOrderBy) {
       edges {
         node {
           id
@@ -8662,7 +8691,7 @@ export const OptionsDocument = gql`
         }
       }
     }
-    purposes {
+    purposes(orderBy: $purposesOrderBy) {
       edges {
         node {
           id
@@ -8673,7 +8702,7 @@ export const OptionsDocument = gql`
         }
       }
     }
-    reservationPurposes {
+    reservationPurposes(orderBy: $reservationPurposesOrderBy) {
       edges {
         node {
           id
@@ -8705,16 +8734,19 @@ export const OptionsDocument = gql`
         }
       }
     }
-    equipments {
-      edges {
-        node {
-          id
-          pk
-          nameFi
-          nameEn
-          nameSv
-        }
-      }
+    equipmentsAll(orderBy: $equipmentsOrderBy) {
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
+    }
+    unitsAll(orderBy: $unitsOrderBy) {
+      id
+      pk
+      nameFi
+      nameSv
+      nameEn
     }
   }
 `;
@@ -8731,6 +8763,11 @@ export const OptionsDocument = gql`
  * @example
  * const { data, loading, error } = useOptionsQuery({
  *   variables: {
+ *      reservationUnitTypesOrderBy: // value for 'reservationUnitTypesOrderBy'
+ *      purposesOrderBy: // value for 'purposesOrderBy'
+ *      unitsOrderBy: // value for 'unitsOrderBy'
+ *      equipmentsOrderBy: // value for 'equipmentsOrderBy'
+ *      reservationPurposesOrderBy: // value for 'reservationPurposesOrderBy'
  *   },
  * });
  */
@@ -9443,22 +9480,18 @@ export const SearchFormParamsUnitDocument = gql`
     $onlySeasonalBookable: Boolean
     $orderBy: [UnitOrderingChoices]
   ) {
-    units(
+    unitsAll(
       publishedReservationUnits: $publishedReservationUnits
       ownReservations: $ownReservations
       onlyDirectBookable: $onlyDirectBookable
       onlySeasonalBookable: $onlySeasonalBookable
       orderBy: $orderBy
     ) {
-      edges {
-        node {
-          id
-          pk
-          nameFi
-          nameEn
-          nameSv
-        }
-      }
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
     }
   }
 `;

--- a/apps/ui/modules/queries/params.tsx
+++ b/apps/ui/modules/queries/params.tsx
@@ -8,22 +8,18 @@ export const SEARCH_FORM_PARAMS_UNIT = gql`
     $onlySeasonalBookable: Boolean
     $orderBy: [UnitOrderingChoices]
   ) {
-    units(
+    unitsAll(
       publishedReservationUnits: $publishedReservationUnits
       ownReservations: $ownReservations
       onlyDirectBookable: $onlyDirectBookable
       onlySeasonalBookable: $onlySeasonalBookable
       orderBy: $orderBy
     ) {
-      edges {
-        node {
-          id
-          pk
-          nameFi
-          nameEn
-          nameSv
-        }
-      }
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
     }
   }
 `;

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -11,8 +11,12 @@ import {
   ReservationUnitOrderingChoices,
   type OptionsQuery,
   OptionsDocument,
-  type SearchFormParamsUnitQueryVariables,
-  type SearchFormParamsUnitQuery,
+  EquipmentOrderingChoices,
+  UnitOrderingChoices,
+  ReservationUnitTypeOrderingChoices,
+  PurposeOrderingChoices,
+  SearchFormParamsUnitQuery,
+  SearchFormParamsUnitQueryVariables,
   SearchFormParamsUnitDocument,
 } from "@gql/gql-types";
 import { filterNonNullable } from "common/src/helpers";
@@ -297,16 +301,21 @@ export async function getSearchOptions(
   const lang = convertLanguageCode(locale ?? "");
   const { data: optionsData } = await apolloClient.query<OptionsQuery>({
     query: OptionsDocument,
+    variables: {
+      reservationUnitTypesOrderBy: ReservationUnitTypeOrderingChoices.RankAsc,
+      purposesOrderBy: PurposeOrderingChoices.RankAsc,
+      unitsOrderBy: UnitOrderingChoices.NameFiAsc,
+      equipmentsOrderBy: EquipmentOrderingChoices.CategoryRankAsc,
+    },
   });
+
   const reservationUnitTypes = filterNonNullable(
     optionsData?.reservationUnitTypes?.edges?.map((edge) => edge?.node)
   );
   const purposes = filterNonNullable(
     optionsData?.purposes?.edges?.map((edge) => edge?.node)
   );
-  const equipments = filterNonNullable(
-    optionsData?.equipments?.edges?.map((edge) => edge?.node)
-  );
+  const equipments = filterNonNullable(optionsData?.equipmentsAll);
 
   const reservationUnitTypeOptions = reservationUnitTypes.map((n) => ({
     value: n.pk ?? 0,
@@ -320,7 +329,6 @@ export async function getSearchOptions(
     value: n.pk ?? 0,
     label: getTranslationSafe(n, "name", lang),
   }));
-
   const { data: unitData } = await apolloClient.query<
     SearchFormParamsUnitQuery,
     SearchFormParamsUnitQueryVariables
@@ -332,9 +340,7 @@ export async function getSearchOptions(
       ...(page === "seasonal" ? { onlySeasonalBookable: true } : {}),
     },
   });
-  const unitOptions = filterNonNullable(
-    unitData?.units?.edges?.map((e) => e?.node)
-  ).map((node) => ({
+  const unitOptions = filterNonNullable(unitData?.unitsAll).map((node) => ({
     value: node.pk ?? 0,
     label: getTranslationSafe(node, "name", lang),
   }));

--- a/apps/ui/pages/index.tsx
+++ b/apps/ui/pages/index.tsx
@@ -67,9 +67,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       orderBy: [UnitOrderingChoices.RankAsc],
     },
   });
-  const units = filterNonNullable(
-    unitData?.units?.edges?.map((edge) => edge?.node)
-  );
+  const units = filterNonNullable(unitData?.unitsAll);
 
   return {
     props: {

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -2416,8 +2416,12 @@ export type QueryUnitsAllArgs = {
   nameSv?: InputMaybe<Scalars["String"]["input"]>;
   nameSv_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameSv_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
+  onlyDirectBookable?: InputMaybe<Scalars["Boolean"]["input"]>;
+  onlySeasonalBookable?: InputMaybe<Scalars["Boolean"]["input"]>;
   onlyWithPermission?: InputMaybe<Scalars["Boolean"]["input"]>;
   orderBy?: InputMaybe<Array<InputMaybe<UnitOrderingChoices>>>;
+  ownReservations?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedReservationUnits?: InputMaybe<Scalars["Boolean"]["input"]>;
   unit?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
 };
 

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -2570,11 +2570,15 @@ type Query {
     nameSv: String
     nameSv_Icontains: String
     nameSv_Istartswith: String
+    onlyDirectBookable: Boolean
+    onlySeasonalBookable: Boolean
     onlyWithPermission: Boolean
     """
     Järjestä
     """
     orderBy: [UnitOrderingChoices]
+    ownReservations: Boolean
+    publishedReservationUnits: Boolean
     unit: [Int]
   ): [UnitAllNode!]
   user(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Uses the non-paged endpoints for units and equipment filter options
- Fixes the sorting of options on the search page filters in client view as follows:
  - *purpose:* by rank
  - *unit:* by name
  - *equipments:* by equipments category rank
  - *reservation type:* by rank
- Sorts the reservation purpose options by rank, when making a reservation on client side

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check corresponding name/rank value from Django, and see that the options in respective select-inputs are in the same order on the search page
- Do the same for reservation purposes

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3541
- TILA-3553