### PR TITLE
Fix rejected occurrences tab sorting and pagination

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -6950,6 +6950,7 @@ export type RejectedOccurrencesQueryVariables = Exact<{
 
 export type RejectedOccurrencesQuery = {
   rejectedOccurrences?: {
+    totalCount?: number | null;
     pageInfo: { hasNextPage: boolean; endCursor?: string | null };
     edges: Array<{
       node?: {
@@ -12320,6 +12321,7 @@ export const RejectedOccurrencesDocument = gql`
         hasNextPage
         endCursor
       }
+      totalCount
       edges {
         node {
           id

--- a/apps/admin-ui/src/common/apolloClient.ts
+++ b/apps/admin-ui/src/common/apolloClient.ts
@@ -73,6 +73,7 @@ function createClient(apiBaseUrl: string) {
             applicationSections: relayStylePagination(),
             allocatedTimeSlots: relayStylePagination(),
             bannerNotifications: relayStylePagination(),
+            rejectedOccurrences: relayStylePagination(),
           },
         },
       },

--- a/apps/admin-ui/src/spa/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
@@ -16,6 +16,7 @@ import { filterNonNullable } from "common/src/helpers";
 import { getPermissionErrors } from "common/src/apolloUtils";
 import { useTranslation } from "next-i18next";
 import { getFilteredUnits } from "./utils";
+import { LIST_PAGE_SIZE } from "@/common/const";
 import { CenterSpinner } from "common/styles/util";
 
 type Props = {
@@ -38,6 +39,7 @@ function RejectedOccurrencesDataLoader({
   const { data, previousData, loading, fetchMore } =
     useRejectedOccurrencesQuery({
       variables: {
+        first: LIST_PAGE_SIZE,
         applicationRound: applicationRoundPk,
         unit: getFilteredUnits(unitFilter, unitOptions),
         reservationUnit: reservationUnitFilter
@@ -115,10 +117,14 @@ function transformOrderBy(
       return desc
         ? [RejectedOccurrenceOrderingChoices.ApplicationSectionNameDesc]
         : [RejectedOccurrenceOrderingChoices.ApplicationSectionNameAsc];
+    case "rejected_unit_name_fi":
+      return desc
+        ? [RejectedOccurrenceOrderingChoices.UnitNameDesc]
+        : [RejectedOccurrenceOrderingChoices.UnitNameAsc];
     case "rejected_reservation_unit_name_fi":
       return desc
-        ? [RejectedOccurrenceOrderingChoices.ReservationUnitPkDesc]
-        : [RejectedOccurrenceOrderingChoices.ReservationUnitPkAsc];
+        ? [RejectedOccurrenceOrderingChoices.ReservationUnitNameDesc]
+        : [RejectedOccurrenceOrderingChoices.ReservationUnitNameAsc];
     case "time_of_occurrence":
       return desc
         ? [RejectedOccurrenceOrderingChoices.BeginDatetimeDesc]

--- a/apps/admin-ui/src/spa/application-rounds/[id]/review/RejectedOccurrencesTable.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/review/RejectedOccurrencesTable.tsx
@@ -161,7 +161,7 @@ export function RejectedOccurrencesTable({
   isLoading,
   sort,
   sortChanged: onSortChanged,
-}: Props) {
+}: Readonly<Props>) {
   const { t } = useTranslation();
 
   const rows = rejectedOccurrences.map((ro) => timeSlotMapper(t, ro));


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes the sorting and pagination of the rejected occurrences listing, shown in a tab under a handled application round which resulted in rejected occurrences

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Sorting by unit name and reservation unit name should now work (along with all the other sorting options)
- Check that the pagination works:
  - If you have an application round which has resulted in over 50 rejected occurrences you can test it by viewing that application round
  - Otherwise: you need to have an application round which has resulted in at least a few rejected occurrences to be able to test this. To avoid having to create over 50 rejected occurrences you can use any smaller value instead of `LIST_PAGE_SIZE` on line `42` in `apps/admin-ui/src/spa/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx`. This defines the page size to be used in the listing, making testing pagination possible even with a smaller total count.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3446
