### PR TITLE
fix: Unit filter and equipment filter option orders

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -6407,15 +6407,16 @@ export type UpdateImageMutation = {
 };
 
 export type ReservationUnitEditorParametersQueryVariables = Exact<{
-  [key: string]: never;
+  equipmentsOrderBy?: InputMaybe<EquipmentOrderingChoices>;
 }>;
 
 export type ReservationUnitEditorParametersQuery = {
-  equipments?: {
-    edges: Array<{
-      node?: { id: string; nameFi?: string | null; pk?: number | null } | null;
-    } | null>;
-  } | null;
+  equipmentsAll?: Array<{
+    id: string;
+    name: string;
+    nameFi?: string | null;
+    pk?: number | null;
+  }> | null;
   taxPercentages?: {
     edges: Array<{
       node?: { id: string; pk?: number | null; value: string } | null;
@@ -11413,15 +11414,14 @@ export type UpdateImageMutationOptions = Apollo.BaseMutationOptions<
   UpdateImageMutationVariables
 >;
 export const ReservationUnitEditorParametersDocument = gql`
-  query ReservationUnitEditorParameters {
-    equipments {
-      edges {
-        node {
-          id
-          nameFi
-          pk
-        }
-      }
+  query ReservationUnitEditorParameters(
+    $equipmentsOrderBy: EquipmentOrderingChoices
+  ) {
+    equipmentsAll(orderBy: [$equipmentsOrderBy]) {
+      id
+      name
+      nameFi
+      pk
     }
     taxPercentages {
       edges {
@@ -11502,6 +11502,7 @@ export const ReservationUnitEditorParametersDocument = gql`
  * @example
  * const { data, loading, error } = useReservationUnitEditorParametersQuery({
  *   variables: {
+ *      equipmentsOrderBy: // value for 'equipmentsOrderBy'
  *   },
  * });
  */

--- a/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/index.tsx
@@ -39,6 +39,7 @@ import {
   useCreateReservationUnitMutation,
   useUpdateReservationUnitMutation,
   useReservationUnitEditQuery,
+  EquipmentOrderingChoices,
 } from "@gql/gql-types";
 import { ControlledSelect } from "common/src/components/form/ControlledSelect";
 import { DateTimeInput } from "common/src/components/form/DateTimeInput";
@@ -1417,20 +1418,18 @@ function DescriptionSection({
   purposes,
   qualifiers,
   reservationUnitTypes,
-}: {
+}: Readonly<{
   form: UseFormReturn<ReservationUnitEditFormValues>;
-  equipments: ReservationUnitEditorParametersQuery["equipments"];
+  equipments: ReservationUnitEditorParametersQuery["equipmentsAll"];
   purposes: ReservationUnitEditorParametersQuery["purposes"];
   qualifiers: ReservationUnitEditorParametersQuery["qualifiers"];
   reservationUnitTypes: ReservationUnitEditorParametersQuery["reservationUnitTypes"];
-}) {
+}>) {
   const { t } = useTranslation();
   const { control, formState } = form;
   const { errors } = formState;
 
-  const equipmentOptions = filterNonNullable(
-    equipments?.edges.map((n) => n?.node)
-  ).map((n) => ({
+  const equipmentOptions = filterNonNullable(equipments).map((n) => ({
     value: n.pk ?? -1,
     label: n.nameFi ?? "no-name",
   }));
@@ -1634,6 +1633,9 @@ function ReservationUnitEditor({
       // eslint-disable-next-line no-console
       console.error(e);
       errorToast({ text: t("errors.errorFetchingData") });
+    },
+    variables: {
+      equipmentsOrderBy: EquipmentOrderingChoices.CategoryRankAsc,
     },
   });
 
@@ -1848,7 +1850,7 @@ function ReservationUnitEditor({
         <BasicSection form={form} unit={unit} />
         <DescriptionSection
           form={form}
-          equipments={parametersData?.equipments}
+          equipments={parametersData?.equipmentsAll}
           purposes={parametersData?.purposes}
           qualifiers={parametersData?.qualifiers}
           reservationUnitTypes={parametersData?.reservationUnitTypes}

--- a/apps/admin-ui/src/spa/ReservationUnit/edit/queries.tsx
+++ b/apps/admin-ui/src/spa/ReservationUnit/edit/queries.tsx
@@ -192,15 +192,14 @@ export const UPDATE_IMAGE_TYPE = gql`
 `;
 
 export const RESERVATION_UNIT_EDITOR_PARAMETERS = gql`
-  query ReservationUnitEditorParameters {
-    equipments {
-      edges {
-        node {
-          id
-          nameFi
-          pk
-        }
-      }
+  query ReservationUnitEditorParameters(
+    $equipmentsOrderBy: EquipmentOrderingChoices
+  ) {
+    equipmentsAll(orderBy: [$equipmentsOrderBy]) {
+      id
+      name
+      nameFi
+      pk
     }
     taxPercentages {
       edges {

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -333,6 +333,7 @@ export async function getSearchOptions(
     query: SearchFormParamsUnitDocument,
     variables: {
       publishedReservationUnits: true,
+      orderBy: UnitOrderingChoices.NameFiAsc,
       ...(page === "direct" ? { onlyDirectBookable: true } : {}),
       ...(page === "seasonal" ? { onlySeasonalBookable: true } : {}),
     },


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Uses alphabetical order for the unit filter options in the search form (client)
- Uses the unpaginated query for equipments in the reservation unit edit page (admin), also fixing the order

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check out the dropdown-menus mentioned above. Alphabetical order is easy to check, and the reservation unit edit page equipments filter should have the same option order as the one on the search page.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3765
