### PR TITLE
fix: submit / cancel button labels more consistent

### DIFF
--- a/apps/ui/components/CancellationForm.tsx
+++ b/apps/ui/components/CancellationForm.tsx
@@ -101,7 +101,7 @@ export function CancellationForm(props: {
               size="large"
             >
               <IconCross aria-hidden="true" />
-              {t("reservations:cancelButton")}
+              {t("common:stop")}
             </ButtonLikeLink>
             <Button
               type="submit"

--- a/apps/ui/components/application/Page2.tsx
+++ b/apps/ui/components/application/Page2.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import {
   Button,
   ButtonVariant,
+  IconArrowLeft,
   IconArrowRight,
   Notification,
   NotificationSize,
@@ -497,6 +498,7 @@ function Page2({ application, onNext }: Props): JSX.Element {
         <Button
           variant={ButtonVariant.Secondary}
           onClick={() => router.push(`${application.pk}/page1`)}
+          iconStart={<IconArrowLeft />}
         >
           {t("common:prev")}
         </Button>

--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -267,7 +267,7 @@ export function EditStep0({
             data-testid="reservation-edit__button--cancel"
           >
             <IconCross aria-hidden="true" />
-            {t("reservations:cancelButton")}
+            {t("common:stop")}
           </ButtonLikeLink>
           <Button
             type="submit"
@@ -282,7 +282,7 @@ export function EditStep0({
             disabled={!focusSlot.isReservable || !isDirty || isLoading}
             data-testid="reservation__button--continue"
           >
-            {t("reservationCalendar:nextStep")}
+            {t("common:next")}
           </Button>
         </Actions>
       </Form>

--- a/apps/ui/components/reservation/EditStep1.tsx
+++ b/apps/ui/components/reservation/EditStep1.tsx
@@ -83,6 +83,9 @@ const StyledReservationInfoCard = styled(ReservationInfoCard)`
 `;
 
 const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
   @media (min-width: ${breakpoints.m}) {
     grid-row: 2 / -1;
     grid-column: 1 / span 1;
@@ -185,7 +188,7 @@ export function EditStep1({
             data-testid="reservation-edit__button--cancel"
           >
             <IconCross aria-hidden="true" />
-            {t("reservations:cancelButton")}
+            {t("common:stop")}
           </ButtonLikeLink>
           <Button
             type="submit"

--- a/apps/ui/components/reservation/Step0.tsx
+++ b/apps/ui/components/reservation/Step0.tsx
@@ -5,11 +5,11 @@
 import type { OptionType } from "common/types/common";
 import {
   Notification,
-  IconArrowLeft,
   IconArrowRight,
   Button,
   ButtonVariant,
   LoadingSpinner,
+  IconCross,
 } from "hds-react";
 import { useFormContext, UseFormReturn } from "react-hook-form";
 import React, { useState } from "react";
@@ -131,17 +131,17 @@ export function Step0({
           disabled={submitDisabled || isSubmitting}
           data-testid="reservation__button--continue"
         >
-          {t("reservationCalendar:nextStep")}
+          {t("common:next")}
         </Button>
         <Button
           type="button"
           variant={ButtonVariant.Secondary}
-          iconStart={<IconArrowLeft aria-hidden="true" />}
+          iconStart={<IconCross aria-hidden="true" />}
           disabled={isSubmitting}
           onClick={cancelReservation}
           data-testid="reservation__button--cancel"
         >
-          {t("common:cancel")}
+          {t("common:stop")}
         </Button>
       </ActionContainer>
     </>

--- a/apps/ui/components/reservation/Step1.tsx
+++ b/apps/ui/components/reservation/Step1.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   ButtonVariant,
   IconArrowLeft,
-  IconArrowRight,
   LoadingSpinner,
   Notification,
 } from "hds-react";
@@ -24,7 +23,7 @@ type Props = {
   reservation: NodeT;
   supportedFields: FieldName[];
   options: OptionsRecord;
-  requiresHandling: boolean;
+  requiresPayment: boolean;
   setStep: React.Dispatch<React.SetStateAction<number>>;
 };
 
@@ -32,7 +31,7 @@ export function Step1({
   reservation,
   supportedFields,
   options,
-  requiresHandling,
+  requiresPayment,
   setStep,
 }: Props): JSX.Element {
   const { t } = useTranslation();
@@ -55,9 +54,6 @@ export function Step1({
   const reservationUnit = reservation?.reservationUnits?.find(() => true);
 
   const areTermsAccepted = isTermsAccepted.space && isTermsAccepted.service;
-  const submitText = t(
-    `reservationCalendar:${requiresHandling ? "nextStep" : "makeReservation"}`
-  );
 
   if (!reservationUnit) {
     return (
@@ -85,23 +81,19 @@ export function Step1({
         <Button
           type="submit"
           variant={isSubmitting ? ButtonVariant.Clear : ButtonVariant.Primary}
-          iconEnd={
-            isSubmitting ? (
-              <LoadingSpinner small />
-            ) : requiresHandling ? (
-              <IconArrowRight aria-hidden="true" />
-            ) : undefined
-          }
+          iconEnd={isSubmitting ? <LoadingSpinner small /> : undefined}
           data-testid="reservation__button--continue"
           disabled={!areTermsAccepted || isSubmitting}
         >
-          {submitText}
+          {requiresPayment
+            ? t("notification:waitingForPayment.continueReservation")
+            : t("reservationCalendar:makeReservation")}
         </Button>
         <Button
           variant={ButtonVariant.Secondary}
           iconStart={<IconArrowLeft aria-hidden="true" />}
           onClick={() => setStep(0)}
-          data-testid="reservation__button--cancel"
+          data-testid="reservation__button--prev"
         >
           {t("common:prev")}
         </Button>

--- a/apps/ui/components/reservations/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/reservations/UnpaidReservationNotification.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import styled from "styled-components";
-import { breakpoints } from "common/src/common/style";
 import {
   ReservationOrderingChoices,
   useListReservationsQuery,
@@ -20,33 +19,14 @@ import { toApiDate } from "common/src/common/util";
 import { errorToast, successToast } from "common/src/common/toast";
 import { getReservationInProgressPath } from "@/modules/urls";
 import { Button, ButtonSize, ButtonVariant, LoadingSpinner } from "hds-react";
+import { Flex } from "common/styles/util";
 
 type QueryT = NonNullable<ListReservationsQuery["reservations"]>;
 type EdgeT = NonNullable<QueryT["edges"][number]>;
 type NodeT = NonNullable<EdgeT["node"]>;
 
-const NotificationContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: var(--spacing-s);
-
-  @media (min-width: ${breakpoints.m}) {
-    flex-direction: row;
-  }
-`;
-
 const BodyText = styled.p`
   margin: 0;
-`;
-
-const NotificationButtons = styled.div`
-  display: flex;
-  gap: var(--spacing-s);
-
-  > button {
-    white-space: nowrap;
-  }
 `;
 
 function isNotFoundError(error: unknown): boolean {
@@ -129,9 +109,9 @@ function ReservationNotification({
       closeButtonLabelText={t("common:close")}
       data-testid="unpaid-reservation-notification__title"
     >
-      <NotificationContent>
+      <Flex $wrap="wrap" $direction="row">
         <BodyText>{text}</BodyText>
-        <NotificationButtons>
+        <Flex $gap="s" $direction="row">
           <Button
             variant={isLoading ? ButtonVariant.Clear : ButtonVariant.Secondary}
             size={ButtonSize.Small}
@@ -151,8 +131,8 @@ function ReservationNotification({
           >
             {submitButtonText}
           </Button>
-        </NotificationButtons>
-      </NotificationContent>
+        </Flex>
+      </Flex>
     </NotificationWrapper>
   );
 }

--- a/apps/ui/pages/applications/[id]/page3.tsx
+++ b/apps/ui/pages/applications/[id]/page3.tsx
@@ -33,7 +33,12 @@ import { getCommonServerSideProps } from "@/modules/serverUtils";
 import { base64encode, toNumber } from "common/src/helpers";
 import { errorToast } from "common/src/common/toast";
 import { getApplicationPath } from "@/modules/urls";
-import { Button, ButtonVariant, IconArrowRight } from "hds-react";
+import {
+  Button,
+  ButtonVariant,
+  IconArrowLeft,
+  IconArrowRight,
+} from "hds-react";
 import { ButtonContainer } from "common/styles/util";
 import styled from "styled-components";
 
@@ -51,7 +56,11 @@ function Buttons({
 
   return (
     <ButtonContainer>
-      <Button variant={ButtonVariant.Secondary} onClick={onPrev}>
+      <Button
+        iconStart={<IconArrowLeft aria-hidden="true" />}
+        variant={ButtonVariant.Secondary}
+        onClick={onPrev}
+      >
         {t("common:prev")}
       </Button>
       <Button

--- a/apps/ui/pages/applications/[id]/preview.tsx
+++ b/apps/ui/pages/applications/[id]/preview.tsx
@@ -21,7 +21,12 @@ import { errorToast } from "common/src/common/toast";
 import { getApplicationPath } from "@/modules/urls";
 import { ButtonLikeLink } from "@/components/common/ButtonLikeLink";
 import { ButtonContainer, Flex } from "common/styles/util";
-import { Button, ButtonVariant, LoadingSpinner } from "hds-react";
+import {
+  Button,
+  ButtonVariant,
+  IconArrowLeft,
+  LoadingSpinner,
+} from "hds-react";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 type PropsNarrowed = Exclude<Props, { notFound: boolean }>;
@@ -102,6 +107,7 @@ function Preview(props: PropsNarrowed): JSX.Element {
         />
         <ButtonContainer>
           <ButtonLikeLink size="large" href={getApplicationPath(pk, "page3")}>
+            <IconArrowLeft aria-hidden="true" />
             {t("common:prev")}
           </ButtonLikeLink>
           <Button

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -412,10 +412,8 @@ function NewReservation(props: PropsNarrowed): JSX.Element | null {
               reservation={reservation}
               supportedFields={supportedFields}
               options={options}
-              // TODO this is correct but confusing.
-              // There used to be 5 steps for payed reservations but the stepper is hidden for them now.
-              requiresHandling={steps.length > 2}
               setStep={setStep}
+              requiresPayment={steps.length > 2}
             />
           )}
         </StyledForm>

--- a/apps/ui/public/locales/en/common.json
+++ b/apps/ui/public/locales/en/common.json
@@ -84,6 +84,7 @@
   "loginAlt": "Sign in",
   "logout": "Sign out",
   "cancel": "Cancel",
+  "stop": "Cancel",
   "imgAltForSpace": "Image of the spaces {{name}}",
   "address": {
     "streetAddress": "Address",

--- a/apps/ui/public/locales/fi/common.json
+++ b/apps/ui/public/locales/fi/common.json
@@ -84,6 +84,7 @@
   "loginAlt": "Kirjaudu sisään",
   "logout": "Kirjaudu ulos",
   "cancel": "Peru",
+  "stop": "Keskeytä",
   "imgAltForSpace": "Kuva tilasta {{name}}",
   "address": {
     "streetAddress": "Katuosoite",

--- a/apps/ui/public/locales/sv/common.json
+++ b/apps/ui/public/locales/sv/common.json
@@ -84,6 +84,7 @@
   "loginAlt": "Logga in",
   "logout": "Logga ut",
   "cancel": "Avboka",
+  "stop": "Avbryt",
   "imgAltForSpace": "Bild på lokalen {{name}}",
   "address": {
     "streetAddress": "Adress",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: use more consistent button labels for new / edit / cancel reservation `ui`
- Add: arrow icons to `prev` buttons.
- Fix: missing gap to edit page step1.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: check the texts / icons are correct for all languages / funnels.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3192](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3192)


[TILA-3192]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ