### PR TITLE
fix: missing ids for selects

### DIFF
--- a/apps/ui/components/calendar/ReservationCalendarControls.tsx
+++ b/apps/ui/components/calendar/ReservationCalendarControls.tsx
@@ -16,6 +16,7 @@ import {
   fontBold,
   fontMedium,
   fontRegular,
+  SemiBold,
 } from "common/src/common/typography";
 import { breakpoints } from "common/src/common/style";
 import type { ReservationUnitPageQuery } from "@gql/gql-types";
@@ -216,8 +217,9 @@ export function ReservationCalendarControls({
                   : new Date()
               }
             />
-            <div data-testid="reservation__input--duration">
+            <div data-testid="calendar-controls__duration">
               <ControlledSelect
+                id="calendar-controls__duration"
                 name="duration"
                 // react-hook-form has issues with typing generic Select
                 control={control as unknown as Control<FieldValues>}
@@ -226,6 +228,7 @@ export function ReservationCalendarControls({
               />
             </div>
             <ControlledSelect
+              id="calendar-controls__time"
               name="time"
               label={t("reservationCalendar:startTime")}
               // react-hook-form has issues with typing generic Select
@@ -234,14 +237,12 @@ export function ReservationCalendarControls({
               placeholder={t("common:select")}
             />
             <PriceWrapper>
-              {focusSlot.isReservable && (
-                <>
-                  {/* TODO for doesn't work with div either change it to disabled input or remove it */}
-                  <label htmlFor="price">{t("common:price")}</label>
-                  <Price id="price" data-testid="reservation__price--value">
-                    {price}
-                  </Price>
-                </>
+              {focusSlot.isReservable && price != null && (
+                <Price data-testid="calendar-controls__price">
+                  {t("common:price")}
+                  {": "}
+                  <SemiBold>{price}</SemiBold>
+                </Price>
               )}
             </PriceWrapper>
             <Button
@@ -324,7 +325,7 @@ function ControlledToggler({
       </TogglerLabel>
       <ToggleButton
         onClick={() => onChange(!value)}
-        data-testid="reservation-unit__reservation-controls--toggle-button"
+        data-testid="calendar-controls__toggle-button"
         type="button"
       >
         {value ? (

--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -188,6 +188,7 @@ function IconList({
           text: (
             <>
               {unitPrice}
+              {hasSubventionSuffix ? ": " : null}
               {hasSubventionSuffix ? subventionSuffix : null}
             </>
           ),

--- a/apps/ui/components/reservation-unit/QuickReservation.tsx
+++ b/apps/ui/components/reservation-unit/QuickReservation.tsx
@@ -3,7 +3,7 @@ import { Button } from "hds-react";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
 import { chunkArray, fromUIDate, toUIDate } from "common/src/common/util";
-import { fontBold, H4 } from "common/src/common/typography";
+import { fontMedium, H4 } from "common/src/common/typography";
 import type { ReservationUnitPageQuery } from "@gql/gql-types";
 import { breakpoints } from "common";
 import {
@@ -22,7 +22,7 @@ import { ControlledDateInput } from "common/src/components/form";
 import { type PendingReservationFormType } from "@/components/reservation-unit/schema";
 import { ControlledSelect } from "common/src/components/form/ControlledSelect";
 import { type FocusTimeSlot } from "@/modules/reservation";
-import { Flex } from "common/styles/util";
+import { Flex, NoWrap } from "common/styles/util";
 
 type QueryT = NonNullable<ReservationUnitPageQuery["reservationUnit"]>;
 type Props = {
@@ -54,9 +54,8 @@ const Form = styled.form`
 `;
 
 const Price = styled.div`
-  & > * {
-    display: inline-block;
-  }
+  /* no-wrap for price and subvention suffix */
+  display: inline-grid;
   padding-bottom: var(--spacing-m);
   height: var(--spacing-m);
   &:empty {
@@ -74,8 +73,8 @@ const Selects = styled.div`
   }
 `;
 
-const PriceValue = styled.div`
-  ${fontBold}
+const PriceValue = styled.span`
+  ${fontMedium}
 `;
 
 const Subheading = styled.div`
@@ -174,7 +173,7 @@ export function QuickReservation({
       </H4>
       <Selects>
         <ControlledDateInput
-          id="quick-reservation-date"
+          id="quick-reservation__date"
           name="date"
           control={control}
           label={t("reservationCalendar:startDate")}
@@ -184,6 +183,7 @@ export function QuickReservation({
           disableConfirmation={false}
         />
         <ControlledSelect
+          id="quick-reservation__duration"
           name="duration"
           // react-hook-form has issues with typing generic Select
           control={control as unknown as Control<FieldValues>}
@@ -206,11 +206,13 @@ export function QuickReservation({
         />
       </div>
       <Flex $direction="row" $justifyContent="space-between">
-        <Price data-testid="quick-reservation-price">
+        <Price data-testid="quick-reservation__price">
           {focusSlot?.isReservable && (
             <>
-              {t("common:price")}: <PriceValue>{price}</PriceValue>
-              {!isFreeOfCharge && subventionSuffix}
+              <NoWrap>
+                {t("common:price")}: <PriceValue>{price}</PriceValue>
+              </NoWrap>
+              <NoWrap>{!isFreeOfCharge && subventionSuffix}</NoWrap>
             </>
           )}
         </Price>
@@ -266,7 +268,7 @@ function TimeChunkSection({
         </span>
         {nextAvailableTime != null && (
           <Button
-            data-testid="quick-reservation-next-available-time"
+            data-testid="quick-reservation__next-available-time"
             type="button"
             onClick={(e) => {
               e.preventDefault();
@@ -289,7 +291,7 @@ function TimeChunkSection({
           {chunk.map((value: string) => (
             <Slot $active={watch("time") === value} key={value}>
               <SlotButton
-                data-testid="quick-reservation-slot"
+                data-testid="quick-reservation__slot"
                 onClick={() => setValue("time", value, { shouldDirty: true })}
                 type="button"
               >

--- a/apps/ui/components/reservation/SubventionSuffix.tsx
+++ b/apps/ui/components/reservation/SubventionSuffix.tsx
@@ -8,34 +8,32 @@ type Props = {
   ref?: RefObject<HTMLAnchorElement>;
 };
 
-const Anchor = styled.a`
+const Btn = styled.button`
+  display: inline;
+  background-color: unset;
+  border: unset;
+  padding: unset;
+
   text-decoration: underline;
   color: var(--color-black);
   word-break: keep-all;
 `;
 
-const SubventionSuffix = ({
+export function SubventionSuffix({
   placement,
   setIsDialogOpen,
-}: Props): JSX.Element => {
+}: Props): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <>
-      {", "}
-      <Anchor
-        href="#"
-        style={{}}
-        onClick={(e) => {
-          e.preventDefault();
-          setIsDialogOpen(true);
-        }}
-        data-testid={`link__pricing-terms--${placement}`}
-      >
-        {t("reservationCalendar:subventionAvailable")}
-      </Anchor>
-    </>
+    <Btn
+      onClick={(e) => {
+        e.preventDefault();
+        setIsDialogOpen(true);
+      }}
+      data-testid={`link__pricing-terms--${placement}`}
+    >
+      {t("reservationCalendar:subventionAvailable")}
+    </Btn>
   );
-};
-
-export default SubventionSuffix;
+}

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -73,7 +73,7 @@ import {
   getMaxReservationDuration,
   getMinReservationDuration,
 } from "@/modules/reservable";
-import SubventionSuffix from "@/components/reservation/SubventionSuffix";
+import { SubventionSuffix } from "@/components/reservation/SubventionSuffix";
 import InfoDialog from "@/components/common/InfoDialog";
 import { QuickReservation } from "@/components/reservation-unit/QuickReservation";
 import { ReservationInfoContainer } from "@/components/reservation-unit/ReservationInfoContainer";

--- a/packages/common/src/components/form/ControlledDateInput.tsx
+++ b/packages/common/src/components/form/ControlledDateInput.tsx
@@ -33,6 +33,7 @@ export function ControlledDateInput<T extends FieldValues>({
   minDate,
   initialMonth,
   disableConfirmation,
+  ...rest
 }: ControllerProps<T>) {
   const {
     field: { value, onChange },
@@ -41,7 +42,8 @@ export function ControlledDateInput<T extends FieldValues>({
 
   return (
     <DateInput
-      id={id ?? `reservationDialog.${name}`}
+      {...rest}
+      id={id ?? `controlled-date-input__${name}`}
       label={label ?? t(`ReservationDialog.${name}`)}
       minDate={minDate ?? new Date()}
       maxDate={maxDate ?? addYears(new Date(), 2)}

--- a/packages/common/src/components/form/ControlledSelect.tsx
+++ b/packages/common/src/components/form/ControlledSelect.tsx
@@ -31,6 +31,7 @@ interface SelectProps<T extends FieldValues> extends UseControllerProps<T> {
   afterChange?: (
     value: string | number | Array<string | number> | undefined
   ) => void;
+  id?: string;
 }
 
 export function ControlledSelect<T extends FieldValues>({
@@ -52,6 +53,7 @@ export function ControlledSelect<T extends FieldValues>({
   disabled,
   afterChange,
   enableSearch,
+  ...rest
 }: SelectProps<T>): JSX.Element {
   const { t, i18n } = useTranslation(["common"]);
   const language = convertLanguageCode(i18n.language);
@@ -116,6 +118,7 @@ export function ControlledSelect<T extends FieldValues>({
 
   return (
     <Select
+      {...rest}
       style={style}
       className={className}
       clearable={clearable ?? false}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: Select `ids` that were removed during HDS upgrade.
- Refactor: price section link to a button as it should be (and remove incorrect `label`).
- Add: `id` support to Controlled components.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automation: robot should work properly (for new / edit reservations).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
