### PR TITLE
fix: Rejected occurrences tab pagination

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -6725,6 +6725,7 @@ export type RejectedOccurrencesQueryVariables = Exact<{
 
 export type RejectedOccurrencesQuery = {
   rejectedOccurrences?: {
+    totalCount?: number | null;
     pageInfo: { hasNextPage: boolean; endCursor?: string | null };
     edges: Array<{
       node?: {
@@ -12218,6 +12219,7 @@ export const RejectedOccurrencesDocument = gql`
       after: $after
       first: $first
     ) {
+      totalCount
       pageInfo {
         hasNextPage
         endCursor

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -610,6 +610,7 @@ const translations: ITranslations = {
     madeReservations: ["Varatut vuorot"],
     allocatedReservations: ["Jaetut vuorot"],
     rejectedOccurrences: ["Hylätyt ajankohdat"],
+    rejectedOccurrencesCount: ["hylättyä ajankohtaa"],
     applications: ["Hakemukset"],
     roundCriteria: ["Kierroksen kriteerit"],
     // TODO this is used in Criteria page

--- a/apps/admin-ui/src/spa/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/review/RejectedOccurrencesDataLoader.tsx
@@ -66,13 +66,18 @@ function RejectedOccurrencesDataLoader({
     return <CenterSpinner />;
   }
 
-  const totalCount = dataToUse?.rejectedOccurrences?.edges.length ?? 0;
+  const totalCount = dataToUse?.rejectedOccurrences?.totalCount ?? 0;
   const rejectedOccurrences = filterNonNullable(
     dataToUse?.rejectedOccurrences?.edges.map((edge) => edge?.node)
   );
 
   return (
     <>
+      <span>
+        <b>
+          {totalCount} {t("ApplicationRound.rejectedOccurrencesCount")}
+        </b>
+      </span>
       <RejectedOccurrencesTable
         rejectedOccurrences={rejectedOccurrences}
         isLoading={loading}
@@ -159,6 +164,7 @@ export const REJECTED_OCCURRENCES_QUERY = gql`
       after: $after
       first: $first
     ) {
+      totalCount
       pageInfo {
         hasNextPage
         endCursor


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- "Show more"-button now appears and functions as it should in the rejected occurrences tab, on completed application rounds where there are more than 50 items in the list
- Shows total number of rejected occurrences above the listing, as on other tabs

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check out/make a reservation round which has more than 50 rejected occurrences, and see the respective tab. Check that the "show more" section works like in the other tabs

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3766
