### PR TITLE
fix: cancel breadcrumb incorrect translation

### DIFF
--- a/apps/ui/components/CancellationForm.tsx
+++ b/apps/ui/components/CancellationForm.tsx
@@ -86,6 +86,7 @@ export function CancellationForm(props: {
       <Form onSubmit={handleSubmit(onNext)}>
         <AutoGrid>
           <ControlledSelect
+            id="reservation-cancel__reason"
             name="reason"
             control={control}
             label={t("reservations:cancel.reason")}

--- a/apps/ui/pages/reservation/cancel.tsx
+++ b/apps/ui/pages/reservation/cancel.tsx
@@ -33,7 +33,7 @@ function Cancel({ apiBaseUrl }: NarrowedProps): JSX.Element {
       title: t("breadcrumb:reservations"),
     },
     {
-      title: t("reservations:cancelReservation"),
+      title: t("reservations:cancel.reservation"),
     },
   ] as const;
 

--- a/apps/ui/pages/reservations/[id]/cancel.tsx
+++ b/apps/ui/pages/reservations/[id]/cancel.tsx
@@ -41,8 +41,6 @@ function getBreadcrumbs(
         title: t("breadcrumb:application", { id: applicationPk }),
       },
       {
-        // NOTE Don't set slug. It hides the mobile breadcrumb
-        slug: "",
         title: t("reservations:cancel.reservation"),
       },
     ];
@@ -57,7 +55,7 @@ function getBreadcrumbs(
       title: t("reservations:reservationName", { id: reservation.pk }),
     },
     {
-      title: t("reservations:cancelReservation"),
+      title: t("reservations:cancel.reservation"),
     },
   ] as const;
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: cancel single reservation breadcrumb translation key. `ui`
- Add: id (for e2e tests) to cancel reason select.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automation: 
- Manual testing: check the cancel page breadcrumb with all languages.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
