### PR TITLE
refactor: separate page queries

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -5520,6 +5520,51 @@ export type ReserveeBillingFieldsFragment = {
   billingAddressZip?: string | null;
 };
 
+export type MetaFieldsFragment = {
+  applyingForFreeOfCharge?: boolean | null;
+  freeOfChargeReason?: string | null;
+  description?: string | null;
+  numPersons?: number | null;
+  reserveeFirstName?: string | null;
+  reserveeLastName?: string | null;
+  reserveeEmail?: string | null;
+  reserveePhone?: string | null;
+  reserveeType?: CustomerTypeChoice | null;
+  reserveeOrganisationName?: string | null;
+  reserveeId?: string | null;
+  reserveeIsUnregisteredAssociation?: boolean | null;
+  reserveeAddressStreet?: string | null;
+  reserveeAddressCity?: string | null;
+  reserveeAddressZip?: string | null;
+  billingFirstName?: string | null;
+  billingLastName?: string | null;
+  billingPhone?: string | null;
+  billingEmail?: string | null;
+  billingAddressStreet?: string | null;
+  billingAddressCity?: string | null;
+  billingAddressZip?: string | null;
+  ageGroup?: {
+    id: string;
+    pk?: number | null;
+    maximum?: number | null;
+    minimum: number;
+  } | null;
+  purpose?: {
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
+  } | null;
+  homeCity?: {
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameSv?: string | null;
+    nameEn?: string | null;
+  } | null;
+};
+
 export type TermsOfUseNameFieldsFragment = {
   nameFi?: string | null;
   nameEn?: string | null;
@@ -5990,8 +6035,6 @@ export type UnitQuery = {
       } | null;
     }>;
     location?: {
-      longitude?: string | null;
-      latitude?: string | null;
       id: string;
       addressStreetFi?: string | null;
       addressZip: string;
@@ -8552,6 +8595,65 @@ export type SpaceQuery = {
   } | null;
 };
 
+export const ReserveeNameFieldsFragmentDoc = gql`
+  fragment ReserveeNameFields on ReservationNode {
+    reserveeFirstName
+    reserveeLastName
+    reserveeEmail
+    reserveePhone
+    reserveeType
+    reserveeOrganisationName
+    reserveeId
+  }
+`;
+export const ReserveeBillingFieldsFragmentDoc = gql`
+  fragment ReserveeBillingFields on ReservationNode {
+    reserveeId
+    reserveeIsUnregisteredAssociation
+    reserveeAddressStreet
+    reserveeAddressCity
+    reserveeAddressZip
+    billingFirstName
+    billingLastName
+    billingPhone
+    billingEmail
+    billingAddressStreet
+    billingAddressCity
+    billingAddressZip
+  }
+`;
+export const MetaFieldsFragmentDoc = gql`
+  fragment MetaFields on ReservationNode {
+    ...ReserveeNameFields
+    ...ReserveeBillingFields
+    applyingForFreeOfCharge
+    freeOfChargeReason
+    description
+    numPersons
+    ageGroup {
+      id
+      pk
+      maximum
+      minimum
+    }
+    purpose {
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
+    }
+    homeCity {
+      id
+      pk
+      nameFi
+      nameSv
+      nameEn
+    }
+  }
+  ${ReserveeNameFieldsFragmentDoc}
+  ${ReserveeBillingFieldsFragmentDoc}
+`;
 export const TermsOfUseNameFieldsFragmentDoc = gql`
   fragment TermsOfUseNameFields on TermsOfUseNode {
     nameFi
@@ -9054,33 +9156,6 @@ export const ReservationsInIntervalFragmentDoc = gql`
     }
   }
 `;
-export const ReserveeNameFieldsFragmentDoc = gql`
-  fragment ReserveeNameFields on ReservationNode {
-    reserveeFirstName
-    reserveeLastName
-    reserveeEmail
-    reserveePhone
-    reserveeType
-    reserveeOrganisationName
-    reserveeId
-  }
-`;
-export const ReserveeBillingFieldsFragmentDoc = gql`
-  fragment ReserveeBillingFields on ReservationNode {
-    reserveeId
-    reserveeIsUnregisteredAssociation
-    reserveeAddressStreet
-    reserveeAddressCity
-    reserveeAddressZip
-    billingFirstName
-    billingLastName
-    billingPhone
-    billingEmail
-    billingAddressStreet
-    billingAddressCity
-    billingAddressZip
-  }
-`;
 export const ReservationMetaFieldsFragmentDoc = gql`
   fragment ReservationMetaFields on ReservationNode {
     ageGroup {
@@ -9530,8 +9605,6 @@ export const UnitDocument = gql`
       }
       location {
         ...LocationFields
-        longitude
-        latitude
       }
     }
   }

--- a/apps/admin-ui/src/common/queries.tsx
+++ b/apps/admin-ui/src/common/queries.tsx
@@ -43,8 +43,6 @@ export const UNIT_QUERY = gql`
       }
       location {
         ...LocationFields
-        longitude
-        latitude
       }
     }
   }

--- a/apps/ui/components/Instructions.tsx
+++ b/apps/ui/components/Instructions.tsx
@@ -1,8 +1,9 @@
 import {
+  type InstructionsFragment,
   type Maybe,
-  type ReservationQuery,
   ReservationStateChoice,
 } from "@/gql/gql-types";
+import { gql } from "@apollo/client";
 import { H4 } from "common";
 import {
   convertLanguageCode,
@@ -11,12 +12,28 @@ import {
 import { Sanitize } from "common/src/components/Sanitize";
 import { useTranslation } from "next-i18next";
 
-// TODO replace with a fragment
-type NodeT = NonNullable<ReservationQuery["reservation"]>;
-type Props = {
-  reservation: Pick<NodeT, "reservationUnits" | "state">;
-};
+export const INSTRUCTIOSN_FRAGMENT = gql`
+  fragment Instructions on ReservationNode {
+    id
+    state
+    reservationUnits {
+      id
+      reservationPendingInstructionsFi
+      reservationPendingInstructionsEn
+      reservationPendingInstructionsSv
+      reservationConfirmedInstructionsFi
+      reservationConfirmedInstructionsEn
+      reservationConfirmedInstructionsSv
+      reservationCancelledInstructionsFi
+      reservationCancelledInstructionsEn
+      reservationCancelledInstructionsSv
+    }
+  }
+`;
 
+type Props = {
+  reservation: InstructionsFragment;
+};
 export function Instructions({ reservation }: Props): JSX.Element | null {
   const { t, i18n } = useTranslation();
 

--- a/apps/ui/components/reservation-unit/Address.tsx
+++ b/apps/ui/components/reservation-unit/Address.tsx
@@ -5,7 +5,7 @@ import { fontMedium, H4 } from "common/src/common/typography";
 import type {
   Maybe,
   LocationFieldsI18nFragment,
-  UnitFieldsFragment,
+  AddressFieldsFragment,
 } from "@gql/gql-types";
 import { IconLinkExternal } from "hds-react";
 import { IconButton } from "common/src/components";
@@ -16,6 +16,7 @@ import {
   getTranslationSafe,
 } from "common/src/common/util";
 import { type LocalizationLanguages } from "common/src/helpers";
+import { gql } from "@apollo/client";
 
 const AddressSpan = styled.span`
   font-size: var(--fontsize-body-l);
@@ -39,7 +40,7 @@ type UrlReturn = string;
 
 function createHslUrl(
   locale: LocalizationLanguages,
-  location?: Maybe<LocationFieldsI18nFragment>
+  location: Maybe<LocationFieldsI18nFragment> | undefined
 ): UrlReturn {
   if (!location) {
     return "";
@@ -61,18 +62,14 @@ function createHslUrl(
 
 function createGoogleUrl(
   locale: LocalizationLanguages,
-  location?: Maybe<LocationFieldsI18nFragment>
+  location: Maybe<LocationFieldsI18nFragment> | undefined
 ): UrlReturn {
   if (!location) {
     return "";
   }
 
-  const addressStreet =
-    getTranslationSafe(location, "addressStreet", locale) ||
-    location.addressStreetFi;
-  const addressCity =
-    getTranslationSafe(location, "addressCity", locale) ||
-    location.addressCityFi;
+  const addressStreet = getTranslationSafe(location, "addressStreet", locale);
+  const addressCity = getTranslationSafe(location, "addressCity", locale);
 
   const destination = addressStreet
     ? encodeURI(`${addressStreet},${addressCity}`)
@@ -83,7 +80,7 @@ function createGoogleUrl(
 
 function createMapUrl(
   locale: LocalizationLanguages,
-  unit?: Maybe<Pick<UnitFieldsFragment, "tprekId">>
+  unit: Maybe<Pick<AddressFieldsFragment, "tprekId">> | undefined
 ): string {
   if (!unit?.tprekId) {
     return "";
@@ -94,7 +91,7 @@ function createMapUrl(
 
 function createAccessibilityUrl(
   locale: LocalizationLanguages,
-  unit?: Maybe<Pick<UnitFieldsFragment, "tprekId">>
+  unit: Maybe<Pick<AddressFieldsFragment, "tprekId">> | undefined
 ): UrlReturn {
   if (!unit?.tprekId) {
     return "";
@@ -105,7 +102,7 @@ function createAccessibilityUrl(
 
 type Props = {
   title: string;
-  unit?: Maybe<UnitFieldsFragment> | undefined;
+  unit: Maybe<AddressFieldsFragment> | undefined;
 };
 
 export function AddressSection({ title, unit }: Props): JSX.Element {
@@ -114,12 +111,12 @@ export function AddressSection({ title, unit }: Props): JSX.Element {
   const { location } = unit ?? {};
   const lang = convertLanguageCode(i18n.language);
 
-  const addressStreet =
-    (location && getTranslationSafe(location, "addressStreet", lang)) ||
-    location?.addressStreetFi;
-  const addressCity =
-    (location && getTranslationSafe(location, "addressCity", lang)) ||
-    location?.addressCityFi;
+  const addressStreet = location
+    ? getTranslationSafe(location, "addressStreet", lang)
+    : undefined;
+  const addressCity = location
+    ? getTranslationSafe(location, "addressCity", lang)
+    : undefined;
 
   const unitMapUrl = createMapUrl(lang, unit);
   const googleUrl = createGoogleUrl(lang, location);
@@ -137,24 +134,32 @@ export function AddressSection({ title, unit }: Props): JSX.Element {
         <IconButton
           href={unitMapUrl}
           label={t("reservationUnit:linkMap")}
-          icon={<IconLinkExternal aria-hidden />}
+          icon={<IconLinkExternal aria-hidden="true" />}
         />
         <IconButton
           href={googleUrl}
           label={t("reservationUnit:linkGoogle")}
-          icon={<IconLinkExternal aria-hidden />}
+          icon={<IconLinkExternal aria-hidden="true" />}
         />
         <IconButton
           href={hslUrl}
           label={t("reservationUnit:linkHSL")}
-          icon={<IconLinkExternal aria-hidden />}
+          icon={<IconLinkExternal aria-hidden="true" />}
         />
         <IconButton
           href={accessibilityUrl}
           label={t("reservationUnit:linkAccessibility")}
-          icon={<IconLinkExternal aria-hidden />}
+          icon={<IconLinkExternal aria-hidden="true" />}
         />
       </Links>
     </div>
   );
 }
+
+export const ADDRESS_FIELDS = gql`
+  fragment AddressFields on UnitNode {
+    ...UnitNameFieldsI18N
+    id
+    tprekId
+  }
+`;

--- a/apps/ui/components/reservation-unit/ReservationInfoContainer.tsx
+++ b/apps/ui/components/reservation-unit/ReservationInfoContainer.tsx
@@ -58,13 +58,17 @@ function getStatus(
 export function ReservationInfoContainer({
   reservationUnit,
   reservationUnitIsReservable,
-}: Props): JSX.Element {
+}: Props): JSX.Element | null {
   const { t } = useTranslation();
 
   const isReservable =
     reservationUnitIsReservable &&
     (reservationUnit.reservationsMaxDaysBefore != null ||
       reservationUnit.reservationsMinDaysBefore != null);
+
+  if (!reservationUnitIsReservable) {
+    return null;
+  }
 
   // TODO this should be a list
   return (

--- a/apps/ui/components/reservation/AcceptTerms.tsx
+++ b/apps/ui/components/reservation/AcceptTerms.tsx
@@ -3,19 +3,16 @@ import TermsBox from "common/src/termsbox/TermsBox";
 import { useTranslation } from "next-i18next";
 import { getTranslation } from "@/modules/util";
 import { Sanitize } from "common/src/components/Sanitize";
-import { type ReservationUnitPageQuery } from "@/gql/gql-types";
+import { type TermsOfUseFragment } from "@/gql/gql-types";
 import { Flex } from "common/styles/util";
 
-type ReservationUnitNodeT = NonNullable<
-  ReservationUnitPageQuery["reservationUnit"]
->;
 export function AcceptTerms({
   reservationUnit,
   isTermsAccepted,
   setIsTermsAccepted,
 }: {
   reservationUnit: Pick<
-    ReservationUnitNodeT,
+    TermsOfUseFragment,
     "cancellationTerms" | "paymentTerms" | "serviceSpecificTerms"
   >;
   isTermsAccepted: { space: boolean; service: boolean };

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -2,7 +2,7 @@ import { breakpoints } from "common/src/common/style";
 import type { PendingReservation } from "@/modules/types";
 import type {
   BlockingReservationFieldsFragment,
-  ReservationQuery,
+  ReservationEditPageQuery,
   ReservationUnitPageQuery,
 } from "@gql/gql-types";
 import { differenceInMinutes } from "date-fns";
@@ -42,7 +42,7 @@ import { H4 } from "common";
 type ReservationUnitNodeT = NonNullable<
   ReservationUnitPageQuery["reservationUnit"]
 >;
-type ReservationNodeT = NonNullable<ReservationQuery["reservation"]>;
+type ReservationNodeT = NonNullable<ReservationEditPageQuery["reservation"]>;
 type Props = {
   reservation: ReservationNodeT;
   reservationUnit: ReservationUnitNodeT;

--- a/apps/ui/components/reservation/EditStep1.tsx
+++ b/apps/ui/components/reservation/EditStep1.tsx
@@ -1,5 +1,5 @@
 import {
-  type ReservationQuery,
+  type ReservationEditPageQuery,
   type ReservationUnitPageQuery,
 } from "@gql/gql-types";
 import { Button, IconArrowLeft, IconCross } from "hds-react";
@@ -25,7 +25,7 @@ import { getReservationPath } from "@/modules/urls";
 type ReservationUnitNodeT = NonNullable<
   ReservationUnitPageQuery["reservationUnit"]
 >;
-type ReservationNodeT = NonNullable<ReservationQuery["reservation"]>;
+type ReservationNodeT = NonNullable<ReservationEditPageQuery["reservation"]>;
 type Props = {
   reservation: ReservationNodeT;
   reservationUnit: ReservationUnitNodeT;

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -109,7 +109,6 @@ export function ReservationInfoCard({
 
   const { begin, end } = reservation || {};
   // NOTE can be removed after this has been refactored not to be used for PendingReservation
-  const taxPercentageValue = reservation.taxPercentageValue;
 
   const timeString = capitalize(
     formatDateTimeRange(t, new Date(begin), new Date(end))
@@ -133,7 +132,7 @@ export function ReservationInfoCard({
     shouldDisplayReservationUnitPrice
   );
   const shouldDisplayTaxPercentage: boolean =
-    reservation.state === ReservationStateChoice.RequiresHandling && begin
+    reservation.state === ReservationStateChoice.RequiresHandling
       ? isReservationUnitPaid(reservationUnit.pricings, new Date(begin))
       : Number(reservation?.price) > 0;
 
@@ -146,6 +145,7 @@ export function ReservationInfoCard({
       ? getTranslationSafe(reservationUnit.unit, "name", lang)
       : "-";
 
+  const { taxPercentageValue } = reservation;
   // TODO why does this not use the Card component?
   return (
     <Wrapper $type={type} className={className} style={style}>

--- a/apps/ui/components/reservation/Step0.tsx
+++ b/apps/ui/components/reservation/Step0.tsx
@@ -11,11 +11,7 @@ import styled from "styled-components";
 import MetaFields from "common/src/reservation-form/MetaFields";
 import { ActionContainer } from "./styles";
 import InfoDialog from "../common/InfoDialog";
-import {
-  CustomerTypeChoice,
-  type ReservationQuery,
-  type ReservationUnitPageFieldsFragment,
-} from "@gql/gql-types";
+import { CustomerTypeChoice, type ReservationQuery } from "@gql/gql-types";
 import { filterNonNullable } from "common/src/helpers";
 import { containsField, FieldName } from "common/src/metaFieldsHelpers";
 import { getApplicationFields, getGeneralFields } from "./SummaryFields";
@@ -28,19 +24,18 @@ import {
 
 type ReservationT = NonNullable<ReservationQuery["reservation"]>;
 type Props = {
-  reservationUnit: ReservationUnitPageFieldsFragment;
   cancelReservation: () => void;
   reservation: ReservationT;
   options: Record<string, OptionType[]>;
 };
 
 export function Step0({
-  reservationUnit,
   reservation,
   cancelReservation,
   options,
 }: Props): JSX.Element {
   const { t, i18n } = useTranslation();
+  const reservationUnit = reservation?.reservationUnits?.find(() => true);
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -51,7 +46,7 @@ export function Step0({
   } = form;
 
   const supportedFields = filterNonNullable(
-    reservationUnit.metadataSet?.supportedFields
+    reservationUnit?.metadataSet?.supportedFields
   );
   const reserveeType = watch("reserveeType");
   const homeCity = watch("homeCity");
@@ -70,10 +65,15 @@ export function Step0({
   const submitDisabled = !isValid || !isReserveeTypeValid || !isHomeCityValid;
 
   const lang = convertLanguageCode(i18n.language);
-  const pricingTerms = reservationUnit.pricingTerms
+  const pricingTerms = reservationUnit?.pricingTerms
     ? getTranslationSafe(reservationUnit.pricingTerms, "text", lang)
     : "";
 
+  if (reservationUnit == null) {
+    return (
+      <Notification type="error">{t("common:errors.dataError")}</Notification>
+    );
+  }
   return (
     <>
       <MetaFields

--- a/apps/ui/components/reservation/Step1.tsx
+++ b/apps/ui/components/reservation/Step1.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "next-i18next";
-import { Button, IconArrowLeft, IconArrowRight } from "hds-react";
-import {
-  type ReservationQuery,
-  type ReservationUnitPageFieldsFragment,
-} from "@gql/gql-types";
+import { Button, IconArrowLeft, IconArrowRight, Notification } from "hds-react";
+import { type ReservationQuery } from "@gql/gql-types";
 import { ActionContainer } from "./styles";
 import { useFormContext } from "react-hook-form";
 import {
@@ -18,7 +15,6 @@ import { AcceptTerms } from "./AcceptTerms";
 type NodeT = NonNullable<ReservationQuery["reservation"]>;
 type Props = {
   reservation: NodeT;
-  reservationUnit: ReservationUnitPageFieldsFragment;
   supportedFields: FieldName[];
   options: OptionsRecord;
   requiresHandling: boolean;
@@ -27,7 +23,6 @@ type Props = {
 
 export function Step1({
   reservation,
-  reservationUnit,
   supportedFields,
   options,
   requiresHandling,
@@ -50,6 +45,8 @@ export function Step1({
     setIsTermsAccepted({ ...isTermsAccepted, [key]: val });
   };
 
+  const reservationUnit = reservation?.reservationUnits?.find(() => true);
+
   const areTermsAccepted = isTermsAccepted.space && isTermsAccepted.service;
   const loadingText = t(
     `reservationCalendar:${requiresHandling ? "nextStep" : "makeReservation"}Loading`
@@ -58,6 +55,11 @@ export function Step1({
     `reservationCalendar:${requiresHandling ? "nextStep" : "makeReservation"}`
   );
 
+  if (!reservationUnit) {
+    return (
+      <Notification type="error">{t("common:errors.dataError")}</Notification>
+    );
+  }
   return (
     <>
       <GeneralFields
@@ -80,7 +82,7 @@ export function Step1({
           variant="primary"
           type="submit"
           iconRight={
-            requiresHandling ? <IconArrowRight aria-hidden /> : undefined
+            requiresHandling ? <IconArrowRight aria-hidden="true" /> : undefined
           }
           data-testid="reservation__button--continue"
           isLoading={isSubmitting}
@@ -91,7 +93,7 @@ export function Step1({
         </Button>
         <Button
           variant="secondary"
-          iconLeft={<IconArrowLeft aria-hidden />}
+          iconLeft={<IconArrowLeft aria-hidden="true" />}
           onClick={() => setStep(0)}
           data-testid="reservation__button--cancel"
         >

--- a/apps/ui/components/reservation/SummaryFields.tsx
+++ b/apps/ui/components/reservation/SummaryFields.tsx
@@ -2,14 +2,11 @@ import styled from "styled-components";
 import { type TFunction, useTranslation } from "next-i18next";
 import { getReservationApplicationFields } from "common/src/reservation-form/util";
 import { capitalize } from "@/modules/util";
-import {
-  CustomerTypeChoice,
-  type ReservationNode,
-  type ReservationQuery,
-} from "@/gql/gql-types";
+import { CustomerTypeChoice, type ReservationNode } from "@/gql/gql-types";
 import { type FieldName, containsField } from "common/src/metaFieldsHelpers";
 import { AutoGrid } from "common/styles/util";
 import { H4 } from "common";
+import { type MetaFieldsFragment } from "common/gql/gql-types";
 
 type OptionType = {
   label: string;
@@ -20,7 +17,7 @@ export type OptionsRecord = Record<
   "purpose" | "ageGroup" | "homeCity",
   OptionType[]
 >;
-type NodeT = NonNullable<ReservationQuery["reservation"]>;
+type NodeT = MetaFieldsFragment;
 
 const ParagraphAlt = styled.div<{ $isWide?: boolean }>`
   ${({ $isWide }) => $isWide && "grid-column: 1 / -1;"}

--- a/apps/ui/components/reservations/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/reservations/UnpaidReservationNotification.tsx
@@ -209,7 +209,7 @@ export function InProgressReservationNotification() {
     deleteReservation,
     { data: deleteData, error: deleteError, loading: isDeleteLoading },
   ] = useDeleteReservationMutation();
-  const deleted = deleteData?.deleteReservation?.deleted;
+  const deleted = deleteData?.deleteTentativeReservation?.deleted;
 
   const order = unpaidReservation?.paymentOrder[0];
   const checkoutUrl = getCheckoutUrl(order, i18n.language);

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -6291,11 +6291,11 @@ export type UpdateReservationMutation = {
 };
 
 export type DeleteReservationMutationVariables = Exact<{
-  input: ReservationDeleteMutationInput;
+  input: ReservationDeleteTentativeMutationInput;
 }>;
 
 export type DeleteReservationMutation = {
-  deleteReservation?: { deleted?: boolean | null } | null;
+  deleteTentativeReservation?: { deleted?: boolean | null } | null;
 };
 
 export type CancelReservationMutationVariables = Exact<{
@@ -10285,8 +10285,8 @@ export type UpdateReservationMutationOptions = Apollo.BaseMutationOptions<
   UpdateReservationMutationVariables
 >;
 export const DeleteReservationDocument = gql`
-  mutation DeleteReservation($input: ReservationDeleteMutationInput!) {
-    deleteReservation(input: $input) {
+  mutation DeleteReservation($input: ReservationDeleteTentativeMutationInput!) {
+    deleteTentativeReservation(input: $input) {
       deleted
     }
   }

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5311,6 +5311,42 @@ export enum Weekday {
   Wednesday = "WEDNESDAY",
 }
 
+export type InstructionsFragment = {
+  id: string;
+  state?: ReservationStateChoice | null;
+  reservationUnits: Array<{
+    id: string;
+    reservationPendingInstructionsFi?: string | null;
+    reservationPendingInstructionsEn?: string | null;
+    reservationPendingInstructionsSv?: string | null;
+    reservationConfirmedInstructionsFi?: string | null;
+    reservationConfirmedInstructionsEn?: string | null;
+    reservationConfirmedInstructionsSv?: string | null;
+    reservationCancelledInstructionsFi?: string | null;
+    reservationCancelledInstructionsEn?: string | null;
+    reservationCancelledInstructionsSv?: string | null;
+  }>;
+};
+
+export type AddressFieldsFragment = {
+  id: string;
+  tprekId?: string | null;
+  pk?: number | null;
+  nameFi?: string | null;
+  nameEn?: string | null;
+  nameSv?: string | null;
+  location?: {
+    addressStreetEn?: string | null;
+    addressStreetSv?: string | null;
+    addressCityEn?: string | null;
+    addressCitySv?: string | null;
+    id: string;
+    addressStreetFi?: string | null;
+    addressZip: string;
+    addressCityFi?: string | null;
+  } | null;
+};
+
 export type ReservationInfoContainerFragment = {
   reservationBegins?: string | null;
   reservationEnds?: string | null;
@@ -6152,68 +6188,10 @@ export type UnitNameFieldsI18NFragment = {
   } | null;
 };
 
-export type UnitFieldsFragment = {
-  id: string;
-  tprekId?: string | null;
-  pk?: number | null;
-  nameFi?: string | null;
-  nameEn?: string | null;
-  nameSv?: string | null;
-  location?: {
-    id: string;
-    latitude?: string | null;
-    longitude?: string | null;
-    addressStreetEn?: string | null;
-    addressStreetSv?: string | null;
-    addressCityEn?: string | null;
-    addressCitySv?: string | null;
-    addressStreetFi?: string | null;
-    addressZip: string;
-    addressCityFi?: string | null;
-  } | null;
-};
-
-export type ReservationUnitFieldsFragment = {
-  id: string;
-  pk?: number | null;
-  uuid: string;
-  nameFi?: string | null;
-  nameEn?: string | null;
-  nameSv?: string | null;
-  reservationPendingInstructionsFi?: string | null;
-  reservationPendingInstructionsEn?: string | null;
-  reservationPendingInstructionsSv?: string | null;
-  reservationConfirmedInstructionsFi?: string | null;
-  reservationConfirmedInstructionsEn?: string | null;
-  reservationConfirmedInstructionsSv?: string | null;
-  reservationCancelledInstructionsFi?: string | null;
-  reservationCancelledInstructionsEn?: string | null;
-  reservationCancelledInstructionsSv?: string | null;
+export type TermsOfUseFragment = {
   termsOfUseFi?: string | null;
   termsOfUseEn?: string | null;
   termsOfUseSv?: string | null;
-  minPersons?: number | null;
-  maxPersons?: number | null;
-  unit?: {
-    id: string;
-    tprekId?: string | null;
-    pk?: number | null;
-    nameFi?: string | null;
-    nameEn?: string | null;
-    nameSv?: string | null;
-    location?: {
-      id: string;
-      latitude?: string | null;
-      longitude?: string | null;
-      addressStreetEn?: string | null;
-      addressStreetSv?: string | null;
-      addressCityEn?: string | null;
-      addressCitySv?: string | null;
-      addressStreetFi?: string | null;
-      addressZip: string;
-      addressCityFi?: string | null;
-    } | null;
-  } | null;
   serviceSpecificTerms?: {
     id: string;
     textFi?: string | null;
@@ -6240,27 +6218,6 @@ export type ReservationUnitFieldsFragment = {
     textFi?: string | null;
     textEn?: string | null;
     textSv?: string | null;
-  } | null;
-  pricings: Array<{
-    id: string;
-    begins: string;
-    priceUnit: PriceUnit;
-    lowestPrice: string;
-    highestPrice: string;
-    taxPercentage: { id: string; pk?: number | null; value: string };
-  }>;
-  images: Array<{
-    id: string;
-    imageUrl?: string | null;
-    largeUrl?: string | null;
-    mediumUrl?: string | null;
-    smallUrl?: string | null;
-    imageType: ImageType;
-  }>;
-  metadataSet?: {
-    id: string;
-    requiredFields: Array<{ id: string; fieldName: string }>;
-    supportedFields: Array<{ id: string; fieldName: string }>;
   } | null;
 };
 
@@ -6459,25 +6416,6 @@ export type ListReservationsQuery = {
   } | null;
 };
 
-export type ReservationInfoFragment = {
-  description?: string | null;
-  numPersons?: number | null;
-  purpose?: {
-    id: string;
-    pk?: number | null;
-    nameFi?: string | null;
-    nameEn?: string | null;
-    nameSv?: string | null;
-  } | null;
-  ageGroup?: {
-    id: string;
-    pk?: number | null;
-    minimum: number;
-    maximum?: number | null;
-  } | null;
-  homeCity?: { id: string; pk?: number | null; name: string } | null;
-};
-
 export type OrderFieldsFragment = {
   id: string;
   reservationPk?: string | null;
@@ -6509,168 +6447,6 @@ export type ReservationStateQuery = {
     id: string;
     pk?: number | null;
     state?: ReservationStateChoice | null;
-  } | null;
-};
-
-export type ReservationQueryVariables = Exact<{
-  id: Scalars["ID"]["input"];
-}>;
-
-export type ReservationQuery = {
-  reservation?: {
-    id: string;
-    pk?: number | null;
-    name?: string | null;
-    applyingForFreeOfCharge?: boolean | null;
-    freeOfChargeReason?: string | null;
-    bufferTimeBefore: number;
-    bufferTimeAfter: number;
-    begin: string;
-    end: string;
-    calendarUrl?: string | null;
-    state?: ReservationStateChoice | null;
-    price?: string | null;
-    priceNet?: string | null;
-    taxPercentageValue?: string | null;
-    isHandled?: boolean | null;
-    reserveeFirstName?: string | null;
-    reserveeLastName?: string | null;
-    reserveeEmail?: string | null;
-    reserveePhone?: string | null;
-    reserveeType?: CustomerTypeChoice | null;
-    reserveeOrganisationName?: string | null;
-    reserveeId?: string | null;
-    reserveeIsUnregisteredAssociation?: boolean | null;
-    reserveeAddressStreet?: string | null;
-    reserveeAddressCity?: string | null;
-    reserveeAddressZip?: string | null;
-    billingFirstName?: string | null;
-    billingLastName?: string | null;
-    billingPhone?: string | null;
-    billingEmail?: string | null;
-    billingAddressStreet?: string | null;
-    billingAddressCity?: string | null;
-    billingAddressZip?: string | null;
-    description?: string | null;
-    numPersons?: number | null;
-    user?: { id: string; email: string; pk?: number | null } | null;
-    paymentOrder: Array<{
-      id: string;
-      reservationPk?: string | null;
-      status?: OrderStatus | null;
-      paymentType: PaymentType;
-      receiptUrl?: string | null;
-      checkoutUrl?: string | null;
-    }>;
-    reservationUnits: Array<{
-      id: string;
-      canApplyFreeOfCharge: boolean;
-      pk?: number | null;
-      uuid: string;
-      nameFi?: string | null;
-      nameEn?: string | null;
-      nameSv?: string | null;
-      reservationPendingInstructionsFi?: string | null;
-      reservationPendingInstructionsEn?: string | null;
-      reservationPendingInstructionsSv?: string | null;
-      reservationConfirmedInstructionsFi?: string | null;
-      reservationConfirmedInstructionsEn?: string | null;
-      reservationConfirmedInstructionsSv?: string | null;
-      reservationCancelledInstructionsFi?: string | null;
-      reservationCancelledInstructionsEn?: string | null;
-      reservationCancelledInstructionsSv?: string | null;
-      termsOfUseFi?: string | null;
-      termsOfUseEn?: string | null;
-      termsOfUseSv?: string | null;
-      minPersons?: number | null;
-      maxPersons?: number | null;
-      unit?: {
-        id: string;
-        tprekId?: string | null;
-        pk?: number | null;
-        nameFi?: string | null;
-        nameEn?: string | null;
-        nameSv?: string | null;
-        location?: {
-          id: string;
-          latitude?: string | null;
-          longitude?: string | null;
-          addressStreetEn?: string | null;
-          addressStreetSv?: string | null;
-          addressCityEn?: string | null;
-          addressCitySv?: string | null;
-          addressStreetFi?: string | null;
-          addressZip: string;
-          addressCityFi?: string | null;
-        } | null;
-      } | null;
-      serviceSpecificTerms?: {
-        id: string;
-        textFi?: string | null;
-        textEn?: string | null;
-        textSv?: string | null;
-      } | null;
-      cancellationTerms?: {
-        id: string;
-        textFi?: string | null;
-        textEn?: string | null;
-        textSv?: string | null;
-      } | null;
-      paymentTerms?: {
-        id: string;
-        textFi?: string | null;
-        textEn?: string | null;
-        textSv?: string | null;
-      } | null;
-      pricingTerms?: {
-        nameFi?: string | null;
-        nameEn?: string | null;
-        nameSv?: string | null;
-        id: string;
-        textFi?: string | null;
-        textEn?: string | null;
-        textSv?: string | null;
-      } | null;
-      pricings: Array<{
-        id: string;
-        begins: string;
-        priceUnit: PriceUnit;
-        lowestPrice: string;
-        highestPrice: string;
-        taxPercentage: { id: string; pk?: number | null; value: string };
-      }>;
-      images: Array<{
-        id: string;
-        imageUrl?: string | null;
-        largeUrl?: string | null;
-        mediumUrl?: string | null;
-        smallUrl?: string | null;
-        imageType: ImageType;
-      }>;
-      cancellationRule?: {
-        id: string;
-        canBeCancelledTimeBefore?: number | null;
-      } | null;
-      metadataSet?: {
-        id: string;
-        requiredFields: Array<{ id: string; fieldName: string }>;
-        supportedFields: Array<{ id: string; fieldName: string }>;
-      } | null;
-    }>;
-    purpose?: {
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-      nameEn?: string | null;
-      nameSv?: string | null;
-    } | null;
-    ageGroup?: {
-      id: string;
-      pk?: number | null;
-      minimum: number;
-      maximum?: number | null;
-    } | null;
-    homeCity?: { id: string; pk?: number | null; name: string } | null;
   } | null;
 };
 
@@ -6741,6 +6517,12 @@ export type EquipmentFieldsFragment = {
 };
 
 export type ReservationUnitPageFieldsFragment = {
+  id: string;
+  pk?: number | null;
+  uuid: string;
+  nameFi?: string | null;
+  nameEn?: string | null;
+  nameSv?: string | null;
   isDraft: boolean;
   descriptionFi?: string | null;
   descriptionEn?: string | null;
@@ -6754,24 +6536,11 @@ export type ReservationUnitPageFieldsFragment = {
   reservationState?: ReservationUnitReservationState | null;
   numActiveUserReservations?: number | null;
   requireReservationHandling: boolean;
-  id: string;
-  pk?: number | null;
-  uuid: string;
-  nameFi?: string | null;
-  nameEn?: string | null;
-  nameSv?: string | null;
-  reservationPendingInstructionsFi?: string | null;
-  reservationPendingInstructionsEn?: string | null;
-  reservationPendingInstructionsSv?: string | null;
-  reservationConfirmedInstructionsFi?: string | null;
-  reservationConfirmedInstructionsEn?: string | null;
-  reservationConfirmedInstructionsSv?: string | null;
-  reservationCancelledInstructionsFi?: string | null;
-  reservationCancelledInstructionsEn?: string | null;
-  reservationCancelledInstructionsSv?: string | null;
   termsOfUseFi?: string | null;
   termsOfUseEn?: string | null;
   termsOfUseSv?: string | null;
+  minPersons?: number | null;
+  maxPersons?: number | null;
   reservationBegins?: string | null;
   reservationEnds?: string | null;
   reservationsMaxDaysBefore?: number | null;
@@ -6779,8 +6548,32 @@ export type ReservationUnitPageFieldsFragment = {
   minReservationDuration?: number | null;
   maxReservationDuration?: number | null;
   maxReservationsPerUser?: number | null;
-  minPersons?: number | null;
-  maxPersons?: number | null;
+  unit?: {
+    id: string;
+    tprekId?: string | null;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
+    location?: {
+      addressStreetEn?: string | null;
+      addressStreetSv?: string | null;
+      addressCityEn?: string | null;
+      addressCitySv?: string | null;
+      id: string;
+      addressStreetFi?: string | null;
+      addressZip: string;
+      addressCityFi?: string | null;
+    } | null;
+  } | null;
+  pricings: Array<{
+    id: string;
+    begins: string;
+    priceUnit: PriceUnit;
+    lowestPrice: string;
+    highestPrice: string;
+    taxPercentage: { id: string; pk?: number | null; value: string };
+  }>;
   images: Array<{
     id: string;
     imageUrl?: string | null;
@@ -6820,26 +6613,6 @@ export type ReservationUnitPageFieldsFragment = {
       nameSv?: string | null;
     };
   }>;
-  unit?: {
-    id: string;
-    tprekId?: string | null;
-    pk?: number | null;
-    nameFi?: string | null;
-    nameEn?: string | null;
-    nameSv?: string | null;
-    location?: {
-      id: string;
-      latitude?: string | null;
-      longitude?: string | null;
-      addressStreetEn?: string | null;
-      addressStreetSv?: string | null;
-      addressCityEn?: string | null;
-      addressCitySv?: string | null;
-      addressStreetFi?: string | null;
-      addressZip: string;
-      addressCityFi?: string | null;
-    } | null;
-  } | null;
   serviceSpecificTerms?: {
     id: string;
     textFi?: string | null;
@@ -6867,14 +6640,6 @@ export type ReservationUnitPageFieldsFragment = {
     textEn?: string | null;
     textSv?: string | null;
   } | null;
-  pricings: Array<{
-    id: string;
-    begins: string;
-    priceUnit: PriceUnit;
-    lowestPrice: string;
-    highestPrice: string;
-    taxPercentage: { id: string; pk?: number | null; value: string };
-  }>;
   metadataSet?: {
     id: string;
     requiredFields: Array<{ id: string; fieldName: string }>;
@@ -6894,154 +6659,6 @@ export type BlockingReservationFieldsFragment = {
   bufferTimeBefore: number;
   bufferTimeAfter: number;
   affectedReservationUnits?: Array<number | null> | null;
-};
-
-export type ReservationUnitQueryVariables = Exact<{
-  id: Scalars["ID"]["input"];
-}>;
-
-export type ReservationUnitQuery = {
-  reservationUnit?: {
-    isDraft: boolean;
-    descriptionFi?: string | null;
-    descriptionEn?: string | null;
-    descriptionSv?: string | null;
-    reservationKind: ReservationKind;
-    bufferTimeBefore: number;
-    bufferTimeAfter: number;
-    reservationStartInterval: ReservationStartInterval;
-    canApplyFreeOfCharge: boolean;
-    publishingState?: ReservationUnitPublishingState | null;
-    reservationState?: ReservationUnitReservationState | null;
-    numActiveUserReservations?: number | null;
-    requireReservationHandling: boolean;
-    id: string;
-    pk?: number | null;
-    uuid: string;
-    nameFi?: string | null;
-    nameEn?: string | null;
-    nameSv?: string | null;
-    reservationPendingInstructionsFi?: string | null;
-    reservationPendingInstructionsEn?: string | null;
-    reservationPendingInstructionsSv?: string | null;
-    reservationConfirmedInstructionsFi?: string | null;
-    reservationConfirmedInstructionsEn?: string | null;
-    reservationConfirmedInstructionsSv?: string | null;
-    reservationCancelledInstructionsFi?: string | null;
-    reservationCancelledInstructionsEn?: string | null;
-    reservationCancelledInstructionsSv?: string | null;
-    termsOfUseFi?: string | null;
-    termsOfUseEn?: string | null;
-    termsOfUseSv?: string | null;
-    reservationBegins?: string | null;
-    reservationEnds?: string | null;
-    reservationsMaxDaysBefore?: number | null;
-    reservationsMinDaysBefore?: number | null;
-    minReservationDuration?: number | null;
-    maxReservationDuration?: number | null;
-    maxReservationsPerUser?: number | null;
-    minPersons?: number | null;
-    maxPersons?: number | null;
-    images: Array<{
-      id: string;
-      imageUrl?: string | null;
-      largeUrl?: string | null;
-      mediumUrl?: string | null;
-      smallUrl?: string | null;
-      imageType: ImageType;
-    }>;
-    applicationRoundTimeSlots: Array<{
-      id: string;
-      closed: boolean;
-      weekday: number;
-      reservableTimes?: Array<{ begin: string; end: string } | null> | null;
-    }>;
-    applicationRounds: Array<{
-      id: string;
-      reservationPeriodBegin: string;
-      reservationPeriodEnd: string;
-    }>;
-    reservationUnitType?: {
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-      nameEn?: string | null;
-      nameSv?: string | null;
-    } | null;
-    equipments: Array<{
-      id: string;
-      pk?: number | null;
-      nameFi?: string | null;
-      nameEn?: string | null;
-      nameSv?: string | null;
-      category: {
-        id: string;
-        nameFi?: string | null;
-        nameEn?: string | null;
-        nameSv?: string | null;
-      };
-    }>;
-    unit?: {
-      id: string;
-      tprekId?: string | null;
-      pk?: number | null;
-      nameFi?: string | null;
-      nameEn?: string | null;
-      nameSv?: string | null;
-      location?: {
-        id: string;
-        latitude?: string | null;
-        longitude?: string | null;
-        addressStreetEn?: string | null;
-        addressStreetSv?: string | null;
-        addressCityEn?: string | null;
-        addressCitySv?: string | null;
-        addressStreetFi?: string | null;
-        addressZip: string;
-        addressCityFi?: string | null;
-      } | null;
-    } | null;
-    serviceSpecificTerms?: {
-      id: string;
-      textFi?: string | null;
-      textEn?: string | null;
-      textSv?: string | null;
-    } | null;
-    cancellationTerms?: {
-      id: string;
-      textFi?: string | null;
-      textEn?: string | null;
-      textSv?: string | null;
-    } | null;
-    paymentTerms?: {
-      id: string;
-      textFi?: string | null;
-      textEn?: string | null;
-      textSv?: string | null;
-    } | null;
-    pricingTerms?: {
-      nameFi?: string | null;
-      nameEn?: string | null;
-      nameSv?: string | null;
-      id: string;
-      textFi?: string | null;
-      textEn?: string | null;
-      textSv?: string | null;
-    } | null;
-    pricings: Array<{
-      id: string;
-      begins: string;
-      priceUnit: PriceUnit;
-      lowestPrice: string;
-      highestPrice: string;
-      taxPercentage: { id: string; pk?: number | null; value: string };
-    }>;
-    metadataSet?: {
-      id: string;
-      requiredFields: Array<{ id: string; fieldName: string }>;
-      supportedFields: Array<{ id: string; fieldName: string }>;
-    } | null;
-  } | null;
 };
 
 export type IsReservableFieldsFragment = {
@@ -7073,6 +6690,12 @@ export type ReservationUnitPageQueryVariables = Exact<{
 
 export type ReservationUnitPageQuery = {
   reservationUnit?: {
+    id: string;
+    pk?: number | null;
+    uuid: string;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
     isDraft: boolean;
     descriptionFi?: string | null;
     descriptionEn?: string | null;
@@ -7092,27 +6715,38 @@ export type ReservationUnitPageQuery = {
     reservationsMinDaysBefore?: number | null;
     reservationBegins?: string | null;
     reservationEnds?: string | null;
-    id: string;
-    pk?: number | null;
-    uuid: string;
-    nameFi?: string | null;
-    nameEn?: string | null;
-    nameSv?: string | null;
-    reservationPendingInstructionsFi?: string | null;
-    reservationPendingInstructionsEn?: string | null;
-    reservationPendingInstructionsSv?: string | null;
-    reservationConfirmedInstructionsFi?: string | null;
-    reservationConfirmedInstructionsEn?: string | null;
-    reservationConfirmedInstructionsSv?: string | null;
-    reservationCancelledInstructionsFi?: string | null;
-    reservationCancelledInstructionsEn?: string | null;
-    reservationCancelledInstructionsSv?: string | null;
     termsOfUseFi?: string | null;
     termsOfUseEn?: string | null;
     termsOfUseSv?: string | null;
-    maxReservationsPerUser?: number | null;
     minPersons?: number | null;
     maxPersons?: number | null;
+    maxReservationsPerUser?: number | null;
+    unit?: {
+      id: string;
+      tprekId?: string | null;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+      location?: {
+        addressStreetEn?: string | null;
+        addressStreetSv?: string | null;
+        addressCityEn?: string | null;
+        addressCitySv?: string | null;
+        id: string;
+        addressStreetFi?: string | null;
+        addressZip: string;
+        addressCityFi?: string | null;
+      } | null;
+    } | null;
+    pricings: Array<{
+      id: string;
+      begins: string;
+      priceUnit: PriceUnit;
+      lowestPrice: string;
+      highestPrice: string;
+      taxPercentage: { id: string; pk?: number | null; value: string };
+    }>;
     images: Array<{
       id: string;
       imageUrl?: string | null;
@@ -7156,26 +6790,6 @@ export type ReservationUnitPageQuery = {
       startDatetime?: string | null;
       endDatetime?: string | null;
     } | null> | null;
-    unit?: {
-      id: string;
-      tprekId?: string | null;
-      pk?: number | null;
-      nameFi?: string | null;
-      nameEn?: string | null;
-      nameSv?: string | null;
-      location?: {
-        id: string;
-        latitude?: string | null;
-        longitude?: string | null;
-        addressStreetEn?: string | null;
-        addressStreetSv?: string | null;
-        addressCityEn?: string | null;
-        addressCitySv?: string | null;
-        addressStreetFi?: string | null;
-        addressZip: string;
-        addressCityFi?: string | null;
-      } | null;
-    } | null;
     serviceSpecificTerms?: {
       id: string;
       textFi?: string | null;
@@ -7203,14 +6817,6 @@ export type ReservationUnitPageQuery = {
       textEn?: string | null;
       textSv?: string | null;
     } | null;
-    pricings: Array<{
-      id: string;
-      begins: string;
-      priceUnit: PriceUnit;
-      lowestPrice: string;
-      highestPrice: string;
-      taxPercentage: { id: string; pk?: number | null; value: string };
-    }>;
     metadataSet?: {
       id: string;
       requiredFields: Array<{ id: string; fieldName: string }>;
@@ -7679,6 +7285,51 @@ export type ReserveeBillingFieldsFragment = {
   billingAddressZip?: string | null;
 };
 
+export type MetaFieldsFragment = {
+  applyingForFreeOfCharge?: boolean | null;
+  freeOfChargeReason?: string | null;
+  description?: string | null;
+  numPersons?: number | null;
+  reserveeFirstName?: string | null;
+  reserveeLastName?: string | null;
+  reserveeEmail?: string | null;
+  reserveePhone?: string | null;
+  reserveeType?: CustomerTypeChoice | null;
+  reserveeOrganisationName?: string | null;
+  reserveeId?: string | null;
+  reserveeIsUnregisteredAssociation?: boolean | null;
+  reserveeAddressStreet?: string | null;
+  reserveeAddressCity?: string | null;
+  reserveeAddressZip?: string | null;
+  billingFirstName?: string | null;
+  billingLastName?: string | null;
+  billingPhone?: string | null;
+  billingEmail?: string | null;
+  billingAddressStreet?: string | null;
+  billingAddressCity?: string | null;
+  billingAddressZip?: string | null;
+  ageGroup?: {
+    id: string;
+    pk?: number | null;
+    maximum?: number | null;
+    minimum: number;
+  } | null;
+  purpose?: {
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
+  } | null;
+  homeCity?: {
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameSv?: string | null;
+    nameEn?: string | null;
+  } | null;
+};
+
 export type TermsOfUseNameFieldsFragment = {
   nameFi?: string | null;
   nameEn?: string | null;
@@ -8097,6 +7748,150 @@ export type ApplicationViewQuery = {
   } | null;
 };
 
+export type ReservationQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type ReservationQuery = {
+  reservation?: {
+    id: string;
+    pk?: number | null;
+    name?: string | null;
+    bufferTimeBefore: number;
+    bufferTimeAfter: number;
+    calendarUrl?: string | null;
+    applyingForFreeOfCharge?: boolean | null;
+    freeOfChargeReason?: string | null;
+    description?: string | null;
+    numPersons?: number | null;
+    taxPercentageValue?: string | null;
+    begin: string;
+    end: string;
+    state?: ReservationStateChoice | null;
+    price?: string | null;
+    reserveeFirstName?: string | null;
+    reserveeLastName?: string | null;
+    reserveeEmail?: string | null;
+    reserveePhone?: string | null;
+    reserveeType?: CustomerTypeChoice | null;
+    reserveeOrganisationName?: string | null;
+    reserveeId?: string | null;
+    reserveeIsUnregisteredAssociation?: boolean | null;
+    reserveeAddressStreet?: string | null;
+    reserveeAddressCity?: string | null;
+    reserveeAddressZip?: string | null;
+    billingFirstName?: string | null;
+    billingLastName?: string | null;
+    billingPhone?: string | null;
+    billingEmail?: string | null;
+    billingAddressStreet?: string | null;
+    billingAddressCity?: string | null;
+    billingAddressZip?: string | null;
+    paymentOrder: Array<{
+      id: string;
+      reservationPk?: string | null;
+      status?: OrderStatus | null;
+      paymentType: PaymentType;
+      receiptUrl?: string | null;
+      checkoutUrl?: string | null;
+    }>;
+    reservationUnits: Array<{
+      id: string;
+      canApplyFreeOfCharge: boolean;
+      requireReservationHandling: boolean;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+      minPersons?: number | null;
+      maxPersons?: number | null;
+      termsOfUseFi?: string | null;
+      termsOfUseEn?: string | null;
+      termsOfUseSv?: string | null;
+      reservationBegins?: string | null;
+      reservationEnds?: string | null;
+      images: Array<{
+        id: string;
+        imageUrl?: string | null;
+        largeUrl?: string | null;
+        mediumUrl?: string | null;
+        smallUrl?: string | null;
+        imageType: ImageType;
+      }>;
+      unit?: {
+        id: string;
+        nameFi?: string | null;
+        nameEn?: string | null;
+        nameSv?: string | null;
+      } | null;
+      cancellationRule?: {
+        id: string;
+        canBeCancelledTimeBefore?: number | null;
+      } | null;
+      metadataSet?: {
+        id: string;
+        requiredFields: Array<{ id: string; fieldName: string }>;
+        supportedFields: Array<{ id: string; fieldName: string }>;
+      } | null;
+      serviceSpecificTerms?: {
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      cancellationTerms?: {
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      paymentTerms?: {
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      pricingTerms?: {
+        nameFi?: string | null;
+        nameEn?: string | null;
+        nameSv?: string | null;
+        id: string;
+        textFi?: string | null;
+        textEn?: string | null;
+        textSv?: string | null;
+      } | null;
+      pricings: Array<{
+        id: string;
+        begins: string;
+        priceUnit: PriceUnit;
+        lowestPrice: string;
+        highestPrice: string;
+        taxPercentage: { id: string; pk?: number | null; value: string };
+      }>;
+    }>;
+    ageGroup?: {
+      id: string;
+      pk?: number | null;
+      maximum?: number | null;
+      minimum: number;
+    } | null;
+    purpose?: {
+      id: string;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+    } | null;
+    homeCity?: {
+      id: string;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameSv?: string | null;
+      nameEn?: string | null;
+    } | null;
+  } | null;
+};
+
 export type ReservationCancelPageQueryVariables = Exact<{
   id: Scalars["ID"]["input"];
 }>;
@@ -8104,12 +7899,12 @@ export type ReservationCancelPageQueryVariables = Exact<{
 export type ReservationCancelPageQuery = {
   reservation?: {
     id: string;
-    pk?: number | null;
     name?: string | null;
+    pk?: number | null;
+    taxPercentageValue?: string | null;
     begin: string;
     end: string;
     state?: ReservationStateChoice | null;
-    taxPercentageValue?: string | null;
     price?: string | null;
     reservationUnits: Array<{
       id: string;
@@ -8193,6 +7988,212 @@ export type ReservationCancelPageQuery = {
   } | null;
 };
 
+export type ReservationConfirmationPageQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type ReservationConfirmationPageQuery = {
+  reservation?: {
+    id: string;
+    pk?: number | null;
+    name?: string | null;
+    calendarUrl?: string | null;
+    reserveeFirstName?: string | null;
+    reserveeLastName?: string | null;
+    reserveeEmail?: string | null;
+    reserveePhone?: string | null;
+    reserveeType?: CustomerTypeChoice | null;
+    reserveeOrganisationName?: string | null;
+    reserveeId?: string | null;
+    reserveeIsUnregisteredAssociation?: boolean | null;
+    reserveeAddressStreet?: string | null;
+    reserveeAddressCity?: string | null;
+    reserveeAddressZip?: string | null;
+    billingFirstName?: string | null;
+    billingLastName?: string | null;
+    billingPhone?: string | null;
+    billingEmail?: string | null;
+    billingAddressStreet?: string | null;
+    billingAddressCity?: string | null;
+    billingAddressZip?: string | null;
+    description?: string | null;
+    numPersons?: number | null;
+    taxPercentageValue?: string | null;
+    begin: string;
+    end: string;
+    state?: ReservationStateChoice | null;
+    price?: string | null;
+    paymentOrder: Array<{
+      id: string;
+      reservationPk?: string | null;
+      status?: OrderStatus | null;
+      paymentType: PaymentType;
+      receiptUrl?: string | null;
+      checkoutUrl?: string | null;
+    }>;
+    reservationUnits: Array<{
+      id: string;
+      canApplyFreeOfCharge: boolean;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+      reservationPendingInstructionsFi?: string | null;
+      reservationPendingInstructionsEn?: string | null;
+      reservationPendingInstructionsSv?: string | null;
+      reservationConfirmedInstructionsFi?: string | null;
+      reservationConfirmedInstructionsEn?: string | null;
+      reservationConfirmedInstructionsSv?: string | null;
+      reservationCancelledInstructionsFi?: string | null;
+      reservationCancelledInstructionsEn?: string | null;
+      reservationCancelledInstructionsSv?: string | null;
+      reservationBegins?: string | null;
+      reservationEnds?: string | null;
+      images: Array<{
+        id: string;
+        imageUrl?: string | null;
+        largeUrl?: string | null;
+        mediumUrl?: string | null;
+        smallUrl?: string | null;
+        imageType: ImageType;
+      }>;
+      unit?: {
+        id: string;
+        nameFi?: string | null;
+        nameEn?: string | null;
+        nameSv?: string | null;
+      } | null;
+      cancellationRule?: {
+        id: string;
+        canBeCancelledTimeBefore?: number | null;
+      } | null;
+      pricings: Array<{
+        id: string;
+        begins: string;
+        priceUnit: PriceUnit;
+        lowestPrice: string;
+        highestPrice: string;
+        taxPercentage: { id: string; pk?: number | null; value: string };
+      }>;
+    }>;
+    purpose?: {
+      id: string;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+    } | null;
+    ageGroup?: {
+      id: string;
+      pk?: number | null;
+      minimum: number;
+      maximum?: number | null;
+    } | null;
+  } | null;
+};
+
+export type ReservationEditPageQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type ReservationEditPageQuery = {
+  reservation?: {
+    id: string;
+    pk?: number | null;
+    name?: string | null;
+    isHandled?: boolean | null;
+    applyingForFreeOfCharge?: boolean | null;
+    freeOfChargeReason?: string | null;
+    description?: string | null;
+    numPersons?: number | null;
+    taxPercentageValue?: string | null;
+    begin: string;
+    end: string;
+    state?: ReservationStateChoice | null;
+    price?: string | null;
+    reserveeFirstName?: string | null;
+    reserveeLastName?: string | null;
+    reserveeEmail?: string | null;
+    reserveePhone?: string | null;
+    reserveeType?: CustomerTypeChoice | null;
+    reserveeOrganisationName?: string | null;
+    reserveeId?: string | null;
+    reserveeIsUnregisteredAssociation?: boolean | null;
+    reserveeAddressStreet?: string | null;
+    reserveeAddressCity?: string | null;
+    reserveeAddressZip?: string | null;
+    billingFirstName?: string | null;
+    billingLastName?: string | null;
+    billingPhone?: string | null;
+    billingEmail?: string | null;
+    billingAddressStreet?: string | null;
+    billingAddressCity?: string | null;
+    billingAddressZip?: string | null;
+    reservationUnits: Array<{
+      id: string;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+      minPersons?: number | null;
+      maxPersons?: number | null;
+      reservationBegins?: string | null;
+      reservationEnds?: string | null;
+      images: Array<{
+        id: string;
+        imageUrl?: string | null;
+        largeUrl?: string | null;
+        mediumUrl?: string | null;
+        smallUrl?: string | null;
+        imageType: ImageType;
+      }>;
+      unit?: {
+        id: string;
+        nameFi?: string | null;
+        nameEn?: string | null;
+        nameSv?: string | null;
+      } | null;
+      cancellationRule?: {
+        id: string;
+        canBeCancelledTimeBefore?: number | null;
+      } | null;
+      metadataSet?: {
+        id: string;
+        requiredFields: Array<{ id: string; fieldName: string }>;
+        supportedFields: Array<{ id: string; fieldName: string }>;
+      } | null;
+      pricings: Array<{
+        id: string;
+        begins: string;
+        priceUnit: PriceUnit;
+        lowestPrice: string;
+        highestPrice: string;
+        taxPercentage: { id: string; pk?: number | null; value: string };
+      }>;
+    }>;
+    ageGroup?: {
+      id: string;
+      pk?: number | null;
+      maximum?: number | null;
+      minimum: number;
+    } | null;
+    purpose?: {
+      id: string;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameEn?: string | null;
+      nameSv?: string | null;
+    } | null;
+    homeCity?: {
+      id: string;
+      pk?: number | null;
+      nameFi?: string | null;
+      nameSv?: string | null;
+      nameEn?: string | null;
+    } | null;
+  } | null;
+};
+
 export type ApplicationRecurringReservationQueryVariables = Exact<{
   id: Scalars["ID"]["input"];
 }>;
@@ -8221,13 +8222,8 @@ export type ReservationPageQuery = {
   reservation?: {
     id: string;
     pk?: number | null;
-    name?: string | null;
     applyingForFreeOfCharge?: boolean | null;
-    begin: string;
-    end: string;
     calendarUrl?: string | null;
-    state?: ReservationStateChoice | null;
-    price?: string | null;
     reserveeFirstName?: string | null;
     reserveeLastName?: string | null;
     reserveeEmail?: string | null;
@@ -8248,9 +8244,16 @@ export type ReservationPageQuery = {
     billingAddressZip?: string | null;
     description?: string | null;
     numPersons?: number | null;
+    taxPercentageValue?: string | null;
+    begin: string;
+    end: string;
+    state?: ReservationStateChoice | null;
+    price?: string | null;
     paymentOrder: Array<{
       id: string;
+      reservationPk?: string | null;
       status?: OrderStatus | null;
+      paymentType: PaymentType;
       receiptUrl?: string | null;
       checkoutUrl?: string | null;
     }>;
@@ -8259,7 +8262,6 @@ export type ReservationPageQuery = {
       id: string;
       canApplyFreeOfCharge: boolean;
       pk?: number | null;
-      uuid: string;
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
@@ -8272,30 +8274,47 @@ export type ReservationPageQuery = {
       reservationCancelledInstructionsFi?: string | null;
       reservationCancelledInstructionsEn?: string | null;
       reservationCancelledInstructionsSv?: string | null;
+      minPersons?: number | null;
+      maxPersons?: number | null;
       termsOfUseFi?: string | null;
       termsOfUseEn?: string | null;
       termsOfUseSv?: string | null;
-      minPersons?: number | null;
-      maxPersons?: number | null;
+      reservationBegins?: string | null;
+      reservationEnds?: string | null;
       unit?: {
         id: string;
         tprekId?: string | null;
-        pk?: number | null;
         nameFi?: string | null;
         nameEn?: string | null;
         nameSv?: string | null;
+        pk?: number | null;
         location?: {
-          id: string;
-          latitude?: string | null;
-          longitude?: string | null;
           addressStreetEn?: string | null;
           addressStreetSv?: string | null;
           addressCityEn?: string | null;
           addressCitySv?: string | null;
+          id: string;
           addressStreetFi?: string | null;
           addressZip: string;
           addressCityFi?: string | null;
         } | null;
+      } | null;
+      images: Array<{
+        id: string;
+        imageUrl?: string | null;
+        largeUrl?: string | null;
+        mediumUrl?: string | null;
+        smallUrl?: string | null;
+        imageType: ImageType;
+      }>;
+      cancellationRule?: {
+        id: string;
+        canBeCancelledTimeBefore?: number | null;
+      } | null;
+      metadataSet?: {
+        id: string;
+        requiredFields: Array<{ id: string; fieldName: string }>;
+        supportedFields: Array<{ id: string; fieldName: string }>;
       } | null;
       serviceSpecificTerms?: {
         id: string;
@@ -8332,23 +8351,6 @@ export type ReservationPageQuery = {
         highestPrice: string;
         taxPercentage: { id: string; pk?: number | null; value: string };
       }>;
-      images: Array<{
-        id: string;
-        imageUrl?: string | null;
-        largeUrl?: string | null;
-        mediumUrl?: string | null;
-        smallUrl?: string | null;
-        imageType: ImageType;
-      }>;
-      cancellationRule?: {
-        id: string;
-        canBeCancelledTimeBefore?: number | null;
-      } | null;
-      metadataSet?: {
-        id: string;
-        requiredFields: Array<{ id: string; fieldName: string }>;
-        supportedFields: Array<{ id: string; fieldName: string }>;
-      } | null;
     }>;
     purpose?: {
       id: string;
@@ -8363,10 +8365,45 @@ export type ReservationPageQuery = {
       minimum: number;
       maximum?: number | null;
     } | null;
-    homeCity?: { id: string; pk?: number | null; name: string } | null;
   } | null;
 };
 
+export type ReservationInfoFragment = {
+  description?: string | null;
+  numPersons?: number | null;
+  purpose?: {
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
+  } | null;
+  ageGroup?: {
+    id: string;
+    pk?: number | null;
+    minimum: number;
+    maximum?: number | null;
+  } | null;
+};
+
+export const InstructionsFragmentDoc = gql`
+  fragment Instructions on ReservationNode {
+    id
+    state
+    reservationUnits {
+      id
+      reservationPendingInstructionsFi
+      reservationPendingInstructionsEn
+      reservationPendingInstructionsSv
+      reservationConfirmedInstructionsFi
+      reservationConfirmedInstructionsEn
+      reservationConfirmedInstructionsSv
+      reservationCancelledInstructionsFi
+      reservationCancelledInstructionsEn
+      reservationCancelledInstructionsSv
+    }
+  }
+`;
 export const PricingFieldsFragmentDoc = gql`
   fragment PricingFields on ReservationUnitPricingNode {
     id
@@ -8760,30 +8797,6 @@ export const ReservationOrderStatusFragmentDoc = gql`
     }
   }
 `;
-export const ReservationInfoFragmentDoc = gql`
-  fragment ReservationInfo on ReservationNode {
-    description
-    purpose {
-      id
-      pk
-      nameFi
-      nameEn
-      nameSv
-    }
-    ageGroup {
-      id
-      pk
-      minimum
-      maximum
-    }
-    homeCity {
-      id
-      pk
-      name
-    }
-    numPersons
-  }
-`;
 export const OrderFieldsFragmentDoc = gql`
   fragment OrderFields on PaymentOrderNode {
     id
@@ -8825,18 +8838,35 @@ export const UnitNameFieldsI18NFragmentDoc = gql`
   }
   ${LocationFieldsI18nFragmentDoc}
 `;
-export const UnitFieldsFragmentDoc = gql`
-  fragment UnitFields on UnitNode {
+export const AddressFieldsFragmentDoc = gql`
+  fragment AddressFields on UnitNode {
     ...UnitNameFieldsI18N
     id
     tprekId
-    location {
-      id
-      latitude
-      longitude
-    }
   }
   ${UnitNameFieldsI18NFragmentDoc}
+`;
+export const TermsOfUseFragmentDoc = gql`
+  fragment TermsOfUse on ReservationUnitNode {
+    termsOfUseFi
+    termsOfUseEn
+    termsOfUseSv
+    serviceSpecificTerms {
+      ...TermsOfUseTextFields
+    }
+    cancellationTerms {
+      ...TermsOfUseTextFields
+    }
+    paymentTerms {
+      ...TermsOfUseTextFields
+    }
+    pricingTerms {
+      ...TermsOfUseNameFields
+      ...TermsOfUseTextFields
+    }
+  }
+  ${TermsOfUseTextFieldsFragmentDoc}
+  ${TermsOfUseNameFieldsFragmentDoc}
 `;
 export const MetadataSetsFragmentDoc = gql`
   fragment MetadataSets on ReservationUnitNode {
@@ -8855,57 +8885,6 @@ export const MetadataSetsFragmentDoc = gql`
       }
     }
   }
-`;
-export const ReservationUnitFieldsFragmentDoc = gql`
-  fragment ReservationUnitFields on ReservationUnitNode {
-    unit {
-      ...UnitFields
-    }
-    id
-    pk
-    uuid
-    nameFi
-    nameEn
-    nameSv
-    reservationPendingInstructionsFi
-    reservationPendingInstructionsEn
-    reservationPendingInstructionsSv
-    reservationConfirmedInstructionsFi
-    reservationConfirmedInstructionsEn
-    reservationConfirmedInstructionsSv
-    reservationCancelledInstructionsFi
-    reservationCancelledInstructionsEn
-    reservationCancelledInstructionsSv
-    termsOfUseFi
-    termsOfUseEn
-    termsOfUseSv
-    serviceSpecificTerms {
-      ...TermsOfUseTextFields
-    }
-    cancellationTerms {
-      ...TermsOfUseTextFields
-    }
-    paymentTerms {
-      ...TermsOfUseTextFields
-    }
-    pricingTerms {
-      ...TermsOfUseNameFields
-      ...TermsOfUseTextFields
-    }
-    pricings {
-      ...PricingFields
-    }
-    images {
-      ...Image
-    }
-    ...MetadataSets
-  }
-  ${UnitFieldsFragmentDoc}
-  ${TermsOfUseTextFieldsFragmentDoc}
-  ${TermsOfUseNameFieldsFragmentDoc}
-  ${PricingFieldsFragmentDoc}
-  ${ImageFragmentDoc}
-  ${MetadataSetsFragmentDoc}
 `;
 export const ReservationUnitTypeFieldsFragmentDoc = gql`
   fragment ReservationUnitTypeFields on ReservationUnitTypeNode {
@@ -8944,11 +8923,24 @@ export const EquipmentFieldsFragmentDoc = gql`
 `;
 export const ReservationUnitPageFieldsFragmentDoc = gql`
   fragment ReservationUnitPageFields on ReservationUnitNode {
-    ...ReservationUnitFields
-    isDraft
+    unit {
+      ...AddressFields
+    }
+    id
+    pk
+    uuid
+    nameFi
+    nameEn
+    nameSv
+    ...TermsOfUse
+    pricings {
+      ...PricingFields
+    }
     images {
       ...Image
     }
+    ...MetadataSets
+    isDraft
     applicationRoundTimeSlots {
       id
       closed
@@ -8984,8 +8976,11 @@ export const ReservationUnitPageFieldsFragmentDoc = gql`
       ...EquipmentFields
     }
   }
-  ${ReservationUnitFieldsFragmentDoc}
+  ${AddressFieldsFragmentDoc}
+  ${TermsOfUseFragmentDoc}
+  ${PricingFieldsFragmentDoc}
   ${ImageFragmentDoc}
+  ${MetadataSetsFragmentDoc}
   ${ReservationUnitTypeFieldsFragmentDoc}
   ${ReservationInfoContainerFragmentDoc}
   ${EquipmentFieldsFragmentDoc}
@@ -9092,6 +9087,38 @@ export const ReserveeBillingFieldsFragmentDoc = gql`
     billingAddressZip
   }
 `;
+export const MetaFieldsFragmentDoc = gql`
+  fragment MetaFields on ReservationNode {
+    ...ReserveeNameFields
+    ...ReserveeBillingFields
+    applyingForFreeOfCharge
+    freeOfChargeReason
+    description
+    numPersons
+    ageGroup {
+      id
+      pk
+      maximum
+      minimum
+    }
+    purpose {
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
+    }
+    homeCity {
+      id
+      pk
+      nameFi
+      nameSv
+      nameEn
+    }
+  }
+  ${ReserveeNameFieldsFragmentDoc}
+  ${ReserveeBillingFieldsFragmentDoc}
+`;
 export const BannerNotificationCommonFragmentDoc = gql`
   fragment BannerNotificationCommon on BannerNotificationNode {
     id
@@ -9101,6 +9128,25 @@ export const BannerNotificationCommonFragmentDoc = gql`
     messageEn
     messageFi
     messageSv
+  }
+`;
+export const ReservationInfoFragmentDoc = gql`
+  fragment ReservationInfo on ReservationNode {
+    description
+    purpose {
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
+    }
+    ageGroup {
+      id
+      pk
+      minimum
+      maximum
+    }
+    numPersons
   }
 `;
 export const OptionsDocument = gql`
@@ -10602,123 +10648,6 @@ export type ReservationStateQueryResult = Apollo.QueryResult<
   ReservationStateQuery,
   ReservationStateQueryVariables
 >;
-export const ReservationDocument = gql`
-  query Reservation($id: ID!) {
-    reservation(id: $id) {
-      id
-      pk
-      name
-      ...ReserveeNameFields
-      ...ReserveeBillingFields
-      ...ReservationInfo
-      applyingForFreeOfCharge
-      freeOfChargeReason
-      bufferTimeBefore
-      bufferTimeAfter
-      begin
-      end
-      calendarUrl
-      user {
-        id
-        email
-        pk
-      }
-      state
-      price
-      priceNet
-      taxPercentageValue
-      paymentOrder {
-        ...OrderFields
-      }
-      reservationUnits {
-        id
-        canApplyFreeOfCharge
-        ...ReservationUnitFields
-        ...CancellationRuleFields
-      }
-      isHandled
-    }
-  }
-  ${ReserveeNameFieldsFragmentDoc}
-  ${ReserveeBillingFieldsFragmentDoc}
-  ${ReservationInfoFragmentDoc}
-  ${OrderFieldsFragmentDoc}
-  ${ReservationUnitFieldsFragmentDoc}
-  ${CancellationRuleFieldsFragmentDoc}
-`;
-
-/**
- * __useReservationQuery__
- *
- * To run a query within a React component, call `useReservationQuery` and pass it any options that fit your needs.
- * When your component renders, `useReservationQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useReservationQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useReservationQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    ReservationQuery,
-    ReservationQueryVariables
-  > &
-    (
-      | { variables: ReservationQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ReservationQuery, ReservationQueryVariables>(
-    ReservationDocument,
-    options
-  );
-}
-export function useReservationLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    ReservationQuery,
-    ReservationQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ReservationQuery, ReservationQueryVariables>(
-    ReservationDocument,
-    options
-  );
-}
-export function useReservationSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        ReservationQuery,
-        ReservationQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<ReservationQuery, ReservationQueryVariables>(
-    ReservationDocument,
-    options
-  );
-}
-export type ReservationQueryHookResult = ReturnType<typeof useReservationQuery>;
-export type ReservationLazyQueryHookResult = ReturnType<
-  typeof useReservationLazyQuery
->;
-export type ReservationSuspenseQueryHookResult = ReturnType<
-  typeof useReservationSuspenseQuery
->;
-export type ReservationQueryResult = Apollo.QueryResult<
-  ReservationQuery,
-  ReservationQueryVariables
->;
 export const AdjustReservationTimeDocument = gql`
   mutation AdjustReservationTime($input: ReservationAdjustTimeMutationInput!) {
     adjustReservationTime(input: $input) {
@@ -10889,89 +10818,6 @@ export type RefreshOrderMutationResult =
 export type RefreshOrderMutationOptions = Apollo.BaseMutationOptions<
   RefreshOrderMutation,
   RefreshOrderMutationVariables
->;
-export const ReservationUnitDocument = gql`
-  query ReservationUnit($id: ID!) {
-    reservationUnit(id: $id) {
-      ...ReservationUnitPageFields
-    }
-  }
-  ${ReservationUnitPageFieldsFragmentDoc}
-`;
-
-/**
- * __useReservationUnitQuery__
- *
- * To run a query within a React component, call `useReservationUnitQuery` and pass it any options that fit your needs.
- * When your component renders, `useReservationUnitQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useReservationUnitQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useReservationUnitQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    ReservationUnitQuery,
-    ReservationUnitQueryVariables
-  > &
-    (
-      | { variables: ReservationUnitQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ReservationUnitQuery, ReservationUnitQueryVariables>(
-    ReservationUnitDocument,
-    options
-  );
-}
-export function useReservationUnitLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    ReservationUnitQuery,
-    ReservationUnitQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    ReservationUnitQuery,
-    ReservationUnitQueryVariables
-  >(ReservationUnitDocument, options);
-}
-export function useReservationUnitSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        ReservationUnitQuery,
-        ReservationUnitQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<
-    ReservationUnitQuery,
-    ReservationUnitQueryVariables
-  >(ReservationUnitDocument, options);
-}
-export type ReservationUnitQueryHookResult = ReturnType<
-  typeof useReservationUnitQuery
->;
-export type ReservationUnitLazyQueryHookResult = ReturnType<
-  typeof useReservationUnitLazyQuery
->;
-export type ReservationUnitSuspenseQueryHookResult = ReturnType<
-  typeof useReservationUnitSuspenseQuery
->;
-export type ReservationUnitQueryResult = Apollo.QueryResult<
-  ReservationUnitQuery,
-  ReservationUnitQueryVariables
 >;
 export const ReservationUnitPageDocument = gql`
   query ReservationUnitPage(
@@ -11994,16 +11840,116 @@ export type ApplicationViewQueryResult = Apollo.QueryResult<
   ApplicationViewQuery,
   ApplicationViewQueryVariables
 >;
+export const ReservationDocument = gql`
+  query Reservation($id: ID!) {
+    reservation(id: $id) {
+      id
+      pk
+      name
+      ...MetaFields
+      ...ReservationInfoCard
+      bufferTimeBefore
+      bufferTimeAfter
+      calendarUrl
+      paymentOrder {
+        ...OrderFields
+      }
+      reservationUnits {
+        id
+        canApplyFreeOfCharge
+        ...CancellationRuleFields
+        ...MetadataSets
+        ...TermsOfUse
+        requireReservationHandling
+      }
+    }
+  }
+  ${MetaFieldsFragmentDoc}
+  ${ReservationInfoCardFragmentDoc}
+  ${OrderFieldsFragmentDoc}
+  ${CancellationRuleFieldsFragmentDoc}
+  ${MetadataSetsFragmentDoc}
+  ${TermsOfUseFragmentDoc}
+`;
+
+/**
+ * __useReservationQuery__
+ *
+ * To run a query within a React component, call `useReservationQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReservationQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReservationQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useReservationQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ReservationQuery,
+    ReservationQueryVariables
+  > &
+    (
+      | { variables: ReservationQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ReservationQuery, ReservationQueryVariables>(
+    ReservationDocument,
+    options
+  );
+}
+export function useReservationLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ReservationQuery,
+    ReservationQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ReservationQuery, ReservationQueryVariables>(
+    ReservationDocument,
+    options
+  );
+}
+export function useReservationSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        ReservationQuery,
+        ReservationQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<ReservationQuery, ReservationQueryVariables>(
+    ReservationDocument,
+    options
+  );
+}
+export type ReservationQueryHookResult = ReturnType<typeof useReservationQuery>;
+export type ReservationLazyQueryHookResult = ReturnType<
+  typeof useReservationLazyQuery
+>;
+export type ReservationSuspenseQueryHookResult = ReturnType<
+  typeof useReservationSuspenseQuery
+>;
+export type ReservationQueryResult = Apollo.QueryResult<
+  ReservationQuery,
+  ReservationQueryVariables
+>;
 export const ReservationCancelPageDocument = gql`
   query ReservationCancelPage($id: ID!) {
     reservation(id: $id) {
       id
       ...ReservationInfoCard
-      pk
       name
-      begin
-      end
-      state
       reservationUnits {
         id
         ...CancellationRuleFields
@@ -12124,6 +12070,207 @@ export type ReservationCancelPageQueryResult = Apollo.QueryResult<
   ReservationCancelPageQuery,
   ReservationCancelPageQueryVariables
 >;
+export const ReservationConfirmationPageDocument = gql`
+  query ReservationConfirmationPage($id: ID!) {
+    reservation(id: $id) {
+      id
+      pk
+      name
+      ...ReserveeNameFields
+      ...ReserveeBillingFields
+      ...ReservationInfo
+      ...ReservationInfoCard
+      ...Instructions
+      calendarUrl
+      paymentOrder {
+        ...OrderFields
+      }
+      reservationUnits {
+        id
+        canApplyFreeOfCharge
+        ...CancellationRuleFields
+      }
+    }
+  }
+  ${ReserveeNameFieldsFragmentDoc}
+  ${ReserveeBillingFieldsFragmentDoc}
+  ${ReservationInfoFragmentDoc}
+  ${ReservationInfoCardFragmentDoc}
+  ${InstructionsFragmentDoc}
+  ${OrderFieldsFragmentDoc}
+  ${CancellationRuleFieldsFragmentDoc}
+`;
+
+/**
+ * __useReservationConfirmationPageQuery__
+ *
+ * To run a query within a React component, call `useReservationConfirmationPageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReservationConfirmationPageQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReservationConfirmationPageQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useReservationConfirmationPageQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ReservationConfirmationPageQuery,
+    ReservationConfirmationPageQueryVariables
+  > &
+    (
+      | { variables: ReservationConfirmationPageQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ReservationConfirmationPageQuery,
+    ReservationConfirmationPageQueryVariables
+  >(ReservationConfirmationPageDocument, options);
+}
+export function useReservationConfirmationPageLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ReservationConfirmationPageQuery,
+    ReservationConfirmationPageQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ReservationConfirmationPageQuery,
+    ReservationConfirmationPageQueryVariables
+  >(ReservationConfirmationPageDocument, options);
+}
+export function useReservationConfirmationPageSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        ReservationConfirmationPageQuery,
+        ReservationConfirmationPageQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    ReservationConfirmationPageQuery,
+    ReservationConfirmationPageQueryVariables
+  >(ReservationConfirmationPageDocument, options);
+}
+export type ReservationConfirmationPageQueryHookResult = ReturnType<
+  typeof useReservationConfirmationPageQuery
+>;
+export type ReservationConfirmationPageLazyQueryHookResult = ReturnType<
+  typeof useReservationConfirmationPageLazyQuery
+>;
+export type ReservationConfirmationPageSuspenseQueryHookResult = ReturnType<
+  typeof useReservationConfirmationPageSuspenseQuery
+>;
+export type ReservationConfirmationPageQueryResult = Apollo.QueryResult<
+  ReservationConfirmationPageQuery,
+  ReservationConfirmationPageQueryVariables
+>;
+export const ReservationEditPageDocument = gql`
+  query ReservationEditPage($id: ID!) {
+    reservation(id: $id) {
+      id
+      pk
+      name
+      isHandled
+      ...MetaFields
+      ...ReservationInfoCard
+      reservationUnits {
+        id
+        ...CancellationRuleFields
+        ...MetadataSets
+      }
+    }
+  }
+  ${MetaFieldsFragmentDoc}
+  ${ReservationInfoCardFragmentDoc}
+  ${CancellationRuleFieldsFragmentDoc}
+  ${MetadataSetsFragmentDoc}
+`;
+
+/**
+ * __useReservationEditPageQuery__
+ *
+ * To run a query within a React component, call `useReservationEditPageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReservationEditPageQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useReservationEditPageQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useReservationEditPageQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ReservationEditPageQuery,
+    ReservationEditPageQueryVariables
+  > &
+    (
+      | { variables: ReservationEditPageQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ReservationEditPageQuery,
+    ReservationEditPageQueryVariables
+  >(ReservationEditPageDocument, options);
+}
+export function useReservationEditPageLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ReservationEditPageQuery,
+    ReservationEditPageQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ReservationEditPageQuery,
+    ReservationEditPageQueryVariables
+  >(ReservationEditPageDocument, options);
+}
+export function useReservationEditPageSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        ReservationEditPageQuery,
+        ReservationEditPageQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    ReservationEditPageQuery,
+    ReservationEditPageQueryVariables
+  >(ReservationEditPageDocument, options);
+}
+export type ReservationEditPageQueryHookResult = ReturnType<
+  typeof useReservationEditPageQuery
+>;
+export type ReservationEditPageLazyQueryHookResult = ReturnType<
+  typeof useReservationEditPageLazyQuery
+>;
+export type ReservationEditPageSuspenseQueryHookResult = ReturnType<
+  typeof useReservationEditPageSuspenseQuery
+>;
+export type ReservationEditPageQueryResult = Apollo.QueryResult<
+  ReservationEditPageQuery,
+  ReservationEditPageQueryVariables
+>;
 export const ApplicationRecurringReservationDocument = gql`
   query ApplicationRecurringReservation($id: ID!) {
     recurringReservation(id: $id) {
@@ -12227,38 +12374,43 @@ export const ReservationPageDocument = gql`
     reservation(id: $id) {
       id
       pk
-      name
       ...ReserveeNameFields
       ...ReserveeBillingFields
       ...ReservationInfo
+      ...ReservationInfoCard
+      ...Instructions
       applyingForFreeOfCharge
-      begin
-      end
       calendarUrl
-      state
-      price
       paymentOrder {
-        id
-        status
-        receiptUrl
-        checkoutUrl
+        ...OrderFields
       }
       recurringReservation {
         id
       }
       reservationUnits {
         id
+        unit {
+          id
+          tprekId
+          ...UnitNameFieldsI18N
+        }
         canApplyFreeOfCharge
-        ...ReservationUnitFields
         ...CancellationRuleFields
+        ...MetadataSets
+        ...TermsOfUse
       }
     }
   }
   ${ReserveeNameFieldsFragmentDoc}
   ${ReserveeBillingFieldsFragmentDoc}
   ${ReservationInfoFragmentDoc}
-  ${ReservationUnitFieldsFragmentDoc}
+  ${ReservationInfoCardFragmentDoc}
+  ${InstructionsFragmentDoc}
+  ${OrderFieldsFragmentDoc}
+  ${UnitNameFieldsI18NFragmentDoc}
   ${CancellationRuleFieldsFragmentDoc}
+  ${MetadataSetsFragmentDoc}
+  ${TermsOfUseFragmentDoc}
 `;
 
 /**

--- a/apps/ui/modules/queries/fragments.tsx
+++ b/apps/ui/modules/queries/fragments.tsx
@@ -1,17 +1,6 @@
 import { gql } from "@apollo/client";
-import {
-  PRICING_FRAGMENT,
-  TERMS_OF_USE_NAME_FRAGMENT,
-  TERMS_OF_USE_TEXT_FRAGMENT,
-  IMAGE_FRAGMENT,
-  LOCATION_FRAGMENT_I18N,
-  METADATA_SETS_FRAGMENT,
-} from "common/src/queries/fragments";
-
-// TODO improve naming of the fragments to match the purpose or use case
 
 export const UNIT_NAME_FRAGMENT_I18N = gql`
-  ${LOCATION_FRAGMENT_I18N}
   fragment UnitNameFieldsI18N on UnitNode {
     id
     pk
@@ -24,48 +13,8 @@ export const UNIT_NAME_FRAGMENT_I18N = gql`
   }
 `;
 
-const UNIT_FRAGMENT = gql`
-  ${UNIT_NAME_FRAGMENT_I18N}
-  fragment UnitFields on UnitNode {
-    ...UnitNameFieldsI18N
-    id
-    tprekId
-    location {
-      id
-      latitude
-      longitude
-    }
-  }
-`;
-
-// TODO
-// NOTE only reservationUnit query requires the pricingTerms name (both need text)
-export const RESERVATION_UNIT_FRAGMENT = gql`
-  ${UNIT_FRAGMENT}
-  ${IMAGE_FRAGMENT}
-  ${TERMS_OF_USE_TEXT_FRAGMENT}
-  ${TERMS_OF_USE_NAME_FRAGMENT}
-  ${PRICING_FRAGMENT}
-  ${METADATA_SETS_FRAGMENT}
-  fragment ReservationUnitFields on ReservationUnitNode {
-    unit {
-      ...UnitFields
-    }
-    id
-    pk
-    uuid
-    nameFi
-    nameEn
-    nameSv
-    reservationPendingInstructionsFi
-    reservationPendingInstructionsEn
-    reservationPendingInstructionsSv
-    reservationConfirmedInstructionsFi
-    reservationConfirmedInstructionsEn
-    reservationConfirmedInstructionsSv
-    reservationCancelledInstructionsFi
-    reservationCancelledInstructionsEn
-    reservationCancelledInstructionsSv
+export const TERMS_OF_USE_FRAGMENT = gql`
+  fragment TermsOfUse on ReservationUnitNode {
     termsOfUseFi
     termsOfUseEn
     termsOfUseSv
@@ -82,13 +31,6 @@ export const RESERVATION_UNIT_FRAGMENT = gql`
       ...TermsOfUseNameFields
       ...TermsOfUseTextFields
     }
-    pricings {
-      ...PricingFields
-    }
-    images {
-      ...Image
-    }
-    ...MetadataSets
   }
 `;
 

--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -1,14 +1,6 @@
 import { gql } from "@apollo/client";
-import {
-  RESERVEE_NAME_FRAGMENT,
-  IMAGE_FRAGMENT,
-  PRICING_FRAGMENT,
-  RESERVEE_BILLING_FRAGMENT,
-} from "common/src/queries/fragments";
-import {
-  RESERVATION_UNIT_FRAGMENT,
-  UNIT_NAME_FRAGMENT_I18N,
-} from "./fragments";
+import { IMAGE_FRAGMENT, PRICING_FRAGMENT } from "common/src/queries/fragments";
+import { UNIT_NAME_FRAGMENT_I18N } from "./fragments";
 
 export const CREATE_RESERVATION = gql`
   mutation CreateReservation($input: ReservationCreateMutationInput!) {
@@ -128,32 +120,6 @@ export const LIST_RESERVATIONS = gql`
   }
 `;
 
-// NOTE this is used to display some general info about the reservation (on /reservation/:id page)
-const RESERVATION_INFO_FRAGMENT = gql`
-  fragment ReservationInfo on ReservationNode {
-    description
-    purpose {
-      id
-      pk
-      nameFi
-      nameEn
-      nameSv
-    }
-    ageGroup {
-      id
-      pk
-      minimum
-      maximum
-    }
-    homeCity {
-      id
-      pk
-      name
-    }
-    numPersons
-  }
-`;
-
 export const ORDER_FRAGMENT = gql`
   fragment OrderFields on PaymentOrderNode {
     id
@@ -183,54 +149,6 @@ export const GET_RESERVATION_STATE = gql`
       id
       pk
       state
-    }
-  }
-`;
-
-// TODO do we need all the fields from ReservationUnitNode? ex. pricing (since we should be using the Reservations own pricing anyway)
-// TODO can we split this into smaller queries? per case?
-// making a reservation, showing a reservation, editing a reservation, cancelling a reservation
-// TODO why pricing fields? instead of asking the reservation price info? lets say the unit is normally paid only but you made the reservation free
-export const GET_RESERVATION = gql`
-  ${RESERVEE_NAME_FRAGMENT}
-  ${RESERVEE_BILLING_FRAGMENT}
-  ${RESERVATION_UNIT_FRAGMENT}
-  ${CANCELLATION_RULE_FRAGMENT}
-  ${RESERVATION_INFO_FRAGMENT}
-  query Reservation($id: ID!) {
-    reservation(id: $id) {
-      id
-      pk
-      name
-      ...ReserveeNameFields
-      ...ReserveeBillingFields
-      ...ReservationInfo
-      applyingForFreeOfCharge
-      freeOfChargeReason
-      bufferTimeBefore
-      bufferTimeAfter
-      begin
-      end
-      calendarUrl
-      user {
-        id
-        email
-        pk
-      }
-      state
-      price
-      priceNet
-      taxPercentageValue
-      paymentOrder {
-        ...OrderFields
-      }
-      reservationUnits {
-        id
-        canApplyFreeOfCharge
-        ...ReservationUnitFields
-        ...CancellationRuleFields
-      }
-      isHandled
     }
   }
 `;

--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -21,8 +21,8 @@ export const UPDATE_RESERVATION = gql`
 `;
 
 export const DELETE_RESERVATION = gql`
-  mutation DeleteReservation($input: ReservationDeleteMutationInput!) {
-    deleteReservation(input: $input) {
+  mutation DeleteReservation($input: ReservationDeleteTentativeMutationInput!) {
+    deleteTentativeReservation(input: $input) {
       deleted
     }
   }

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -1,8 +1,5 @@
 import { gql } from "@apollo/client";
-import {
-  RESERVATION_UNIT_FRAGMENT,
-  UNIT_NAME_FRAGMENT_I18N,
-} from "./fragments";
+import { UNIT_NAME_FRAGMENT_I18N } from "./fragments";
 import { IMAGE_FRAGMENT, PRICING_FRAGMENT } from "common/src/queries/fragments";
 
 export { TERMS_OF_USE_QUERY as TERMS_OF_USE } from "common/src/queries/queries";
@@ -27,7 +24,7 @@ const RESERVATION_UNIT_NAME_FRAGMENT = gql`
   }
 `;
 
-const EQUIPMENT_FRAGMENT = gql`
+export const EQUIPMENT_FRAGMENT = gql`
   fragment EquipmentFields on EquipmentNode {
     id
     pk
@@ -43,18 +40,26 @@ const EQUIPMENT_FRAGMENT = gql`
   }
 `;
 
-// TODO remove extra fields that are in the IS_RESERVABLE_FRAGMENT
-const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
-  ${IMAGE_FRAGMENT}
-  ${RESERVATION_UNIT_FRAGMENT}
-  ${RESERVATION_UNIT_TYPE_FRAGMENT}
-  ${EQUIPMENT_FRAGMENT}
+export const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
   fragment ReservationUnitPageFields on ReservationUnitNode {
-    ...ReservationUnitFields
-    isDraft
+    unit {
+      ...AddressFields
+    }
+    id
+    pk
+    uuid
+    nameFi
+    nameEn
+    nameSv
+    ...TermsOfUse
+    pricings {
+      ...PricingFields
+    }
     images {
       ...Image
     }
+    ...MetadataSets
+    isDraft
     applicationRoundTimeSlots {
       id
       closed
@@ -92,7 +97,7 @@ const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
   }
 `;
 
-const BLOCKING_RESERVATION_FRAGMENT = gql`
+export const BLOCKING_RESERVATION_FRAGMENT = gql`
   fragment BlockingReservationFields on ReservationNode {
     pk
     id
@@ -108,17 +113,7 @@ const BLOCKING_RESERVATION_FRAGMENT = gql`
   }
 `;
 
-export const RESERVATION_UNIT_PARAMS_PAGE_QUERY = gql`
-  ${RESERVATION_UNIT_PAGE_FRAGMENT}
-  query ReservationUnit($id: ID!) {
-    reservationUnit(id: $id) {
-      ...ReservationUnitPageFields
-    }
-  }
-`;
-
-const IS_RESERVABLE_FRAGMENT = gql`
-  ${BLOCKING_RESERVATION_FRAGMENT}
+export const IS_RESERVABLE_FRAGMENT = gql`
   fragment IsReservableFields on ReservationUnitNode {
     bufferTimeBefore
     bufferTimeAfter
@@ -138,9 +133,6 @@ const IS_RESERVABLE_FRAGMENT = gql`
 
 // Combined version for the reservation-unit/[id] page so we can show the Calendar and check for collisions
 export const RESERVATION_UNIT_PAGE_QUERY = gql`
-  ${RESERVATION_UNIT_PAGE_FRAGMENT}
-  ${BLOCKING_RESERVATION_FRAGMENT}
-  ${IS_RESERVABLE_FRAGMENT}
   query ReservationUnitPage(
     $id: ID!
     $pk: Int!

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -22,11 +22,10 @@ import {
   type CancellationRuleFieldsFragment,
   type BlockingReservationFieldsFragment,
   type CanUserCancelReservationFragment,
-  type ReservationInfoFragment,
 } from "@gql/gql-types";
 import { getReservationApplicationFields } from "common/src/reservation-form/util";
 import { getIntervalMinutes } from "common/src/conversion";
-import { fromUIDate, getTranslation } from "./util";
+import { fromUIDate } from "./util";
 import { type TFunction } from "i18next";
 import { type PendingReservation } from "@/modules/types";
 import {
@@ -360,27 +359,6 @@ export function canReservationTimeBeChanged({
   });
 }
 
-export function getReservationValue(
-  reservation: ReservationInfoFragment,
-  key: "purpose" | "numPersons" | "ageGroup" | "description"
-): string | number | null {
-  if (key === "ageGroup") {
-    const { minimum, maximum } = reservation.ageGroup || {};
-    return minimum && maximum ? `${minimum} - ${maximum}` : null;
-  } else if (key === "purpose") {
-    if (reservation.purpose != null) {
-      return getTranslation(reservation.purpose, "name");
-    }
-    return null;
-  } else if (key in reservation) {
-    const val = reservation[key as keyof ReservationInfoFragment];
-    if (typeof val === "string" || typeof val === "number") {
-      return val;
-    }
-  }
-  return null;
-}
-
 export function getCheckoutUrl(
   order?: Maybe<{ checkoutUrl?: Maybe<string> }>,
   lang = "fi"
@@ -582,7 +560,7 @@ export function convertReservationFormToApi(
 }
 
 export function transformReservation(
-  reservation?: ReservationNodeT
+  reservation?: Pick<ReservationNodeT, "begin" | "end">
 ): PendingReservationFormType {
   const originalBegin = new Date(reservation?.begin ?? "");
   const originalEnd = new Date(reservation?.end ?? "");

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -238,7 +238,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   };
 }
 
-const StyledApplicationRoundScheduleDay = styled.div`
+const StyledApplicationRoundScheduleDay = styled.p`
   span:first-child {
     display: inline-block;
     font-weight: bold;

--- a/apps/ui/pages/reservations/[id]/cancel.tsx
+++ b/apps/ui/pages/reservations/[id]/cancel.tsx
@@ -138,11 +138,7 @@ export const RESERVATION_CANCEL_PAGE_QUERY = gql`
     reservation(id: $id) {
       id
       ...ReservationInfoCard
-      pk
       name
-      begin
-      end
-      state
       reservationUnits {
         id
         ...CancellationRuleFields

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -5520,6 +5520,51 @@ export type ReserveeBillingFieldsFragment = {
   billingAddressZip?: string | null;
 };
 
+export type MetaFieldsFragment = {
+  applyingForFreeOfCharge?: boolean | null;
+  freeOfChargeReason?: string | null;
+  description?: string | null;
+  numPersons?: number | null;
+  reserveeFirstName?: string | null;
+  reserveeLastName?: string | null;
+  reserveeEmail?: string | null;
+  reserveePhone?: string | null;
+  reserveeType?: CustomerTypeChoice | null;
+  reserveeOrganisationName?: string | null;
+  reserveeId?: string | null;
+  reserveeIsUnregisteredAssociation?: boolean | null;
+  reserveeAddressStreet?: string | null;
+  reserveeAddressCity?: string | null;
+  reserveeAddressZip?: string | null;
+  billingFirstName?: string | null;
+  billingLastName?: string | null;
+  billingPhone?: string | null;
+  billingEmail?: string | null;
+  billingAddressStreet?: string | null;
+  billingAddressCity?: string | null;
+  billingAddressZip?: string | null;
+  ageGroup?: {
+    id: string;
+    pk?: number | null;
+    maximum?: number | null;
+    minimum: number;
+  } | null;
+  purpose?: {
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameEn?: string | null;
+    nameSv?: string | null;
+  } | null;
+  homeCity?: {
+    id: string;
+    pk?: number | null;
+    nameFi?: string | null;
+    nameSv?: string | null;
+    nameEn?: string | null;
+  } | null;
+};
+
 export type TermsOfUseNameFieldsFragment = {
   nameFi?: string | null;
   nameEn?: string | null;
@@ -5788,6 +5833,38 @@ export const ReserveeBillingFieldsFragmentDoc = gql`
     billingAddressCity
     billingAddressZip
   }
+`;
+export const MetaFieldsFragmentDoc = gql`
+  fragment MetaFields on ReservationNode {
+    ...ReserveeNameFields
+    ...ReserveeBillingFields
+    applyingForFreeOfCharge
+    freeOfChargeReason
+    description
+    numPersons
+    ageGroup {
+      id
+      pk
+      maximum
+      minimum
+    }
+    purpose {
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
+    }
+    homeCity {
+      id
+      pk
+      nameFi
+      nameSv
+      nameEn
+    }
+  }
+  ${ReserveeNameFieldsFragmentDoc}
+  ${ReserveeBillingFieldsFragmentDoc}
 `;
 export const TermsOfUseNameFieldsFragmentDoc = gql`
   fragment TermsOfUseNameFields on TermsOfUseNode {

--- a/packages/common/src/queries/fragments.tsx
+++ b/packages/common/src/queries/fragments.tsx
@@ -30,6 +30,37 @@ export const RESERVEE_BILLING_FRAGMENT = gql`
   }
 `;
 
+export const METAFIELDS_FRAGMENT = gql`
+  fragment MetaFields on ReservationNode {
+    ...ReserveeNameFields
+    ...ReserveeBillingFields
+    applyingForFreeOfCharge
+    freeOfChargeReason
+    description
+    numPersons
+    ageGroup {
+      id
+      pk
+      maximum
+      minimum
+    }
+    purpose {
+      id
+      pk
+      nameFi
+      nameEn
+      nameSv
+    }
+    homeCity {
+      id
+      pk
+      nameFi
+      nameSv
+      nameEn
+    }
+  }
+`;
+
 export const TERMS_OF_USE_NAME_FRAGMENT = gql`
   fragment TermsOfUseNameFields on TermsOfUseNode {
     nameFi


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: missing tax percentage in ReservationInfoCard. `customer`
- Refactor: all reservation queries to be page specific and use fragments (mostly based on components). `customer`
- Refactor: move queries / fragments to the component / page they are used in.
- Refactor: remove second SSR query from reservation funnel.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automation: e2e new / edit / cancel reservation should work as before.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3770](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3770)


[TILA-3770]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ