### PR TITLE
Fix select single reservation side effect

### DIFF
--- a/apps/admin-ui/src/component/RecurringReservationsView.tsx
+++ b/apps/admin-ui/src/component/RecurringReservationsView.tsx
@@ -180,7 +180,7 @@ export function RecurringReservationsView({
       header={t("RecurringReservationsView.Heading")}
       items={items}
       reservationToCopy={reservationToCopy}
-      refetch={refetch}
+      refetch={handleChangeSuccess}
     />
   );
 }

--- a/apps/admin-ui/src/component/RecurringReservationsView.tsx
+++ b/apps/admin-ui/src/component/RecurringReservationsView.tsx
@@ -4,7 +4,6 @@ import { format } from "date-fns";
 import {
   ReservationStateChoice,
   type ReservationQuery,
-  type RecurringReservationQuery,
   useRecurringReservationQuery,
   UserPermissionChoice,
 } from "@gql/gql-types";
@@ -26,14 +25,9 @@ import {
   isPossibleToEdit,
 } from "@/modules/reservationModificationRules";
 
-type RecurringReservationType = NonNullable<
-  RecurringReservationQuery["recurringReservation"]
->;
-type ReservationType = NonNullable<RecurringReservationType["reservations"]>[0];
-
 type Props = {
   recurringPk: number;
-  onSelect?: (selected: ReservationType) => void;
+  onSelect?: (selected: number) => void;
   onChange?: () => Promise<ApolloQueryResult<ReservationQuery>>;
   onReservationUpdated?: () => void;
   // optional reservation to copy when creating a new reservation
@@ -142,11 +136,16 @@ export function RecurringReservationsView({
       );
     }
 
-    if (onSelect && x.state === ReservationStateChoice.Confirmed) {
+    const { pk } = x;
+    if (
+      onSelect &&
+      x.state === ReservationStateChoice.Confirmed &&
+      pk != null
+    ) {
       buttons.push(
         <ReservationListButton
           key="show"
-          callback={() => onSelect(x)}
+          callback={() => onSelect(pk)}
           type="show"
           t={t}
         />

--- a/apps/admin-ui/src/component/ReservationListButton.tsx
+++ b/apps/admin-ui/src/component/ReservationListButton.tsx
@@ -32,11 +32,9 @@ export function ReservationListButton({
   switch (type) {
     case "show":
       return (
-        <a href="#reservation-calendar" style={{ textDecoration: "none" }}>
-          <Button key={type} {...btnCommon} iconStart={<IconClock />}>
-            {t("ReservationsListButton.showInCalendar")}
-          </Button>
-        </a>
+        <Button key={type} {...btnCommon} iconStart={<IconClock />}>
+          {t("ReservationsListButton.showInCalendar")}
+        </Button>
       );
     case "deny":
     case "remove":


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: selecting single reservation from series shows it in the calendar (and scrolls to calendar)
- fix: update calendar after creating new reservation to series

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: show reservation in calendar button should work. `admin` recurring reservation.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
