### PR TITLE
fix: show paragraphs in rich text editor

### DIFF
--- a/apps/admin-ui/src/component/RichTextInput.tsx
+++ b/apps/admin-ui/src/component/RichTextInput.tsx
@@ -49,6 +49,9 @@ const StyledReactQuill = styled(ReactQuill)<{
   > div {
     font-size: var(--fontsize-body-l);
     font-family: var(--font-regular);
+    p {
+      margin-bottom: var(--spacing-s);
+    }
   }
 `;
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: show paragraphs in `admin` rich text editor so they match the look of `customer` ui.
- Fix for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1500 sanitised rich text styling.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: CSS change extra line breaks should create huge empty spacing in rich text editor.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3715](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3715)


[TILA-3715]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ