### PR TITLE
fix: remove hiding all <br> tags in sanitizer

### DIFF
--- a/packages/common/src/components/Sanitize.tsx
+++ b/packages/common/src/components/Sanitize.tsx
@@ -11,11 +11,6 @@ const StyledContent = styled.div`
   p:empty {
     display: none;
   }
-
-  /* old data has extra line-breaks instead of just using <p> */
-  p br {
-    display: none;
-  }
   a {
     text-decoration: underline;
     color: var(--tilavaraus-link-color);


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: remove hiding `<br>` tags in the sanitizer.
- Requires: https://github.com/City-of-Helsinki/tilavarauspalvelu-core/pull/1474 to be merged and run on all servers first. 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: check that there are no unnecessary gaps in text that comes from Django RichText (ex. reservation unit descriptions).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3718](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3718)


[TILA-3718]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ