### PR TITLE
add: "Cancelled" status label to recurring reservation lists

### DIFF
--- a/apps/admin-ui/src/component/RecurringReservationsView.tsx
+++ b/apps/admin-ui/src/component/RecurringReservationsView.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { format } from "date-fns";
 import {
-  ReservationStateChoice,
   type ReservationQuery,
+  ReservationStateChoice,
   useRecurringReservationQuery,
   UserPermissionChoice,
 } from "@gql/gql-types";
@@ -41,7 +41,7 @@ export function RecurringReservationsView({
   onChange,
   onReservationUpdated,
   reservationToCopy,
-}: Props) {
+}: Readonly<Props>) {
   const { t } = useTranslation();
   const { setModalContent } = useModal();
 
@@ -166,7 +166,8 @@ export function RecurringReservationsView({
       date: startDate,
       startTime: format(startDate, "H:mm"),
       endTime: format(endDate, "H:mm"),
-      isRemoved: x.state === "DENIED",
+      isRemoved: x.state === ReservationStateChoice.Denied,
+      isCancelled: x.state === ReservationStateChoice.Cancelled,
       buttons,
     };
   });

--- a/apps/admin-ui/src/component/ReservationListButton.tsx
+++ b/apps/admin-ui/src/component/ReservationListButton.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   Button,
+  ButtonPresetTheme,
   ButtonSize,
   ButtonVariant,
   IconArrowUndo,
@@ -17,16 +18,17 @@ export function ReservationListButton({
   type,
   callback,
   t,
-}: {
+}: Readonly<{
   type: "remove" | "deny" | "restore" | "change" | "show";
   callback: () => void;
   // Pass the TFunc because the amount of buttons change and hooks break
   t: TFunction;
-}) {
+}>) {
   const btnCommon = {
     variant: ButtonVariant.Supplementary,
     onClick: callback,
     size: ButtonSize.Small,
+    theme: ButtonPresetTheme.Black,
   } as const;
 
   switch (type) {

--- a/apps/admin-ui/src/component/ReservationsList.tsx
+++ b/apps/admin-ui/src/component/ReservationsList.tsx
@@ -7,11 +7,12 @@ import {
   ReservationQuery,
   UserPermissionChoice,
 } from "@gql/gql-types";
-import { Button, ButtonSize, ButtonVariant } from "hds-react";
+import { Button, ButtonSize, ButtonVariant, IconCross } from "hds-react";
 import { useCheckPermission } from "@/hooks";
 import { NewReservationModal } from "@/component/EditTimeModal";
 import { useModal } from "@/context/ModalContext";
 import { H6 } from "common";
+import StatusLabel from "common/src/components/StatusLabel";
 
 export type NewReservationListItem = {
   date: Date;
@@ -22,6 +23,7 @@ export type NewReservationListItem = {
   reservationPk?: number;
   buttons?: React.ReactNode;
   isRemoved?: boolean;
+  isCancelled?: boolean;
   isOverlapping?: boolean;
   buffers?: {
     before?: number;
@@ -68,13 +70,8 @@ const DateElement = styled.div<{ $isRemoved: boolean }>`
   ${({ $isRemoved }) => ($isRemoved ? "color: var(--color-black-50)" : "")};
 `;
 
-const ErrorLabel = styled.div<{ $isError: boolean }>`
-  & > span {
-    color: var(--color-black);
-    background: ${({ $isError }) =>
-      $isError ? "var(--color-metro-medium-light)" : "var(--color-black-10)"};
-    padding: 0.5rem;
-  }
+const ErrorLabel = styled(StatusLabel)`
+  margin-inline: -8px;
 `;
 
 const stripTimeZeros = (time: string) =>
@@ -88,18 +85,28 @@ function getStatus(x: NewReservationListItem) {
     return {
       isError: true,
       msg: "overlapping",
+      icon: <IconCross aria-hidden />,
     };
   }
   if (x.reason) {
     return {
       isError: true,
       msg: `RejectionReadinessChoice.${x.reason}`,
+      icon: <IconCross aria-hidden />,
     };
   }
   if (x.isRemoved) {
     return {
-      isError: false,
+      isError: true,
       msg: "removed",
+      icon: <IconCross aria-hidden />,
+    };
+  }
+  if (x.isCancelled) {
+    return {
+      isError: false,
+      msg: "cancelled",
+      icon: <IconCross aria-hidden />,
     };
   }
   if (x.error) {
@@ -122,6 +129,7 @@ function getStatus(x: NewReservationListItem) {
     return {
       isError: true,
       msg: `failureMessages.${errorCode}`,
+      icon: <IconCross aria-hidden />,
     };
   }
   return undefined;
@@ -137,11 +145,11 @@ function StatusElement({ item }: { item: NewReservationListItem }) {
     return null;
   }
 
-  const { isError, msg } = status;
+  const { isError, msg, icon } = status;
 
   return (
-    <ErrorLabel $isError={isError}>
-      <span>{t(msg)}</span>
+    <ErrorLabel icon={icon} type={isError ? "error" : "neutral"} slim>
+      {t(msg)}
     </ErrorLabel>
   );
 }
@@ -248,7 +256,10 @@ export function ReservationList(props: Props | ExtendedProps) {
           >
             <TextWrapper $failed={!!item.error}>
               <DateElement
-                $isRemoved={(item.isRemoved || item.isOverlapping) ?? false}
+                $isRemoved={
+                  (item.isRemoved || item.isOverlapping || item.isCancelled) ??
+                  false
+                }
               >
                 {`${toUIDate(item.date, "cccccc d.M.yyyy")}, ${stripTimeZeros(
                   item.startTime

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -426,7 +426,7 @@ const translations: ITranslations = {
         // TODO these should be in the common translations (enum)
         RejectionReadinessChoice: {
           INTERVAL_NOT_ALLOWED: ["Aloitusaika ei sallittu"],
-          OVERLAPPING_RESERVATIONS: ["Päivämäärä ei saatavilla"],
+          OVERLAPPING_RESERVATIONS: ["Ei saatavilla"],
           RESERVATION_UNIT_CLOSED: ["Suljettu"],
         },
         failureMessages: {

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -406,8 +406,9 @@ const translations: ITranslations = {
       pageTitle: ["Tee toistuva varaus"],
       addNewReservation: ["Lisää uusi varaus"],
       Confirmation: {
-        removed: ["Poistettu"],
+        removed: ["Hylätty"],
         overlapping: ["Ei saatavilla"],
+        cancelled: ["Peruttu"],
         title: ["Toistuva varaus tehty"],
         allFailedTitle: ["Toistuvaa varausta ei voitu tehdä"],
         failedSubtitle: ["Epäonnistuneet varaukset"],

--- a/apps/admin-ui/src/spa/reservations/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/index.tsx
@@ -54,6 +54,12 @@ const Accordion = styled(AccordionBase).attrs({
   > div > div:not([class^="LoadingSpinner-module_loadingSpinner"]) {
     width: 100%;
   }
+  && {
+    --icon-size: 24px;
+    [class^="Accordion-module_accordionHeader__"] {
+      --icon-size: 32px;
+    }
+  }
 `;
 
 function DataWrapper({

--- a/apps/ui/components/application/ApprovedReservations.tsx
+++ b/apps/ui/components/application/ApprovedReservations.tsx
@@ -59,6 +59,7 @@ import {
 import { formatDateTimeStrings } from "@/modules/util";
 import { PopupMenu } from "common/src/components/PopupMenu";
 import { useSearchParams } from "next/navigation";
+import type { StatusLabelType } from "common/src/tags";
 
 const N_RESERVATIONS_TO_SHOW = 20;
 
@@ -139,7 +140,7 @@ const TableWrapper = styled.div`
       /* card padding has to be implemented with tds because we can't style tr */
       & td:first-of-type {
         padding-top: var(--spacing-s);
-        font-size: var(--fontsize-heading-2-xs);
+        font-size: var(--fontsize-heading-xs);
         ${fontMedium}
       }
 
@@ -282,15 +283,15 @@ export function ApprovedReservations({ application }: Readonly<Props>) {
           headingLevel={2}
           icons={[
             {
-              icon: <IconCalendarRecurring aria-hidden="true" />,
+              icon: <IconCalendarRecurring aria-hidden />,
               text: formatNumberOfReservations(t, aes),
             },
             {
-              icon: <IconClock aria-hidden="true" />,
+              icon: <IconClock aria-hidden />,
               text: formatReservationTimes(t, aes),
             },
             {
-              icon: <IconLocation aria-hidden="true" />,
+              icon: <IconLocation aria-hidden />,
               text: formatAesName(aes, lang),
               textPostfix:
                 getAesReservationUnitCount(aes) > 1
@@ -402,7 +403,7 @@ function ReservationUnitTable({
       isSortable: false,
       transform: ({ dateOfWeek, time }: ReservationUnitTableElem) => (
         <IconTextWrapper aria-label={t("common:timeLabel")}>
-          <IconClock aria-hidden="true" />
+          <IconClock aria-hidden />
           <OnlyForMobile>{dateOfWeek}</OnlyForMobile>
           {time}
         </IconTextWrapper>
@@ -413,7 +414,7 @@ function ReservationUnitTable({
       headerName: t("application:view.helpModal.title"),
       transform: ({ reservationUnit }: ReservationUnitTableElem) => (
         <StyledLinkLikeButton onClick={() => setModal(reservationUnit)}>
-          <IconInfoCircle aria-hidden="true" />
+          <IconInfoCircle aria-hidden />
           {isMobile
             ? t("application:view.helpLinkLong")
             : t("application:view.helpLink")}
@@ -456,7 +457,7 @@ function ReservationUnitTable({
         <Dialog.Header
           id="reservation-unit-modal-help-header"
           title={getTranslation(modal, "name")}
-          iconStart={<IconInfoCircle aria-hidden="true" />}
+          iconStart={<IconInfoCircle aria-hidden />}
         />
         <Dialog.Content id="dialog-content">
           <Sanitize
@@ -479,7 +480,7 @@ type ReservationsTableElem = {
     ReservationUnitNode,
     "nameSv" | "nameFi" | "nameEn" | "id" | "pk"
   >;
-  status: "" | "rejected" | "modified";
+  status: "" | "rejected" | "modified" | "cancelled";
   isCancellableReason: ReservationCancellableReason;
   pk: number;
 };
@@ -490,8 +491,8 @@ const ReservationUnitLink = styled(IconButton)`
     display: inline-flex;
     flex-wrap: wrap;
 
-    ${fontRegular}
     text-decoration: underline;
+    ${fontRegular}
   }
 
   /* table hides icons by default, override this behaviour */
@@ -520,7 +521,7 @@ function createReservationUnitLink({
       href={getReservationUnitPath(pk)}
       label={name}
       openInNewTab
-      icon={<IconLinkExternal aria-hidden="true" />}
+      icon={<IconLinkExternal aria-hidden />}
     />
   );
 }
@@ -532,6 +533,30 @@ const StyledStatusLabel = styled(StatusLabel)`
     top: var(--spacing-s);
   }
 `;
+
+function getStatusLabelProps(status: string): {
+  icon: JSX.Element;
+  type: StatusLabelType;
+} {
+  switch (status) {
+    case "cancelled":
+      return {
+        icon: <IconCross aria-hidden />,
+        type: "neutral",
+      };
+    case "modified":
+      return {
+        icon: <IconPen aria-hidden />,
+        type: "neutral",
+      };
+    case "denied":
+    default:
+      return {
+        icon: <IconCross aria-hidden />,
+        type: "error",
+      };
+  }
+}
 
 function ReservationsTable({
   reservations,
@@ -611,7 +636,7 @@ function ReservationsTable({
       isSortable: false,
       transform: ({ dayOfWeek, time }: ReservationsTableElem) => (
         <IconTextWrapper aria-label={t("common:timeLabel")}>
-          <IconClock aria-hidden="true" />
+          <IconClock aria-hidden />
           <OnlyForMobile>{dayOfWeek}</OnlyForMobile>
           {time}
         </IconTextWrapper>
@@ -626,7 +651,7 @@ function ReservationsTable({
           className="last-on-mobile"
           aria-label={t("application:view.reservationsTab.reservationUnit")}
         >
-          <IconLocation aria-hidden="true" />
+          <IconLocation aria-hidden />
           {createReservationUnitLink({
             reservationUnit: elem.reservationUnit,
             lang,
@@ -639,13 +664,12 @@ function ReservationsTable({
       headerName: "",
       isSortable: false,
       transform: ({ status }: ReservationsTableElem) => {
-        const icon = status === "rejected" ? <IconCross /> : <IconPen />;
-        const type = status === "rejected" ? "error" : "neutral";
         if (status === "") {
           return "";
         }
+        const labelProps = getStatusLabelProps(status);
         return (
-          <StyledStatusLabel icon={icon} type={type}>
+          <StyledStatusLabel icon={labelProps.icon} type={labelProps.type}>
             {t(`application:view.reservationsTab.${status}`)}
           </StyledStatusLabel>
         );
@@ -659,7 +683,7 @@ function ReservationsTable({
         <Button
           variant={ButtonVariant.Supplementary}
           size={ButtonSize.Small}
-          iconStart={<IconCross aria-hidden="true" />}
+          iconStart={<IconCross aria-hidden />}
           onClick={() => handleCancel(pk)}
           disabled={isCancellableReason !== ""}
           title={
@@ -681,6 +705,20 @@ function ReservationsTable({
       <Table variant="light" indexKey="date" rows={reservations} cols={cols} />
     </TableWrapper>
   );
+}
+
+function getReservationStatusChoice(
+  state: ReservationStateChoice | null | undefined,
+  isModified?: boolean
+): "" | "rejected" | "modified" | "cancelled" {
+  switch (state) {
+    case ReservationStateChoice.Denied:
+      return "rejected";
+    case ReservationStateChoice.Cancelled:
+      return "cancelled";
+    default:
+      return isModified ? "modified" : "";
+  }
 }
 
 function sectionToreservations(
@@ -730,13 +768,8 @@ function sectionToreservations(
         r.allocatedTimeSlot
       );
 
-      const status =
-        res.state === ReservationStateChoice.Cancelled ||
-        res.state === ReservationStateChoice.Denied
-          ? "rejected"
-          : isModified
-            ? "modified"
-            : "";
+      const status = getReservationStatusChoice(res.state, isModified);
+
       return {
         ...rest,
         reservationUnit: r.reservationUnit,

--- a/apps/ui/public/locales/en/application.json
+++ b/apps/ui/public/locales/en/application.json
@@ -226,6 +226,7 @@
       "reservationUnit": "Space",
       "rejected": "Rejected",
       "modified": "Modified",
+      "cancelled": "Cancelled",
       "showAllReservations": "Show all bookings",
       "cancelApplication": "Cancel all bookings",
       "reservationUnitsTitle": "Location",

--- a/apps/ui/public/locales/fi/application.json
+++ b/apps/ui/public/locales/fi/application.json
@@ -222,6 +222,7 @@
       "reservationUnit": "Tila",
       "rejected": "Hylätty",
       "modified": "Muokattu",
+      "cancelled": "Peruttu",
       "showAllReservations": "Näytä kaikki varaukset",
       "cancelApplication": "Peru kaikki varaukset",
       "reservationUnitsTitle": "Toimipiste",

--- a/apps/ui/public/locales/sv/application.json
+++ b/apps/ui/public/locales/sv/application.json
@@ -220,6 +220,7 @@
       "reservationUnit": "Utrymme",
       "rejected": "Avslagen",
       "modified": "Ändrad",
+      "cancelled": "Avbokad",
       "showAllReservations": "Visa alla bokningar",
       "cancelApplication": "Avboka alla bokningar",
       "reservationUnitsTitle": "Verksamhetsställe",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds a "Cancelled" `StatusLabel`to recurring reservation listings, when the user has cancelled a reservation (vs e.g. being denied.
- Changes the overlapping reservations StatusLabel text to simply "Ei saatavilla" 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- As a user with a recurring reservation series, cancel a reservation -> it should have a `StatusLabel` "Cancelled"
- As admin go see the same recurring reservation, and open the "Toistokerrat" accordion. It should also have a `StatusLabel` instead of the _edit-_, _show in calendar-_ and _deny_-buttons

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3758
