### PR TITLE
fix: missing gap on application page 3

### DIFF
--- a/apps/ui/components/application/ApplicantTypeSelector.tsx
+++ b/apps/ui/components/application/ApplicantTypeSelector.tsx
@@ -38,7 +38,7 @@ export const ApplicantTypeSelector = (): JSX.Element => {
   );
 
   return (
-    <>
+    <div>
       <Prefix>{t("application:Page3.as.prefix")}</Prefix>
       {choices.map((id) => (
         <Container key={id}>
@@ -51,6 +51,6 @@ export const ApplicantTypeSelector = (): JSX.Element => {
           />
         </Container>
       ))}
-    </>
+    </div>
   );
 };

--- a/apps/ui/components/application/styled.tsx
+++ b/apps/ui/components/application/styled.tsx
@@ -175,6 +175,6 @@ export const CompactTermsBox = styled(TermsBox)`
 export const SpanTwoColumns = styled(FullRow).attrs({ as: "span" })``;
 
 export const FormSubHeading = styled(H5).attrs({ as: "h2" })`
-  margin: var(--spacing-m) 0 0 0;
+  margin: 0;
   grid-column: 1 / -1;
 `;

--- a/apps/ui/components/common/Sanitize.tsx
+++ b/apps/ui/components/common/Sanitize.tsx
@@ -7,6 +7,7 @@ type Props = {
 };
 
 const StyledContent = styled.div`
+  word-break: break-word;
   p:empty {
     display: none;
   }

--- a/apps/ui/pages/applications/[id]/page3.tsx
+++ b/apps/ui/pages/applications/[id]/page3.tsx
@@ -35,6 +35,7 @@ import { errorToast } from "common/src/common/toast";
 import { getApplicationPath } from "@/modules/urls";
 import { Button, IconArrowRight } from "hds-react";
 import { ButtonContainer } from "common/styles/util";
+import styled from "styled-components";
 
 function Buttons({
   applicationPk,
@@ -176,6 +177,12 @@ function Page3(): JSX.Element | null {
   }
 }
 
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+`;
+
 function Page3Wrapped(props: PropsNarrowed): JSX.Element | null {
   const { pk: appPk } = props;
   const router = useRouter();
@@ -269,11 +276,11 @@ function Page3Wrapped(props: PropsNarrowed): JSX.Element | null {
         application={application}
         isDirty={isDirty}
       >
-        <form noValidate onSubmit={handleSubmit(onSubmit)}>
+        <Form noValidate onSubmit={handleSubmit(onSubmit)}>
           <ApplicantTypeSelector />
           <Page3 />
           <Buttons applicationPk={application.pk} submitDisabled={!isValid} />
-        </form>
+        </Form>
       </ApplicationPageWrapper>
     </FormProvider>
   );


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: gap missing on the application info page `page3` causing action buttons on mobile to have no separation from form.
- Fix: rich text overflowing containers (especially problem with long links on mobile).
- Fix for https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1500

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: style change, gap should be present.
- Manual testing: long words or links in TOS (or other rich text) should not break responsiveness.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
