### PR TITLE
fix: use wrapping div instead of no-gap main container

### DIFF
--- a/apps/ui/components/application/ApprovedReservations.tsx
+++ b/apps/ui/components/application/ApprovedReservations.tsx
@@ -834,18 +834,20 @@ export function ApplicationSection({
     .slice(0, N_RESERVATIONS_TO_SHOW);
 
   return (
-    <Flex $gap="none">
-      <MarginHeader>
-        {t("application:view.reservationsTab.reservationUnitsTitle")}
-      </MarginHeader>
-      <ReservationUnitTable reservationUnits={reservationUnits} />
-      <MarginHeader>
-        {t("application:view.reservationsTab.reservationsTitle")}
-      </MarginHeader>
-      <ReservationsTable
-        reservations={reservations}
-        application={application}
-      />
+    <Flex>
+      <div>
+        <MarginHeader>
+          {t("application:view.reservationsTab.reservationUnitsTitle")}
+        </MarginHeader>
+        <ReservationUnitTable reservationUnits={reservationUnits} />
+        <MarginHeader>
+          {t("application:view.reservationsTab.reservationsTitle")}
+        </MarginHeader>
+        <ReservationsTable
+          reservations={reservations}
+          application={application}
+        />
+      </div>
       <ButtonContainer $justifyContent="center">
         <ButtonLikeLink
           href={getApplicationSectionPath(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Uses a wrapping `<div>` (instead of a `$gap="none"` main container) to remove the gap from between the approved reservation headings and tables

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Check the approved reservations tab in a recurring reservation: the headings should have the proper amounts of margin ([specs](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3759)), and there should be a 1rem `gap` between the bottom buttons and the rest of the page.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-3759
