### PR TITLE
Refactor reservation page and add redirect if part of application

### DIFF
--- a/apps/ui/components/Instructions.tsx
+++ b/apps/ui/components/Instructions.tsx
@@ -1,0 +1,66 @@
+import {
+  type Maybe,
+  type ReservationQuery,
+  ReservationStateChoice,
+} from "@/gql/gql-types";
+import { H4 } from "common";
+import {
+  convertLanguageCode,
+  getTranslationSafe,
+} from "common/src/common/util";
+import { useTranslation } from "next-i18next";
+
+// TODO replace with a fragment
+type NodeT = NonNullable<ReservationQuery["reservation"]>;
+type Props = {
+  reservation: Pick<NodeT, "reservationUnits" | "state">;
+};
+
+export function Instructions({ reservation }: Props): JSX.Element | null {
+  const { t, i18n } = useTranslation();
+
+  const reservationUnit = reservation.reservationUnits.find(() => true);
+  const lang = convertLanguageCode(i18n.language);
+  const instructionsKey = getReservationUnitInstructionsKey(reservation.state);
+  const instructionsText =
+    instructionsKey != null && reservationUnit != null
+      ? getTranslationSafe(reservationUnit, instructionsKey, lang)
+      : null;
+  const showInstructions =
+    reservationUnit != null &&
+    instructionsKey != null &&
+    instructionsText != null &&
+    instructionsText !== "";
+
+  if (!showInstructions) {
+    return null;
+  }
+
+  return (
+    <div>
+      <H4 as="h2">{t("reservations:reservationInfo")}</H4>
+      <p>{instructionsText}</p>
+    </div>
+  );
+}
+
+type InstructionsKey =
+  | "reservationPendingInstructions"
+  | "reservationCancelledInstructions"
+  | "reservationConfirmedInstructions";
+function getReservationUnitInstructionsKey(
+  state: Maybe<ReservationStateChoice> | undefined
+): InstructionsKey | null {
+  switch (state) {
+    case ReservationStateChoice.Created:
+    case ReservationStateChoice.RequiresHandling:
+      return "reservationPendingInstructions";
+    case ReservationStateChoice.Cancelled:
+      return "reservationCancelledInstructions";
+    case ReservationStateChoice.Confirmed:
+      return "reservationConfirmedInstructions";
+    case ReservationStateChoice.Denied:
+    default:
+      return null;
+  }
+}

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -8146,6 +8146,179 @@ export type ReservationCancelPageQuery = {
   } | null;
 };
 
+export type ApplicationRecurringReservationQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type ApplicationRecurringReservationQuery = {
+  recurringReservation?: {
+    id: string;
+    allocatedTimeSlot?: {
+      id: string;
+      reservationUnitOption: {
+        id: string;
+        applicationSection: {
+          id: string;
+          application: { id: string; pk?: number | null };
+        };
+      };
+    } | null;
+  } | null;
+};
+
+export type ReservationPageQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type ReservationPageQuery = {
+  reservation?: {
+    id: string;
+    pk?: number | null;
+    name?: string | null;
+    applyingForFreeOfCharge?: boolean | null;
+    begin: string;
+    end: string;
+    calendarUrl?: string | null;
+    state?: ReservationStateChoice | null;
+    reserveeFirstName?: string | null;
+    reserveeLastName?: string | null;
+    reserveeEmail?: string | null;
+    reserveePhone?: string | null;
+    reserveeType?: CustomerTypeChoice | null;
+    reserveeOrganisationName?: string | null;
+    reserveeId?: string | null;
+    reserveeIsUnregisteredAssociation?: boolean | null;
+    reserveeAddressStreet?: string | null;
+    reserveeAddressCity?: string | null;
+    reserveeAddressZip?: string | null;
+    billingFirstName?: string | null;
+    billingLastName?: string | null;
+    billingPhone?: string | null;
+    billingEmail?: string | null;
+    billingAddressStreet?: string | null;
+    billingAddressCity?: string | null;
+    billingAddressZip?: string | null;
+    description?: string | null;
+    numPersons?: number | null;
+    paymentOrder: Array<{
+      id: string;
+      status?: OrderStatus | null;
+      receiptUrl?: string | null;
+      checkoutUrl?: string | null;
+    }>;
+    recurringReservation?: { id: string } | null;
+    reservationUnits: Array<{
+      id: string;
+      canApplyFreeOfCharge: boolean;
+      pk?: number | null;
+      uuid: string;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+      reservationPendingInstructionsFi?: string | null;
+      reservationPendingInstructionsEn?: string | null;
+      reservationPendingInstructionsSv?: string | null;
+      reservationConfirmedInstructionsFi?: string | null;
+      reservationConfirmedInstructionsEn?: string | null;
+      reservationConfirmedInstructionsSv?: string | null;
+      reservationCancelledInstructionsFi?: string | null;
+      reservationCancelledInstructionsEn?: string | null;
+      reservationCancelledInstructionsSv?: string | null;
+      termsOfUseFi?: string | null;
+      termsOfUseEn?: string | null;
+      termsOfUseSv?: string | null;
+      minPersons?: number | null;
+      maxPersons?: number | null;
+      unit?: {
+        id: string;
+        tprekId?: string | null;
+        pk?: number | null;
+        nameFi?: string | null;
+        nameEn?: string | null;
+        nameSv?: string | null;
+        location?: {
+          id: string;
+          latitude?: string | null;
+          longitude?: string | null;
+          addressStreetEn?: string | null;
+          addressStreetSv?: string | null;
+          addressCityEn?: string | null;
+          addressCitySv?: string | null;
+          addressStreetFi?: string | null;
+          addressZip: string;
+          addressCityFi?: string | null;
+        } | null;
+      } | null;
+      serviceSpecificTerms?: {
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      cancellationTerms?: {
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      paymentTerms?: {
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      pricingTerms?: {
+        nameFi?: string | null;
+        nameEn?: string | null;
+        nameSv?: string | null;
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      pricings: Array<{
+        id: string;
+        begins: string;
+        priceUnit: PriceUnit;
+        lowestPrice: string;
+        highestPrice: string;
+        taxPercentage: { id: string; pk?: number | null; value: string };
+      }>;
+      images: Array<{
+        id: string;
+        imageUrl?: string | null;
+        largeUrl?: string | null;
+        mediumUrl?: string | null;
+        smallUrl?: string | null;
+        imageType: ImageType;
+      }>;
+      cancellationRule?: {
+        id: string;
+        canBeCancelledTimeBefore?: number | null;
+      } | null;
+      metadataSet?: {
+        id: string;
+        requiredFields: Array<{ id: string; fieldName: string }>;
+        supportedFields: Array<{ id: string; fieldName: string }>;
+      } | null;
+    }>;
+    purpose?: {
+      id: string;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+    } | null;
+    ageGroup?: {
+      id: string;
+      pk?: number | null;
+      minimum: number;
+      maximum?: number | null;
+    } | null;
+    homeCity?: { id: string; pk?: number | null; name: string } | null;
+  } | null;
+};
+
 export const PricingFieldsFragmentDoc = gql`
   fragment PricingFields on ReservationUnitPricingNode {
     id
@@ -11892,4 +12065,214 @@ export type ReservationCancelPageSuspenseQueryHookResult = ReturnType<
 export type ReservationCancelPageQueryResult = Apollo.QueryResult<
   ReservationCancelPageQuery,
   ReservationCancelPageQueryVariables
+>;
+export const ApplicationRecurringReservationDocument = gql`
+  query ApplicationRecurringReservation($id: ID!) {
+    recurringReservation(id: $id) {
+      id
+      allocatedTimeSlot {
+        id
+        reservationUnitOption {
+          id
+          applicationSection {
+            id
+            application {
+              id
+              pk
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useApplicationRecurringReservationQuery__
+ *
+ * To run a query within a React component, call `useApplicationRecurringReservationQuery` and pass it any options that fit your needs.
+ * When your component renders, `useApplicationRecurringReservationQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useApplicationRecurringReservationQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useApplicationRecurringReservationQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ApplicationRecurringReservationQuery,
+    ApplicationRecurringReservationQueryVariables
+  > &
+    (
+      | {
+          variables: ApplicationRecurringReservationQueryVariables;
+          skip?: boolean;
+        }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ApplicationRecurringReservationQuery,
+    ApplicationRecurringReservationQueryVariables
+  >(ApplicationRecurringReservationDocument, options);
+}
+export function useApplicationRecurringReservationLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ApplicationRecurringReservationQuery,
+    ApplicationRecurringReservationQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ApplicationRecurringReservationQuery,
+    ApplicationRecurringReservationQueryVariables
+  >(ApplicationRecurringReservationDocument, options);
+}
+export function useApplicationRecurringReservationSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        ApplicationRecurringReservationQuery,
+        ApplicationRecurringReservationQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    ApplicationRecurringReservationQuery,
+    ApplicationRecurringReservationQueryVariables
+  >(ApplicationRecurringReservationDocument, options);
+}
+export type ApplicationRecurringReservationQueryHookResult = ReturnType<
+  typeof useApplicationRecurringReservationQuery
+>;
+export type ApplicationRecurringReservationLazyQueryHookResult = ReturnType<
+  typeof useApplicationRecurringReservationLazyQuery
+>;
+export type ApplicationRecurringReservationSuspenseQueryHookResult = ReturnType<
+  typeof useApplicationRecurringReservationSuspenseQuery
+>;
+export type ApplicationRecurringReservationQueryResult = Apollo.QueryResult<
+  ApplicationRecurringReservationQuery,
+  ApplicationRecurringReservationQueryVariables
+>;
+export const ReservationPageDocument = gql`
+  query ReservationPage($id: ID!) {
+    reservation(id: $id) {
+      id
+      pk
+      name
+      ...ReserveeNameFields
+      ...ReserveeBillingFields
+      ...ReservationInfo
+      applyingForFreeOfCharge
+      begin
+      end
+      calendarUrl
+      state
+      paymentOrder {
+        id
+        status
+        receiptUrl
+        checkoutUrl
+      }
+      recurringReservation {
+        id
+      }
+      reservationUnits {
+        id
+        canApplyFreeOfCharge
+        ...ReservationUnitFields
+        ...CancellationRuleFields
+      }
+    }
+  }
+  ${ReserveeNameFieldsFragmentDoc}
+  ${ReserveeBillingFieldsFragmentDoc}
+  ${ReservationInfoFragmentDoc}
+  ${ReservationUnitFieldsFragmentDoc}
+  ${CancellationRuleFieldsFragmentDoc}
+`;
+
+/**
+ * __useReservationPageQuery__
+ *
+ * To run a query within a React component, call `useReservationPageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReservationPageQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReservationPageQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useReservationPageQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ReservationPageQuery,
+    ReservationPageQueryVariables
+  > &
+    (
+      | { variables: ReservationPageQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ReservationPageQuery, ReservationPageQueryVariables>(
+    ReservationPageDocument,
+    options
+  );
+}
+export function useReservationPageLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ReservationPageQuery,
+    ReservationPageQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ReservationPageQuery,
+    ReservationPageQueryVariables
+  >(ReservationPageDocument, options);
+}
+export function useReservationPageSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        ReservationPageQuery,
+        ReservationPageQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    ReservationPageQuery,
+    ReservationPageQueryVariables
+  >(ReservationPageDocument, options);
+}
+export type ReservationPageQueryHookResult = ReturnType<
+  typeof useReservationPageQuery
+>;
+export type ReservationPageLazyQueryHookResult = ReturnType<
+  typeof useReservationPageLazyQuery
+>;
+export type ReservationPageSuspenseQueryHookResult = ReturnType<
+  typeof useReservationPageSuspenseQuery
+>;
+export type ReservationPageQueryResult = Apollo.QueryResult<
+  ReservationPageQuery,
+  ReservationPageQueryVariables
 >;

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -8074,8 +8074,8 @@ export type ReservationCancelPageQuery = {
       reservationEnds?: string | null;
       cancellationTerms?: {
         id: string;
-        textEn?: string | null;
         textFi?: string | null;
+        textEn?: string | null;
         textSv?: string | null;
       } | null;
       images: Array<{
@@ -11777,10 +11777,7 @@ export const ReservationCancelPageDocument = gql`
         id
         ...CancellationRuleFields
         cancellationTerms {
-          id
-          textEn
-          textFi
-          textSv
+          ...TermsOfUseTextFields
         }
       }
       recurringReservation {

--- a/apps/ui/modules/__tests__/reservationUnit.test.ts
+++ b/apps/ui/modules/__tests__/reservationUnit.test.ts
@@ -11,7 +11,6 @@ import {
 import { toApiDateUnsafe } from "common/src/common/util";
 import {
   type EquipmentNode,
-  ReservationStateChoice,
   PriceUnit,
   ReservationUnitPublishingState,
   type ReservationUnitNode,
@@ -29,7 +28,6 @@ import {
   getFuturePricing,
   getPossibleTimesForDay,
   getPriceString,
-  getReservationUnitInstructionsKey,
   getReservationUnitName,
   getReservationUnitPrice,
   getUnitName,
@@ -700,35 +698,6 @@ describe("getUnitName", () => {
     };
 
     expect(getUnitName(unit, "sv")).toEqual("Unit 1 FI");
-  });
-});
-
-describe("getReservationUnitInstructionsKey", () => {
-  it("should return correct key pending states", () => {
-    expect(
-      getReservationUnitInstructionsKey(ReservationStateChoice.Created)
-    ).toEqual("reservationPendingInstructions");
-    expect(
-      getReservationUnitInstructionsKey(ReservationStateChoice.RequiresHandling)
-    ).toEqual("reservationPendingInstructions");
-  });
-
-  it("should return correct key cancelled states", () => {
-    expect(
-      getReservationUnitInstructionsKey(ReservationStateChoice.Cancelled)
-    ).toEqual("reservationCancelledInstructions");
-  });
-
-  it("should return correct key confirmed states", () => {
-    expect(
-      getReservationUnitInstructionsKey(ReservationStateChoice.Confirmed)
-    ).toEqual("reservationConfirmedInstructions");
-  });
-
-  it("should return no key for rest", () => {
-    expect(
-      getReservationUnitInstructionsKey(ReservationStateChoice.Denied)
-    ).toEqual(null);
   });
 });
 

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -22,6 +22,7 @@ import {
   type CancellationRuleFieldsFragment,
   type BlockingReservationFieldsFragment,
   type CanUserCancelReservationFragment,
+  type ReservationInfoFragment,
 } from "@gql/gql-types";
 import { getReservationApplicationFields } from "common/src/reservation-form/util";
 import { getIntervalMinutes } from "common/src/conversion";
@@ -359,41 +360,25 @@ export function canReservationTimeBeChanged({
   });
 }
 
-// FIXME this is awful: we don't use the Node type anymore, this is not type safe, it's not intuative what this does and why
 export function getReservationValue(
-  reservation: ReservationNode,
-  key: string
+  reservation: ReservationInfoFragment,
+  key: "purpose" | "numPersons" | "ageGroup" | "description"
 ): string | number | null {
-  switch (key) {
-    case "ageGroup": {
-      const { minimum, maximum } = reservation.ageGroup || {};
-      return minimum && maximum ? `${minimum} - ${maximum}` : null;
+  if (key === "ageGroup") {
+    const { minimum, maximum } = reservation.ageGroup || {};
+    return minimum && maximum ? `${minimum} - ${maximum}` : null;
+  } else if (key === "purpose") {
+    if (reservation.purpose != null) {
+      return getTranslation(reservation.purpose, "name");
     }
-    case "purpose": {
-      if (reservation.purpose != null) {
-        return getTranslation(reservation.purpose, "name");
-      }
-      return null;
-    }
-    case "homeCity": {
-      if (reservation.homeCity == null) {
-        return null;
-      }
-      return (
-        getTranslation(reservation.homeCity, "name") ||
-        reservation.homeCity.name
-      );
-    }
-    default: {
-      if (key in reservation) {
-        const val = reservation[key as keyof ReservationNode];
-        if (typeof val === "string" || typeof val === "number") {
-          return val;
-        }
-      }
-      return null;
+    return null;
+  } else if (key in reservation) {
+    const val = reservation[key as keyof ReservationInfoFragment];
+    if (typeof val === "string" || typeof val === "number") {
+      return val;
     }
   }
+  return null;
 }
 
 export function getCheckoutUrl(

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -174,27 +174,6 @@ export function getUnitName(
   );
 }
 
-type InstructionsKey =
-  | "reservationPendingInstructions"
-  | "reservationCancelledInstructions"
-  | "reservationConfirmedInstructions";
-export function getReservationUnitInstructionsKey(
-  state: Maybe<ReservationStateChoice> | undefined
-): InstructionsKey | null {
-  switch (state) {
-    case ReservationStateChoice.Created:
-    case ReservationStateChoice.RequiresHandling:
-      return "reservationPendingInstructions";
-    case ReservationStateChoice.Cancelled:
-      return "reservationCancelledInstructions";
-    case ReservationStateChoice.Confirmed:
-      return "reservationConfirmedInstructions";
-    case ReservationStateChoice.Denied:
-    default:
-      return null;
-  }
-}
-
 function isActivePricing(pricing: PricingFieldsFragment): boolean {
   return new Date(pricing.begins) <= new Date();
 }

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -54,6 +54,7 @@ import {
   getFuturePricing,
   getPossibleTimesForDay,
   getPriceString,
+  getReservationUnitName,
   getTimeString,
   isReservationUnitPublished,
   isReservationUnitReservable,
@@ -650,7 +651,10 @@ function ReservationUnit({
           />
         )}
         <JustForDesktop customBreakpoint={breakpoints.l}>
-          <AddressSection reservationUnit={reservationUnit} />
+          <AddressSection
+            unit={reservationUnit.unit}
+            title={getReservationUnitName(reservationUnit) ?? "-"}
+          />
         </JustForDesktop>
       </div>
       <PageContentWrapper>
@@ -727,7 +731,10 @@ function ReservationUnit({
             open
           >
             <JustForMobile customBreakpoint={breakpoints.l}>
-              <AddressSection reservationUnit={reservationUnit} />
+              <AddressSection
+                unit={reservationUnit.unit}
+                title={getReservationUnitName(reservationUnit) ?? "-"}
+              />
             </JustForMobile>
             <MapComponent tprekId={reservationUnit.unit?.tprekId ?? ""} />
           </Accordion>

--- a/apps/ui/pages/reservations/[id]/cancel.tsx
+++ b/apps/ui/pages/reservations/[id]/cancel.tsx
@@ -145,10 +145,7 @@ export const RESERVATION_CANCEL_PAGE_QUERY = gql`
         id
         ...CancellationRuleFields
         cancellationTerms {
-          id
-          textEn
-          textFi
-          textSv
+          ...TermsOfUseTextFields
         }
       }
       recurringReservation {

--- a/apps/ui/pages/reservations/[id]/confirmation.tsx
+++ b/apps/ui/pages/reservations/[id]/confirmation.tsx
@@ -21,17 +21,13 @@ import {
 } from "@/modules/urls";
 import { Button, IconCalendar, IconLinkExternal } from "hds-react";
 import styled from "styled-components";
-import { H1, H4 } from "common/src/common/typography";
-import { getReservationUnitInstructionsKey } from "@/modules/reservationUnit";
+import { H1 } from "common/src/common/typography";
 import { ButtonLikeExternalLink } from "@/components/common/ButtonLikeLink";
 import { Flex } from "common/styles/util";
-import {
-  convertLanguageCode,
-  getTranslationSafe,
-} from "common/src/common/util";
 import { breakpoints } from "common";
 import { InlineStyledLink } from "@/styles/util";
 import { BackLinkList } from "@/components/reservation/CancelledLinkSet";
+import { Instructions } from "@/components/Instructions";
 
 function Confirmation({ apiBaseUrl, reservation }: PropsNarrowed) {
   const { t } = useTranslation();
@@ -113,36 +109,6 @@ function ReservationConfirmation({
   );
 }
 
-function Instructions({
-  reservation,
-}: {
-  reservation: Pick<PropsNarrowed["reservation"], "reservationUnits" | "state">;
-}) {
-  const { t, i18n } = useTranslation();
-
-  const reservationUnit = reservation.reservationUnits.find(() => true);
-  const lang = convertLanguageCode(i18n.language);
-  const instructionsKey = getReservationUnitInstructionsKey(reservation.state);
-  const instructionsText =
-    instructionsKey != null && reservationUnit != null
-      ? getTranslationSafe(reservationUnit, instructionsKey, lang)
-      : null;
-  const showInstructions =
-    reservationUnit != null &&
-    instructionsKey != null &&
-    instructionsText != null &&
-    instructionsText !== "";
-
-  return showInstructions ? (
-    <div>
-      <H4 $noMargin as="h2">
-        {t("reservations:reservationInfo")}
-      </H4>
-      <p>{instructionsText}</p>
-    </div>
-  ) : null;
-}
-
 function Actions({
   reservation,
 }: {
@@ -213,7 +179,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       return {
         props: {
           reservation,
-          ...getCommonServerSideProps(),
+          ...commonProps,
           ...(await serverSideTranslations(locale ?? "fi")),
         },
       };
@@ -226,7 +192,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       notFound: true,
       ...commonProps,
       ...(await serverSideTranslations(locale ?? "fi")),
-      key: `${pk}-confirmation-${locale}`,
     },
   };
 }

--- a/apps/ui/pages/reservations/[id]/edit.tsx
+++ b/apps/ui/pages/reservations/[id]/edit.tsx
@@ -325,7 +325,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         props: {
           ...commonProps,
           ...(await serverSideTranslations(locale ?? "fi")),
-          key: `${pk}-edit-${locale}`,
           pk,
           reservation,
           options,

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -124,6 +124,14 @@ const SecondaryActions = styled(Flex)`
   margin-top: var(--spacing-l);
 `;
 
+function formatReserveeName(
+  reservation: Pick<NodeT, "reserveeFirstName" | "reserveeLastName">
+): string {
+  return `${reservation.reserveeFirstName || ""} ${
+    reservation.reserveeLastName || ""
+  }`.trim();
+}
+
 function ReserveeBusinessInfo({
   reservation,
   supportedFields,
@@ -140,50 +148,52 @@ function ReserveeBusinessInfo({
   supportedFields: Pick<ReservationMetadataFieldNode, "fieldName">[];
 }): JSX.Element {
   const { t } = useTranslation();
+  const arr = [];
+  if (containsField(supportedFields, "reserveeOrganisationName")) {
+    arr.push({
+      key: "organisationName",
+      label: t("reservations:organisationName"),
+      value: reservation.reserveeOrganisationName || "-",
+      testId: "reservation__reservee-organisation-name",
+    });
+  }
+  if (containsField(supportedFields, "reserveeId")) {
+    arr.push({
+      key: "id",
+      label: t("reservations:reserveeId"),
+      value: reservation.reserveeId || "-",
+      testId: "reservation__reservee-id",
+    });
+  }
+  if (containsNameField(supportedFields)) {
+    arr.push({
+      key: "name",
+      label: t("reservations:contactName"),
+      value: formatReserveeName(reservation),
+      testId: "reservation__reservee-name",
+    });
+  }
+  if (containsField(supportedFields, "reserveePhone")) {
+    arr.push({
+      key: "phone",
+      label: t("reservations:contactPhone"),
+      value: reservation.reserveePhone ?? "-",
+      testId: "reservation__reservee-phone",
+    });
+  }
+  if (containsField(supportedFields, "reserveeEmail")) {
+    arr.push({
+      key: "email",
+      label: t("reservations:contactEmail"),
+      value: reservation.reserveeEmail ?? "-",
+      testId: "reservation__reservee-email",
+    });
+  }
   return (
     <>
-      {containsField(supportedFields, "reserveeOrganisationName") && (
-        <p>
-          {t("reservations:organisationName")}:{" "}
-          <span data-testid="reservation__reservee-organisation-name">
-            {reservation.reserveeOrganisationName || "-"}
-          </span>
-        </p>
-      )}
-      {containsField(supportedFields, "reserveeId") && (
-        <p>
-          {t("reservations:reserveeId")}:
-          <span data-testid="reservation__reservee-id">
-            {reservation.reserveeId || "-"}
-          </span>
-        </p>
-      )}
-      {containsNameField(supportedFields) && (
-        <p>
-          {t("reservations:contactName")}:{" "}
-          <span data-testid="reservation__reservee-name">
-            {`${reservation.reserveeFirstName || ""} ${
-              reservation.reserveeLastName || ""
-            }`.trim()}
-          </span>
-        </p>
-      )}
-      {containsField(supportedFields, "reserveePhone") && (
-        <p>
-          {t("reservations:contactPhone")}:
-          <span data-testid="reservation__reservee-phone">
-            {reservation.reserveePhone}
-          </span>
-        </p>
-      )}
-      {containsField(supportedFields, "reserveeEmail") && (
-        <p>
-          {t("reservations:contactEmail")}:
-          <span data-testid="reservation__reservee-email">
-            {reservation.reserveeEmail}
-          </span>
-        </p>
-      )}
+      {arr.map(({ key, ...rest }) => (
+        <LabelValuePair key={key} {...rest} />
+      ))}
     </>
   );
 }
@@ -203,9 +213,7 @@ function ReserveePersonInfo({
   if (containsNameField(supportedFields)) {
     arr.push({
       key: "name",
-      value: `${reservation.reserveeFirstName || ""} ${
-        reservation.reserveeLastName || ""
-      }`.trim(),
+      value: formatReserveeName(reservation),
     });
   }
   if (containsField(supportedFields, "reserveePhone")) {
@@ -222,12 +230,16 @@ function ReserveePersonInfo({
   }
   return (
     <>
-      {arr.map(({ key, value }) => (
-        <p key={key}>
-          {t(`common:${key}`)}:{" "}
-          <span data-testid={`reservation__reservee-${key}`}>{value}</span>
-        </p>
-      ))}
+      {arr
+        .map(({ key, value }) => ({
+          key,
+          label: t(`common:${key}`),
+          value,
+          testId: `reservation__reservee-${key}`,
+        }))
+        .map(({ key, ...rest }) => (
+          <LabelValuePair key={key} {...rest} />
+        ))}
     </>
   );
 }
@@ -296,15 +308,35 @@ function ReservationInfo({
   return (
     <div>
       <H4 as="h2">{t("reservationApplication:applicationInfo")}</H4>
-      {fields.map((field) => (
-        <p key={field}>
-          {t(`reservationApplication:label.common.${field}`)}:{" "}
-          <span data-testid={`reservation__${field}`}>
-            {getReservationValue(reservation, field) || "-"}
-          </span>
-        </p>
-      ))}
+      {fields
+        .map((field) => ({
+          key: field,
+          label: t(`reservationApplication:label.common.${field}`),
+          value: getReservationValue(reservation, field) ?? "-",
+          testId: `reservation__${field}`,
+        }))
+        .map(({ key, ...rest }) => (
+          <LabelValuePair key={key} {...rest} />
+        ))}
     </div>
+  );
+}
+
+type LabelValuePairProps = {
+  label: string;
+  value: string | number;
+  testId: string;
+};
+
+function LabelValuePair({
+  label,
+  value,
+  testId,
+}: LabelValuePairProps): JSX.Element {
+  return (
+    <p>
+      {label}: <span data-testid={testId}>{value}</span>
+    </p>
   );
 }
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Refactor: use fragments and narrow types for reservation page.
- Refactor: move duplicated Instructions to a separate component.
- Refactor: use a separate query for `reservations/[id]` page. Pages should use their own queries and fragments should be reused for components.
- Fix: redirect `reservations/[id]` page if that reservation is part of an application.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

-

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3721](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3721)


[TILA-3721]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ