### PR TITLE
fix: spinner overflowing inside accordion

### DIFF
--- a/apps/admin-ui/src/component/RecurringReservationsView.tsx
+++ b/apps/admin-ui/src/component/RecurringReservationsView.tsx
@@ -18,13 +18,13 @@ import { DenyDialog } from "@/component/DenyDialog";
 import { useModal } from "@/context/ModalContext";
 import { EditTimeModal } from "@/component/EditTimeModal";
 import { base64encode, filterNonNullable } from "common/src/helpers";
-import { LoadingSpinner } from "hds-react";
 import { errorToast } from "common/src/common/toast";
 import { useCheckPermission } from "@/hooks";
 import {
   isPossibleToDeny,
   isPossibleToEdit,
 } from "@/modules/reservationModificationRules";
+import { CenterSpinner } from "common/styles/util";
 
 type RecurringReservationType = NonNullable<
   RecurringReservationQuery["recurringReservation"]
@@ -71,7 +71,7 @@ export function RecurringReservationsView({
   const reservations = filterNonNullable(recurringReservation?.reservations);
 
   if (loading) {
-    return <LoadingSpinner />;
+    return <CenterSpinner />;
   }
 
   const handleChangeSuccess = () => {

--- a/apps/admin-ui/src/spa/reservations/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/index.tsx
@@ -51,7 +51,7 @@ type ReservationType = NonNullable<ReservationQuery["reservation"]>;
 const Accordion = styled(AccordionBase).attrs({
   closeButton: false,
 })`
-  > div > div {
+  > div > div:not([class^="LoadingSpinner-module_loadingSpinner"]) {
     width: 100%;
   }
 `;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: `reservations` page `admin-ui` spinner overflowing inside an accordion.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: check list of reservations with throttle (the spinner should be normal inside the accordion).

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
