### PR TITLE
Fix data testids

### DIFF
--- a/apps/ui/components/common/ListWithPagination.tsx
+++ b/apps/ui/components/common/ListWithPagination.tsx
@@ -53,7 +53,7 @@ function Content({
               <Button
                 onClick={fetchMore}
                 variant="secondary"
-                data-test-id="list-with-pagination__button--paginate"
+                data-testid="list-with-pagination__button--paginate"
               >
                 {t("common:showMore")}
               </Button>

--- a/apps/ui/components/common/PageWrapper.tsx
+++ b/apps/ui/components/common/PageWrapper.tsx
@@ -8,7 +8,7 @@ import Navigation from "./Navigation";
 import { InProgressReservationNotification } from "@/components/reservations/UnpaidReservationNotification";
 import { mainStyles } from "common/styles/layout";
 
-interface Props {
+interface PageProps {
   children: React.ReactNode;
   overrideBackgroundColor?: string;
   apiBaseUrl: string;
@@ -27,7 +27,7 @@ function PageWrapper({
   feedbackUrl,
   children,
   version,
-}: Props): JSX.Element {
+}: PageProps): JSX.Element {
   return (
     <>
       <Head>

--- a/apps/ui/components/index/SearchGuides.tsx
+++ b/apps/ui/components/index/SearchGuides.tsx
@@ -87,7 +87,7 @@ export function SearchGuides(): JSX.Element {
       color="primary"
       src="images/guide-recurring.png"
     >
-      <InfoContainer data-test-id="search-guide__recurring">
+      <InfoContainer data-testid="search-guide__recurring">
         <H3 as="h2" $noMargin>
           {t("infoRecurring.heading")}
         </H3>

--- a/apps/ui/components/recurring/ApplicationRoundCard.tsx
+++ b/apps/ui/components/recurring/ApplicationRoundCard.tsx
@@ -12,7 +12,7 @@ import Card from "common/src/components/Card";
 import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
 import { getApplicationRoundPath } from "@/modules/urls";
 
-interface Props {
+interface CardProps {
   applicationRound: ApplicationRoundFieldsFragment;
 }
 
@@ -43,7 +43,9 @@ function translateRoundDate(
   }
 }
 
-export function ApplicationRoundCard({ applicationRound }: Props): JSX.Element {
+export function ApplicationRoundCard({
+  applicationRound,
+}: CardProps): JSX.Element {
   const { t } = useTranslation();
 
   const state = applicationRound.status;

--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -22,7 +22,7 @@ import { Flex } from "common/styles/util";
 import { breakpoints } from "common";
 
 type QueryT = NonNullable<ReservationUnitPageQuery["reservationUnit"]>;
-interface Props {
+interface HeadProps {
   reservationUnit: QueryT;
   reservationUnitIsReservable?: boolean;
   subventionSuffix?: JSX.Element;
@@ -80,7 +80,7 @@ export function Head({
   reservationUnit,
   reservationUnitIsReservable,
   subventionSuffix,
-}: Props): JSX.Element {
+}: HeadProps): JSX.Element {
   const reservationUnitName = getReservationUnitName(reservationUnit);
   const unitName = getUnitName(reservationUnit.unit ?? undefined);
 
@@ -123,7 +123,7 @@ const IconListWrapper = styled.div`
 function IconList({
   reservationUnit,
   subventionSuffix,
-}: Pick<Props, "reservationUnit" | "subventionSuffix">): JSX.Element {
+}: Pick<HeadProps, "reservationUnit" | "subventionSuffix">): JSX.Element {
   const { t } = useTranslation();
 
   const minDur = reservationUnit.minReservationDuration ?? 0;

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -267,7 +267,7 @@ export function EditStep0({
             iconRight={<IconArrowRight aria-hidden />}
             disabled={!focusSlot.isReservable || !isDirty}
             type="submit"
-            data-testid="reservation-edit__button--continue"
+            data-testid="reservation__button--continue"
             isLoading={isLoading}
             loadingText={t("reservationCalendar:nextStepLoading")}
           >

--- a/apps/ui/components/reservation/EditStep1.tsx
+++ b/apps/ui/components/reservation/EditStep1.tsx
@@ -185,7 +185,7 @@ export function EditStep1({
             variant="primary"
             type="submit"
             disabled={isSubmitting || !termsAccepted}
-            data-testid="reservation-edit__button--submit"
+            data-testid="reservation__button--continue"
             isLoading={isSubmitting}
             loadingText={t("reservations:saveNewTimeLoading")}
           >

--- a/apps/ui/components/reservation/Step0.tsx
+++ b/apps/ui/components/reservation/Step0.tsx
@@ -116,7 +116,7 @@ export function Step0({
           type="submit"
           disabled={submitDisabled}
           iconRight={<IconArrowRight aria-hidden />}
-          data-testid="reservation__button--update"
+          data-testid="reservation__button--continue"
           isLoading={isSubmitting}
           loadingText={t("reservationCalendar:nextStepLoading")}
         >

--- a/apps/ui/components/reservation/Step1.tsx
+++ b/apps/ui/components/reservation/Step1.tsx
@@ -82,7 +82,7 @@ export function Step1({
           iconRight={
             requiresHandling ? <IconArrowRight aria-hidden /> : undefined
           }
-          data-test="reservation__button--update"
+          data-testid="reservation__button--continue"
           isLoading={isSubmitting}
           loadingText={loadingText}
           disabled={!areTermsAccepted}
@@ -93,7 +93,7 @@ export function Step1({
           variant="secondary"
           iconLeft={<IconArrowLeft aria-hidden />}
           onClick={() => setStep(0)}
-          data-test="reservation__button--cancel"
+          data-testid="reservation__button--cancel"
         >
           {t("common:prev")}
         </Button>

--- a/apps/ui/components/search/FilterTagList.tsx
+++ b/apps/ui/components/search/FilterTagList.tsx
@@ -124,7 +124,7 @@ export function FilterTagList({
         <ResetButton
           onClick={() => handleResetTags(hideList)}
           onDelete={() => handleResetTags(hideList)}
-          data-test-id="search-form__reset-button"
+          data-testid="search-form__reset-button"
         >
           {t("searchForm:resetForm")}
         </ResetButton>

--- a/apps/ui/components/search/ReservationUnitCard.tsx
+++ b/apps/ui/components/search/ReservationUnitCard.tsx
@@ -17,7 +17,7 @@ import { getReservationUnitPath } from "@/modules/urls";
 import { ButtonLikeLink } from "../common/ButtonLikeLink";
 
 type Node = ReservationUnitCardFieldsFragment;
-interface IProps {
+interface CardProps {
   reservationUnit: Node;
   selectReservationUnit: (reservationUnit: Node) => void;
   containsReservationUnit: (reservationUnit: Node) => boolean;
@@ -29,7 +29,7 @@ export function ReservationUnitCard({
   selectReservationUnit,
   containsReservationUnit,
   removeReservationUnit,
-}: IProps): JSX.Element {
+}: CardProps): JSX.Element {
   const { t } = useTranslation();
 
   const name = getReservationUnitName(reservationUnit);

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -301,7 +301,7 @@ function SubmitFragment(
           type="submit"
           isLoading={props.reservationForm.formState.isSubmitting}
           loadingText={props.loadingText}
-          data-test="quick-reservation__button--submit"
+          data-testid="quick-reservation__button--submit"
         >
           {props.buttonText}
         </SubmitButton>

--- a/packages/common/src/components/Card.tsx
+++ b/packages/common/src/components/Card.tsx
@@ -364,21 +364,21 @@ function Texts({
           <Header
             className="card__header"
             as={headingElement}
-            data-test-id={headingTestId ?? "card__heading"}
+            data-testid={headingTestId ?? "card__heading"}
           >
             {heading}
           </Header>
         }
         link={link}
       />
-      <Text data-test-id={textTestId ?? "card__content"}>{text}</Text>
+      <Text data-testid={textTestId ?? "card__content"}>{text}</Text>
     </TextContainer>
   );
 }
 
 function Tags({ tags }: Readonly<{ tags?: JSX.Element[] }>) {
   if (!tags) return null;
-  return <TagContainer data-test-id="card__tags">{tags}</TagContainer>;
+  return <TagContainer data-testid="card__tags">{tags}</TagContainer>;
 }
 
 const InfoItem = styled(Flex).attrs({

--- a/packages/common/src/components/form/ControlledSelect.tsx
+++ b/packages/common/src/components/form/ControlledSelect.tsx
@@ -9,7 +9,7 @@ import {
   type UseControllerProps,
 } from "react-hook-form";
 
-interface Props<T extends FieldValues> extends UseControllerProps<T> {
+interface SelectProps<T extends FieldValues> extends UseControllerProps<T> {
   name: Path<T>;
   control: Control<T>;
   label: string;
@@ -47,7 +47,7 @@ export function ControlledSelect<T extends FieldValues>({
   multiselect,
   disabled,
   afterChange,
-}: Props<T>): JSX.Element {
+}: SelectProps<T>): JSX.Element {
   const { t } = useTranslation(["common"]);
   const {
     field: { value, onChange },

--- a/packages/eslint-config-custom/react.js
+++ b/packages/eslint-config-custom/react.js
@@ -98,7 +98,6 @@ module.exports = defineConfig({
     "@typescript-eslint/no-unsafe-return": 0,
     "@typescript-eslint/no-unnecessary-type-arguments": 0,
     // TODO there should be rules for this already
-    "@typescript-eslint/naming-convention": 0,
     "no-implicit-coercion": 0,
     "import/no-named-as-default-member": 0,
     "import/no-named-as-default": 0,
@@ -181,7 +180,6 @@ module.exports = defineConfig({
       },
     ],
     "react/destructuring-assignment": 0,
-    "react/jsx-props-no-spreading": 0,
     "react/prop-types": 0,
     "react/require-default-props": 0,
     "react/static-property-placement": 0,
@@ -192,6 +190,10 @@ module.exports = defineConfig({
         unnamedComponents: ["function-expression", "arrow-function"],
       },
     ],
+    // Custom rule to enforce data-testid attribute naming
+    'react/no-unknown-property': ['error', {
+      requireDataLowercase: true,
+    }],
     // There seems to be no other way to override this than disabling it and rewriting the rules in the naming-convention
     "@typescript-eslint/camelcase": ["off"],
     "@typescript-eslint/no-empty-function": 0,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: typos in`data-testid`.
- Change: use the same `data-testid` for submit button on edit / new reservation pages.
- Chore: enable `naming-convention` lint.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automation: e2e test changes.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
