### PR TITLE
fix: cant save new top level space

### DIFF
--- a/apps/admin-ui/src/spa/unit/space/ParentSelector.tsx
+++ b/apps/admin-ui/src/spa/unit/space/ParentSelector.tsx
@@ -108,7 +108,6 @@ export function ParentSelector({
         error: errorText,
         assistive: helperText,
       }}
-      required
       disabled={options.length === 0}
       clearable={false}
       options={hdsOptions}

--- a/apps/admin-ui/src/spa/unit/space/SpaceEditor.tsx
+++ b/apps/admin-ui/src/spa/unit/space/SpaceEditor.tsx
@@ -42,11 +42,10 @@ function SpaceEditor({ space, unit }: Props): JSX.Element {
 
   const { t } = useTranslation();
 
-  const [updateSpaceMutation, { loading: isMutationLoading }] =
-    useUpdateSpaceMutation();
+  const [mutation, { loading: isMutationLoading }] = useUpdateSpaceMutation();
 
   const updateSpace = (input: SpaceUpdateMutationInput) =>
-    updateSpaceMutation({ variables: { input } });
+    mutation({ variables: { input } });
 
   const {
     data,
@@ -110,7 +109,7 @@ function SpaceEditor({ space, unit }: Props): JSX.Element {
 
   const onSubmit = async (values: SpaceUpdateForm) => {
     try {
-      const { surfaceArea, pk, ...rest } = values;
+      const { parent, surfaceArea, pk, ...rest } = values;
       if (pk == null || pk === 0) {
         errorToast({ text: t("SpaceEditor.saveFailed") });
         return;
@@ -118,6 +117,7 @@ function SpaceEditor({ space, unit }: Props): JSX.Element {
       await updateSpace({
         ...rest,
         pk,
+        parent: parent != null && parent > 0 ? parent : null,
         surfaceArea: Math.ceil(surfaceArea ?? 0),
       });
       successToast({

--- a/apps/admin-ui/src/spa/unit/space/new-space-modal/NewSpaceModal.tsx
+++ b/apps/admin-ui/src/spa/unit/space/new-space-modal/NewSpaceModal.tsx
@@ -46,10 +46,11 @@ export function NewSpaceModal({
     },
   });
 
-  async function createSpaces(values: SpaceUpdateForm) {
+  async function createSpaces({ parent, ...values }: SpaceUpdateForm) {
     try {
       await createSpace({
         ...values,
+        parent: parent != null && parent > 0 ? parent : null,
         name: values.nameFi,
       });
       closeModal();


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: user can save a space without selecting a parent, but selecting top level (ghost) parent fails the mutation.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Manual testing: check saving both new and old space (moving parents) `admin`

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3820](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3820)


[TILA-3820]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ